### PR TITLE
docs: add versioned roadmap planning

### DIFF
--- a/docs/design/v1-ui-mockup-plan.md
+++ b/docs/design/v1-ui-mockup-plan.md
@@ -1,0 +1,61 @@
+# V1 UI Mockup Plan
+
+Figma: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d
+
+## Design System
+
+- Android frame: 390 x 844.
+- Background: `#1C1B1F`.
+- Card background: `#2A2930`.
+- Elevated card: `#312F36`.
+- Primary green: `#2E7D52`.
+- Text primary: `#E6E1E5`.
+- Text secondary: `#CAC4D0`.
+- Border: `rgba(255,255,255,0.08)`.
+- Radius: 12px for cards, 16px for primary buttons.
+- No coloured shadows.
+
+## Screens
+
+### Empty Dashboard
+
+Show total `₹0.00`, no allocation, and a strong `Add Trade` CTA. Empty copy should explain that holdings are created from trades.
+
+### Filled Dashboard
+
+Show portfolio value, day change, allocation summary, quote freshness, basic conviction nudge, and Add Trade CTA. Do not show Minimal Mode or LTCG.
+
+### Add Trade
+
+Top segmented control for Buy/Sell. Asset field, quantity, price, total, date, optional fees, optional conviction row, optional note, sticky Review Trade button.
+
+### Holdings Empty
+
+Show empty card with “No holdings yet” and CTA to Add Trade.
+
+### Holdings Filled
+
+Holding card rows: asset name/symbol, quantity, average cost, current value, unrealised P&L, quote freshness. No LTCG badge in V1.
+
+### Cash Empty/Filled
+
+Hero cash balance, Add Cash and Withdraw buttons, entry history rows.
+
+### Settings
+
+Value masking toggle, quote refresh note, local-first privacy copy, app version placeholder.
+
+### Value Masking
+
+Mask INR wealth values with `₹**** **,***.**`. Do not mask quantities, percentages, or market price per unit.
+
+## Interactions
+
+- Pressable opacity feedback at 0.75.
+- Haptics on Add Trade confirm and value masking toggle.
+- Pull-to-refresh on Dashboard/Holdings.
+- Clear error text for invalid sell quantity and quote failures.
+
+## Manual Figma Recreation Notes
+
+Use the real Figma file as the primary reference. If it is unavailable, recreate screens with the layout order above, 16px horizontal padding, 10px card gap, and 12px internal spacing.

--- a/docs/design/v2-ui-mockup-plan.md
+++ b/docs/design/v2-ui-mockup-plan.md
@@ -1,0 +1,43 @@
+# V2 UI Mockup Plan
+
+Figma: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d
+
+## Design Direction
+
+V2 introduces Minimal Mode and behaviour insights. Standard Mode remains information-dense. Minimal Mode reduces day-change prominence, top movers, aggressive red/green cues, and dashboard noise.
+
+## Screens
+
+### Minimal Dashboard
+
+Show portfolio value, updated timestamp, allocation, Add Trade CTA, and optional LTCG banner. Hide daily P&L, top movers, and insight card by default.
+
+### Minimal Holdings
+
+Show asset name, quantity, current value, and basic LTCG state where relevant. Hide day change and reduce P&L colour emphasis.
+
+### Behaviour Insights
+
+Cards for conviction, patience, frequency. Tone must be observational. Avoid “you should” and “you must”.
+
+### Insight Detail
+
+Show metric summary, contributing trade count, explanation, and related trade rows.
+
+### Basic LTCG States
+
+Use green pill for eligible and amber pill for `LTCG in X days`. Only Indian stocks/ETFs show this.
+
+### Onboarding Nudges
+
+Small cards prompting conviction/intended hold input. Must not block trade entry.
+
+## Interactions
+
+- Mode switch applies immediately.
+- Insight cards can be dismissed or opened.
+- Minimal Mode never removes Add Trade, Holdings, Cash, or History access.
+
+## Manual Figma Recreation Notes
+
+Use V1 components and adjust density/colour. Increase card gap by 4px in Minimal Mode and reduce semantic colour opacity by 30%.

--- a/docs/design/v3-ui-mockup-plan.md
+++ b/docs/design/v3-ui-mockup-plan.md
@@ -1,0 +1,39 @@
+# V3 UI Mockup Plan
+
+Figma: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d
+
+## Design Direction
+
+V3 adds advanced surfaces while preserving the CogVest dark, local-first design language.
+
+## Screens
+
+### Historical Charts
+
+Asset Detail chart card with range selector: `1W`, `1M`, `3M`, `1Y`, `ALL`. Include loading, error, stale-data, and empty states.
+
+### Advanced Asset Search
+
+Search input, recent assets, result rows with logo/name/symbol/exchange, source labels, and manual asset fallback.
+
+### Import/Export
+
+Local backup warning, export button, import picker, validation result state, and destructive-risk warnings.
+
+### Advanced Dashboard Widgets
+
+Configurable cards such as allocation trend, behaviour summary, quote freshness, and tax reminders.
+
+### Advanced LTCG
+
+Lot-level rows with buy date, quantity, eligibility date, days remaining, and FIFO sell impact.
+
+## Interactions
+
+- Advanced actions require explicit confirmation.
+- Import validation errors must be readable and actionable.
+- Chart failures should not block the rest of Asset Detail.
+
+## Manual Figma Recreation Notes
+
+Build from V1/V2 components. Use progressive disclosure for advanced data and avoid turning the app into a dense trading terminal.

--- a/docs/issues/v1-issue-drafts.md
+++ b/docs/issues/v1-issue-drafts.md
@@ -1,0 +1,585 @@
+# V1 Issue Drafts
+
+Milestone: CogVest V1 MVP
+
+## [V1] Scaffold Expo Android app
+
+Labels: `v1`, `infra`, `frontend`, `feature`, `priority-high`
+
+### Context
+Create the Android-first Expo foundation for CogVest.
+
+### Scope
+- Create Expo SDK 52+ TypeScript app.
+- Configure Expo Router tabs.
+- Configure strict TypeScript and Jest.
+- Add base scripts.
+
+### Out of Scope
+- Feature screens beyond placeholders.
+- Runtime business logic.
+
+### Technical Notes
+- Files: `app/_layout.tsx`, `app/(tabs)/_layout.tsx`, tab placeholders, `package.json`, `tsconfig.json`, `jest.config.js`.
+
+### Design Reference
+- `docs/design/v1-ui-mockup-plan.md`
+- Figma: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d
+
+### Acceptance Criteria
+- Five core tabs are visible.
+- App is Android-only.
+- TypeScript strict mode is enabled.
+- Smoke test passes.
+
+### Test Steps
+- Open app with Expo.
+- Navigate tabs.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`
+
+## [V1] Add theme and common UI primitives
+
+Labels: `v1`, `frontend`, `design`, `feature`, `priority-high`
+
+### Context
+Provide reusable UI primitives before screens are built.
+
+### Scope
+- Theme tokens.
+- AppText, AppButton, ScreenContainer, EmptyState, MaskedValue.
+- Pressable opacity feedback and dark card style.
+
+### Out of Scope
+- Full screen implementation.
+- Minimal Mode.
+
+### Technical Notes
+- Files: `src/theme/*`, `src/components/common/*`.
+
+### Design Reference
+- `docs/design/v1-ui-mockup-plan.md`
+
+### Acceptance Criteria
+- Tokens match CogVest design rules.
+- MaskedValue supports V1 masking format.
+- No coloured shadows.
+
+### Test Steps
+- Render common components in tests or story-like screen.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`
+
+## [V1] Define types, store, and persistence
+
+Labels: `v1`, `store`, `feature`, `priority-high`
+
+### Context
+Set the raw-data persistence contract.
+
+### Scope
+- Types for assets, trades, cash, quotes, holdings, preferences.
+- Zustand store.
+- MMKV persistence.
+- Selectors.
+
+### Out of Scope
+- Derived holdings persistence.
+- V2/V3 fields in UI.
+
+### Technical Notes
+- Files: `src/types/*`, `src/store/*`, `src/services/storage/mmkv.ts`, `src/utils/id.ts`.
+
+### Design Reference
+- `docs/roadmap/v1-mvp-spec.md`
+
+### Acceptance Criteria
+- Raw data persists.
+- Derived values are not persisted.
+- Quotes are cached separately from main persisted store if implemented.
+
+### Test Steps
+- Add/update/remove asset, trade, cash entry, preferences.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`
+
+## [V1] Implement domain calculations and formatters
+
+Labels: `v1`, `domain`, `feature`, `testing`, `priority-high`
+
+### Context
+Portfolio values must be pure and testable.
+
+### Scope
+- Holdings.
+- Allocation.
+- Portfolio total/day change.
+- INR/date formatting.
+- Trade validation helpers.
+- Conviction readiness.
+
+### Out of Scope
+- LTCG.
+- Patience/frequency.
+- Historical charts.
+
+### Technical Notes
+- Files: `src/domain/calculations/*`, `src/domain/formatters/*`, `src/domain/validators/trade.ts`.
+
+### Design Reference
+- `docs/roadmap/v1-mvp-spec.md`
+
+### Acceptance Criteria
+- Weighted average and partial sell tests pass.
+- Zero/empty states are handled.
+- Domain functions have no store access.
+
+### Test Steps
+- Run focused unit tests for each domain module.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`
+
+## [V1] Add live quote services
+
+Labels: `v1`, `domain`, `feature`, `priority-high`
+
+### Context
+V1 should feel like a tracker, not a static ledger.
+
+### Scope
+- Yahoo Finance current quotes for Indian stocks/ETFs.
+- CoinGecko current quotes for crypto.
+- Quote resolver.
+- Quote refresh hook.
+- Manual fallback state.
+
+### Out of Scope
+- Historical charts.
+- Advanced asset search.
+- Background polling.
+
+### Technical Notes
+- Files: `src/services/quotes/*`.
+
+### Design Reference
+- `docs/roadmap/v1-mvp-spec.md`
+
+### Acceptance Criteria
+- Quote failures never crash UI.
+- Current prices can refresh on app open/pull-to-refresh.
+- Manual price fallback remains available.
+
+### Test Steps
+- Mock success and failure responses.
+- Manually refresh quotes.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`
+
+## [V1] Build Add Trade validation
+
+Labels: `v1`, `domain`, `testing`, `feature`, `priority-high`
+
+### Context
+Trade validation must be correct before the UI writes local data.
+
+### Scope
+- Zod schema.
+- Future-date validation.
+- Positive quantity/price.
+- Sell quantity validation.
+
+### Out of Scope
+- UI layout.
+- V2 intended hold behaviour.
+
+### Technical Notes
+- Files: `src/domain/validators/trade.ts`, `src/features/trades/tradeForm.ts`.
+
+### Design Reference
+- `docs/design/v1-ui-mockup-plan.md`
+
+### Acceptance Criteria
+- Invalid inputs return actionable errors.
+- Conviction is optional.
+
+### Test Steps
+- Validate buy and sell form cases.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`
+
+## [V1] Build Add Trade screen
+
+Labels: `v1`, `frontend`, `feature`, `priority-high`
+
+### Context
+Fast trade entry is the core V1 workflow.
+
+### Scope
+- Buy/sell toggle.
+- Asset selection/manual creation.
+- Live/manual price.
+- Quantity, fees, date, note.
+- Optional conviction.
+- Review and confirm.
+
+### Out of Scope
+- Intended hold period.
+- Advanced search.
+
+### Technical Notes
+- Files: `app/(tabs)/add-trade.tsx`, `src/components/forms/*`.
+
+### Design Reference
+- `docs/design/v1-ui-mockup-plan.md`
+- Figma: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d
+
+### Acceptance Criteria
+- Standard buy can be logged in under 45 seconds.
+- Confirmed trade persists.
+- Haptic success feedback occurs.
+
+### Test Steps
+- Add buy trade.
+- Add sell trade.
+- Attempt invalid sell.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`
+
+## [V1] Build Holdings screen
+
+Labels: `v1`, `frontend`, `store`, `feature`, `priority-high`
+
+### Context
+Holdings are the primary proof that trades are being derived correctly.
+
+### Scope
+- `useHoldings`.
+- HoldingCard.
+- Empty and filled states.
+- Pull-to-refresh quote action.
+
+### Out of Scope
+- LTCG badges.
+- Minimal Mode.
+
+### Technical Notes
+- Files: `src/features/holdings/useHoldings.ts`, `src/components/cards/HoldingCard.tsx`, `app/(tabs)/holdings.tsx`.
+
+### Design Reference
+- `docs/design/v1-ui-mockup-plan.md`
+
+### Acceptance Criteria
+- Holdings derive from trades and quotes.
+- No hardcoded portfolio values.
+- V1 shows no LTCG UI.
+
+### Test Steps
+- Add trade and verify holding appears.
+- Refresh quote and verify value updates.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`
+
+## [V1] Build Dashboard MVP
+
+Labels: `v1`, `frontend`, `store`, `feature`, `priority-high`
+
+### Context
+Dashboard gives the at-a-glance portfolio view.
+
+### Scope
+- Total value.
+- Allocation.
+- Quote freshness.
+- Basic conviction nudge.
+- Add Trade CTA.
+- Value masking support.
+
+### Out of Scope
+- Minimal Mode.
+- Top movers.
+- LTCG banner.
+
+### Technical Notes
+- Files: `src/features/dashboard/useDashboard.ts`, dashboard cards, `app/(tabs)/dashboard.tsx`.
+
+### Design Reference
+- `docs/design/v1-ui-mockup-plan.md`
+
+### Acceptance Criteria
+- Total equals holdings plus cash.
+- Allocation derives from current values.
+- Conviction state shows not-enough-data guidance.
+
+### Test Steps
+- Add trade, add cash, verify total.
+- Toggle masking.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`
+
+## [V1] Build Cash screen
+
+Labels: `v1`, `frontend`, `store`, `feature`, `priority-medium`
+
+### Context
+Cash is part of total portfolio value.
+
+### Scope
+- Add cash.
+- Withdraw cash.
+- Cash history.
+- Empty state.
+
+### Out of Scope
+- Behaviour overlay.
+- Import/export.
+
+### Technical Notes
+- Files: `app/(tabs)/cash.tsx`, `src/features/cash/useCash.ts`, `src/components/cards/CashEntryRow.tsx`.
+
+### Design Reference
+- `docs/design/v1-ui-mockup-plan.md`
+
+### Acceptance Criteria
+- Cash total is additions minus withdrawals.
+- Dashboard total includes cash.
+
+### Test Steps
+- Add and withdraw cash.
+- Restart and verify persistence.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`
+
+## [V1] Build Settings and value masking
+
+Labels: `v1`, `frontend`, `store`, `feature`, `priority-medium`
+
+### Context
+Users need privacy controls for portfolio values.
+
+### Scope
+- Simple settings screen.
+- Global masking preference.
+- Eye/toggle interaction.
+- Apply masking to V1 INR wealth values.
+
+### Out of Scope
+- Minimal Mode settings.
+- Export/import settings.
+
+### Technical Notes
+- Files: `app/settings.tsx`, preference hooks, value renderers.
+
+### Design Reference
+- `docs/design/v1-ui-mockup-plan.md`
+
+### Acceptance Criteria
+- Wealth values mask globally.
+- Quantities and percentages remain visible.
+- Setting persists after restart.
+
+### Test Steps
+- Toggle masking across dashboard, holdings, cash.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`
+
+## [V1] Configure Android app identity and icons
+
+Labels: `v1`, `infra`, `release`, `testing`, `priority-high`
+
+### Context
+V1 preview/release builds need Android identity.
+
+### Scope
+- App name.
+- Android package.
+- Version fields.
+- Icon/adaptive icon/splash placeholders or plan.
+
+### Out of Scope
+- Play Store auto-submit.
+
+### Technical Notes
+- Files: `app.json` or `app.config.ts`, assets as needed.
+
+### Design Reference
+- `docs/release/android-release-process.md`
+
+### Acceptance Criteria
+- App identity is configured for Android builds.
+- No signing secrets are committed.
+
+### Test Steps
+- Inspect Expo config.
+- Run Expo doctor.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`
+
+## [V1] Configure EAS build profiles
+
+Labels: `v1`, `infra`, `release`, `testing`, `priority-high`
+
+### Context
+Preview APK and production AAB profiles must be defined.
+
+### Scope
+- `eas.json`.
+- development, preview, production profiles.
+
+### Out of Scope
+- Triggering cloud builds without approval.
+
+### Technical Notes
+- Files: `eas.json`, `docs/release/android-release-process.md`.
+
+### Design Reference
+- `docs/release/android-release-process.md`
+
+### Acceptance Criteria
+- Preview outputs APK.
+- Production outputs AAB.
+- `EXPO_TOKEN` is documented, not committed.
+
+### Test Steps
+- Validate EAS config syntax.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`
+
+## [V1] Add Android preview build workflow draft
+
+Labels: `v1`, `infra`, `release`, `testing`, `priority-medium`
+
+### Context
+Preview build automation should be documented before enabling.
+
+### Scope
+- Draft preview workflow.
+- Include install/typecheck/test/Expo doctor/EAS preview build.
+
+### Out of Scope
+- Running paid/cloud build automatically.
+
+### Technical Notes
+- Files: `docs/release/github-actions-drafts.md`.
+
+### Design Reference
+- `docs/release/android-release-process.md`
+
+### Acceptance Criteria
+- Draft names required secret `EXPO_TOKEN`.
+- Workflow does not require emulator.
+
+### Test Steps
+- Review workflow steps.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`
+
+## [V1] Add Android production build workflow draft
+
+Labels: `v1`, `infra`, `release`, `testing`, `priority-medium`
+
+### Context
+Production AAB should be a release-candidate gate, not a dev-complete blocker.
+
+### Scope
+- Draft production AAB workflow.
+- Manual/tag trigger.
+- No auto-submit.
+
+### Out of Scope
+- Google Play service account setup.
+
+### Technical Notes
+- Files: `docs/release/github-actions-drafts.md`.
+
+### Design Reference
+- `docs/release/android-release-process.md`
+
+### Acceptance Criteria
+- Production workflow builds AAB.
+- Play Store upload remains manual for V1.
+
+### Test Steps
+- Review trigger and secret usage.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`
+
+## [V1] Verify preview APK on device
+
+Labels: `v1`, `infra`, `release`, `testing`, `priority-high`
+
+### Context
+V1 dev-complete requires an installable Android preview build.
+
+### Scope
+- Run V1 release checklist dev-complete gate.
+- Build preview APK.
+- Install on real device.
+- Record build URL and manual QA notes.
+
+### Out of Scope
+- Production AAB.
+- Play Store submission.
+
+### Technical Notes
+- Files: `docs/release/v1-release-checklist.md`.
+
+### Design Reference
+- `docs/release/v1-release-checklist.md`
+
+### Acceptance Criteria
+- Preview APK builds.
+- APK installs on a real Android device.
+- Core manual flows pass or defects are logged.
+
+### Test Steps
+- Follow checklist in `docs/release/v1-release-checklist.md`.
+
+### Commands
+- `npx tsc --noEmit`
+- `npx jest`
+- `npx expo start`

--- a/docs/issues/v2-placeholder-issues.md
+++ b/docs/issues/v2-placeholder-issues.md
@@ -1,0 +1,33 @@
+# V2 Placeholder Issues
+
+Milestone: CogVest V2 Behaviour
+
+## [V2] Implement Minimal Mode
+
+Labels: `v2`, `frontend`, `feature`, `priority-high`
+
+Add Standard/Minimal display mode and apply Minimal Mode across supported V2 screens.
+
+## [V2] Build behaviour insight engine
+
+Labels: `v2`, `domain`, `feature`, `priority-high`
+
+Add conviction analytics, patience analysis, trade frequency, and insight generation.
+
+## [V2] Add insight detail screen
+
+Labels: `v2`, `frontend`, `feature`, `priority-medium`
+
+Create a navigable detail view for insight context and contributing data.
+
+## [V2] Add basic LTCG tracker
+
+Labels: `v2`, `domain`, `frontend`, `feature`, `priority-medium`
+
+Show basic LTCG status for Indian stocks/ETFs only.
+
+## [V2] Expand onboarding nudges
+
+Labels: `v2`, `frontend`, `feature`, `priority-low`
+
+Encourage optional behaviour context without blocking trade entry.

--- a/docs/issues/v3-placeholder-issues.md
+++ b/docs/issues/v3-placeholder-issues.md
@@ -1,0 +1,33 @@
+# V3 Placeholder Issues
+
+Milestone: CogVest V3 Advanced
+
+## [V3] Add historical charts
+
+Labels: `v3`, `frontend`, `domain`, `feature`, `priority-high`
+
+Add historical asset chart loading and fallback states.
+
+## [V3] Build advanced asset search
+
+Labels: `v3`, `frontend`, `feature`, `priority-medium`
+
+Improve asset discovery, logos, exchanges, recents, and manual fallback.
+
+## [V3] Implement import/export
+
+Labels: `v3`, `store`, `feature`, `priority-high`
+
+Add local backup/export and import validation flows.
+
+## [V3] Implement advanced FIFO LTCG
+
+Labels: `v3`, `domain`, `feature`, `priority-medium`
+
+Add lot-level FIFO matching and detailed LTCG views.
+
+## [V3] Harden quote caching and release polish
+
+Labels: `v3`, `infra`, `release`, `refactor`, `priority-medium`
+
+Improve quote cache behaviour, Android performance, and optional Play Store automation.

--- a/docs/prompts/versioned-roadmap-planning-prompt.md
+++ b/docs/prompts/versioned-roadmap-planning-prompt.md
@@ -1,0 +1,1527 @@
+You are working on CogVest.
+
+This repo uses the Superpowers plugin in Codex CLI.
+
+Read these files first:
+- AGENTS.md
+- docs/cogvest-master-spec.md
+- docs/cogvest-codex-prompts.md
+- docs/cogvest_standard_mode.png
+- docs/cogvest_minimal_mode.png
+
+---
+
+🧠 SUPERPOWERS / CODEX CLI WORKFLOW
+
+Before making changes:
+
+- Use the appropriate Superpowers planning/design workflow if available.
+- Do not immediately edit files.
+- First inspect the repo, read the referenced docs, and produce a short implementation plan.
+- Ask only if there is a true blocker.
+- Otherwise make reasonable assumptions and document them.
+- Use Superpowers planning before execution.
+- Make changes in small, reviewable commits.
+
+Expected workflow:
+
+1. Read AGENTS.md and all docs listed above.
+2. Use Superpowers planning/brainstorming workflow to split the spec into versions.
+3. Produce a concise plan.
+4. Create/update roadmap, design, testing, release, issue-draft, and prompt files.
+5. Create GitHub labels/milestones/issues only after roadmap files are coherent.
+6. Commit changes on a new branch.
+7. Open a PR.
+
+If a Superpowers workflow/tool is unavailable:
+
+- Continue manually.
+- Document what was unavailable.
+- Do not block the task unless there is no safe fallback.
+
+---
+
+🚧 PLANNING TASK BOUNDARY
+
+This task is for planning and setup only.
+
+Do not implement app features during this task.
+
+Allowed:
+- Roadmap docs
+- Version-specific spec docs
+- Version-specific Codex prompt docs
+- Design docs
+- Testing docs
+- Release docs
+- GitHub issue drafts
+- Labels/milestones/issues
+- Figma mockups or fallback design docs
+- GitHub Actions workflow drafts
+
+Not allowed:
+- Implementing Add Trade
+- Implementing Dashboard
+- Implementing Holdings
+- Implementing Cash
+- Implementing Settings
+- Implementing source-code feature work for V1/V2/V3
+- Installing runtime dependencies unless needed only for planning/release documentation
+- Triggering real cloud builds
+
+---
+
+🎯 TASK
+
+Split the current large product spec and Codex prompt plan into:
+
+1. Multiple SHIPPABLE product versions: V1, V2, V3
+2. Version-specific specs
+3. Version-specific Codex prompts
+4. GitHub Issues for execution
+5. Figma UI mockups, or fallback design docs
+6. Testing strategy and setup for each version
+7. Android release process and GitHub/EAS build automation plan
+
+The goal is to transform a large “build everything” spec into a phased, realistic, execution-ready roadmap.
+
+---
+
+🌿 BRANCH / PR WORKFLOW
+
+Do not commit directly to main.
+
+Use the Superpowers git/branch workflow if available.
+
+Create a branch:
+
+roadmap/versioned-planning
+
+All generated roadmap, design, testing, release, issue-draft, and prompt files must be committed on this branch.
+
+Open a pull request with:
+
+- Summary of files created
+- V1 / V2 / V3 version split summary
+- GitHub labels, milestones, and issues created
+- Figma links or fallback design docs
+- Testing plan summary
+- Release process summary
+- Any unresolved decisions or conflicts
+
+Do not merge automatically.
+
+If PR creation is unavailable:
+
+- Commit the branch locally.
+- Document the exact PR title and body to create manually.
+
+---
+
+📁 CREATE / UPDATE FILES
+
+Create these files:
+
+docs/roadmap/
+- cogvest-version-roadmap.md
+- v1-mvp-spec.md
+- v2-behaviour-spec.md
+- v3-polish-and-advanced-spec.md
+- v1-codex-prompts.md
+- v2-codex-prompts.md
+- v3-codex-prompts.md
+
+docs/design/
+- v1-ui-mockup-plan.md
+- v2-ui-mockup-plan.md
+- v3-ui-mockup-plan.md
+
+docs/testing/
+- v1-testing-plan.md
+- v2-testing-plan.md
+- v3-testing-plan.md
+
+docs/release/
+- android-release-process.md
+- v1-release-checklist.md
+- github-actions-drafts.md
+- play-store-listing-draft.md
+- privacy-policy-notes.md
+
+docs/issues/
+- v1-issue-drafts.md
+- v2-placeholder-issues.md
+- v3-placeholder-issues.md
+
+docs/prompts/
+- versioned-roadmap-planning-prompt.md
+
+Do not delete or overwrite:
+- docs/cogvest-master-spec.md
+- docs/cogvest-codex-prompts.md
+
+Treat the original master spec and original Codex prompts as long-term source-of-truth references.
+
+---
+
+📦 VERSION DEFINITIONS
+
+V1 — Shippable MVP
+Target: 2–3 weeks
+
+Include ONLY:
+
+- App foundation
+- Add Trade
+- Holdings derived from trades
+- Basic Dashboard with total value and allocation
+- Cash tracking
+- Simple Settings
+- Value masking
+- Conviction input from 1–5
+- Basic conviction insight OR “not enough data” state
+- Empty states with clear CTAs
+- Android preview build process
+- Android production build process draft
+- V1 release checklist
+
+Exclude from V1:
+
+- Advanced charts
+- Historical charts
+- Complex asset search
+- Patience analysis
+- Trade frequency analysis
+- Full behaviour engine
+- Advanced LTCG multi-lot FIFO logic
+- Import/export
+- Backend
+- Cloud sync
+- Authentication
+- Push notifications
+- Advanced onboarding
+- Automatic Play Store submission
+
+---
+
+V2 — Behaviour Layer
+
+Include:
+
+- Improved conviction analytics
+- Patience analysis
+- Trade frequency analysis
+- Behaviour insight cards
+- Insight detail screen
+- Basic LTCG tracker for Indian stocks/ETFs
+- Minimal Mode fully implemented across core screens
+- Better onboarding nudges
+- More complete settings
+
+---
+
+V3 — Advanced / Polish
+
+Include:
+
+- Historical charts
+- Advanced asset search
+- Import/export
+- Advanced LTCG FIFO multi-lot logic
+- Quote caching improvements
+- Advanced dashboard widgets
+- UI polish and animations
+- Optional backup/export flows
+- Optional app hardening for release
+- Optional Play Store submission automation
+
+---
+
+📄 FOR EACH VERSION SPEC
+
+Each version spec must include:
+
+- Goal
+- Target user value
+- Included features
+- Explicitly excluded features
+- Screens included
+- Data model changes
+- Domain calculations required
+- Acceptance criteria
+- Test plan
+- Manual QA checklist
+- Definition of done
+- Release gate
+- Release/build requirements
+- Local data/versioning impact
+- Privacy/security notes
+- Known risks/deferred decisions
+
+---
+
+⚙️ FOR EACH VERSION CODEX PROMPT FILE
+
+Break work into SMALL issues.
+
+Each issue must:
+
+- Take approximately 1–3 hours
+- Be independently testable
+- Have clear prerequisites
+- List exact files to create/update
+- Include acceptance criteria
+- Include manual test steps
+- Include commands to run:
+  - npx tsc --noEmit
+  - npx jest
+  - npx expo start
+
+Keep prompts concise and implementation-focused.
+
+Do not create vague prompts like:
+
+- “Build dashboard”
+- “Implement behaviour engine”
+- “Polish UI”
+
+Split UI, domain, store, testing, release, and docs work separately.
+
+---
+
+📌 ISSUE CREATION ORDER
+
+First:
+
+1. Create/update all roadmap/spec/testing/design/release files.
+2. Review consistency between those files.
+3. Ensure V1 is small enough to ship in 2–3 weeks.
+4. Create issue draft markdown files under docs/issues/.
+
+Only after that:
+
+5. Create GitHub labels.
+6. Create GitHub milestones.
+7. Create GitHub issues.
+
+Issues must map directly to the version-specific Codex prompt files.
+
+Use the Superpowers GitHub/issue workflow if available.
+
+If GitHub issue creation is unavailable:
+
+- Do not fail the task.
+- Keep issue drafts in docs/issues/.
+- Include exact issue titles, bodies, labels, and milestones so they can be created manually.
+
+---
+
+📌 GITHUB LABELS
+
+Create these labels if they do not already exist:
+
+Version labels:
+- v1
+- v2
+- v3
+
+Area labels:
+- frontend
+- domain
+- store
+- infra
+- testing
+- design
+- docs
+- release
+
+Type labels:
+- feature
+- bug
+- chore
+- refactor
+
+Priority labels:
+- priority-high
+- priority-medium
+- priority-low
+
+---
+
+📌 GITHUB MILESTONES
+
+Create these milestones if they do not already exist:
+
+- CogVest V1 MVP
+- CogVest V2 Behaviour
+- CogVest V3 Advanced
+
+Milestone descriptions should include:
+
+- version goal
+- included scope
+- excluded scope
+- release gate summary
+- release/build expectations
+- Figma/mockup link if available
+
+---
+
+📌 GITHUB ISSUES
+
+Create detailed GitHub issues for V1 only.
+
+For V2 and V3:
+
+- Create roadmap/spec/prompt files.
+- Create milestone placeholders.
+- Create only high-level placeholder issues unless explicitly asked later to create detailed V2/V3 issues.
+
+Reason:
+
+V1 should be executed now. V2/V3 should stay flexible until V1 is validated.
+
+---
+
+### V1 Issue Structure
+
+Title format:
+
+[V1] Short clear task name
+
+Example:
+
+[V1] Implement Add Trade form validation
+
+Issue body format:
+
+## Context
+What this issue is solving.
+
+## Scope
+Exact things to build.
+
+## Out of Scope
+What must NOT be built.
+
+## Technical Notes
+- Files to create/update
+- Domain functions involved
+- Store changes involved
+- APIs involved, if any
+- Release/build impact, if any
+
+## Design Reference
+- Figma link if available
+- Fallback design doc if Figma is unavailable
+- Relevant screen/state reference
+
+## Acceptance Criteria
+- Clear checklist
+- Must be testable
+
+## Test Steps
+- Manual verification steps
+
+## Commands
+- npx tsc --noEmit
+- npx jest
+- npx expo start
+
+---
+
+### Required V1 Release/Infra Issues
+
+Add V1 GitHub issues for:
+
+- [V1] Configure Android app identity and icons
+- [V1] Configure EAS build profiles
+- [V1] Add Android preview build workflow
+- [V1] Add Android production build workflow draft
+- [V1] Create V1 release checklist
+- [V1] Verify preview APK on device
+
+Label these:
+- v1
+- infra
+- release
+- testing
+
+---
+
+### Issue Rules
+
+- Each issue should take ~1–3 hours.
+- Each issue must be independently testable.
+- No vague issues.
+- No issue should block the entire app.
+- Split UI, domain, store, testing, release, and docs work.
+- Avoid large multi-feature issues.
+- UI issues must link to Figma or fallback design docs.
+- Release issues must link to docs/release/android-release-process.md or docs/release/v1-release-checklist.md.
+- Do not implement UI without a design reference.
+
+---
+
+📌 OPTIONAL: SUB-ISSUES
+
+Use sub-issues only for large features.
+
+Rules:
+
+- Parent issue = feature-level task
+- Sub-issues = implementation-level tasks
+- Max depth = 1
+- Sub-issues must still be independently testable
+- Do not create sub-issues for small tasks
+- If a task can be completed in under 3 hours, do not create sub-issues
+- Prefer flat issues unless complexity demands grouping
+
+Example:
+
+Parent issue:
+[V1] Add Trade Screen
+
+Sub-issues:
+- [V1] Add Trade — Form schema and validation
+- [V1] Add Trade — Conviction selector
+- [V1] Add Trade — Submit and store integration
+- [V1] Add Trade — Review state and success feedback
+
+---
+
+🎨 FIGMA UI MOCKUPS
+
+Before implementation starts, generate UI mockups using the official Codex/Figma integration if available.
+
+Create separate Figma pages/files for:
+
+1. CogVest V1 MVP
+2. CogVest V2 Behaviour Layer
+3. CogVest V3 Advanced / Polish
+
+---
+
+### Figma Design System Requirement
+
+Before screen mockups, create a small design system page with:
+
+- Colours
+- Typography
+- Spacing
+- Card styles
+- Buttons
+- Badges
+- Input fields
+- Bottom navigation
+- Value masking component
+- Conviction selector component
+- Empty state component
+
+Use these components consistently across V1/V2/V3 mockups.
+
+---
+
+### V1 Mockups
+
+Include:
+
+- Empty Dashboard
+- Filled Dashboard
+- Add Trade
+- Holdings empty state
+- Holdings filled state
+- Cash empty state
+- Cash filled state
+- Settings
+- Conviction insight state
+- “Not enough data” conviction state
+- Value masking state
+- V1 release/testing checklist screen or internal QA reference, if useful
+
+---
+
+### V2 Mockups
+
+Include:
+
+- Minimal Mode Dashboard
+- Minimal Mode Holdings
+- Behaviour Insights
+- Insight Detail
+- Basic LTCG states
+- Patience insight state
+- Frequency insight state
+- Better onboarding/nudge states
+
+---
+
+### V3 Mockups
+
+Include:
+
+- Historical Charts
+- Advanced Asset Search
+- Import / Export
+- Advanced Dashboard widgets
+- Polished Asset Detail
+- Advanced LTCG states
+
+---
+
+### Mockup Rules
+
+- Use docs/cogvest_standard_mode.png and docs/cogvest_minimal_mode.png as visual references.
+- Android-first mobile frame.
+- Dark theme by default.
+- Primary accent: #2E7D52.
+- Card radius: 12px.
+- No coloured shadows.
+- Use subtle borders.
+- Use realistic INR values.
+- Include empty and filled states where relevant.
+- Preserve CogVest design language.
+- Standard Mode can show richer information density.
+- Minimal Mode must reduce noise and emotional triggers.
+
+---
+
+### Figma Output
+
+After creating Figma mockups:
+
+- Add Figma links to docs/roadmap/cogvest-version-roadmap.md.
+- Add relevant Figma links to GitHub milestone descriptions.
+- Add relevant Figma links to UI-related GitHub issues.
+
+---
+
+### Figma Fallback
+
+If Figma generation fails or the tool is unavailable:
+
+Do not block roadmap work.
+
+Create detailed fallback design docs:
+
+docs/design/v1-ui-mockup-plan.md
+docs/design/v2-ui-mockup-plan.md
+docs/design/v3-ui-mockup-plan.md
+
+Each fallback design doc must describe:
+
+- Screen layout
+- Components
+- Spacing
+- Interactions
+- Empty states
+- Filled states
+- Error states
+- Design tokens
+- Manual Figma recreation notes
+
+The fallback docs must be detailed enough to recreate the screens manually in Figma.
+
+---
+
+🧪 TESTING STRATEGY
+
+Define testing approach per version.
+
+---
+
+### Unit Testing
+
+Use:
+
+- Jest
+- React Native Testing Library
+
+Test:
+
+- Domain functions
+- Store logic
+- Formatters
+- Validators
+- Selectors
+
+Examples:
+
+- calculateHolding()
+- calculateAllocation()
+- portfolioTotal()
+- analyseConviction()
+- formatINR()
+- trade validation
+- Zustand store actions
+- value masking logic
+
+Every domain function must have unit tests.
+
+---
+
+### Type Safety
+
+Always run:
+
+- npx tsc --noEmit
+
+It must pass with zero errors.
+
+TypeScript strict mode must remain enabled.
+
+No `any` types unless there is a very clear reason documented in the relevant issue.
+
+---
+
+### Component Testing
+
+Use:
+
+- @testing-library/react-native
+
+Test:
+
+- Screen rendering
+- Empty states
+- Basic interactions
+- Form validation messages
+- Value masking display
+- Conviction selector behaviour
+
+---
+
+### Expo Router / Navigation Testing
+
+Where useful, add tests for:
+
+- Tab screen rendering
+- Route-level smoke tests
+- Navigation from Dashboard/Add Trade/Holdings
+
+Use Expo Router testing utilities if the project is configured for them.
+
+---
+
+### Android Runtime Testing
+
+Codex should run:
+
+- npx expo doctor
+- npx expo start
+
+Optional if the local environment supports Android SDK/emulator:
+
+- npx expo run:android
+
+Do not block non-Android CI work if the emulator is unavailable.
+
+Document what could not be tested automatically.
+
+---
+
+### E2E Testing
+
+Use Maestro for limited Android E2E coverage.
+
+Create:
+
+e2e/
+- add-trade.yaml
+- holdings.yaml
+- dashboard.yaml
+- cash.yaml
+- value-masking.yaml
+
+Test only core flows:
+
+- Add a trade
+- View holdings
+- See dashboard total update
+- Add cash
+- Toggle value masking
+
+Rules:
+
+- E2E tests are not required for every issue.
+- Run E2E before version release.
+- Do not over-test visual polish.
+- Do not block V1 development on E2E if local emulator setup is unavailable.
+
+---
+
+### Manual Testing
+
+Each version testing plan must include manual checks.
+
+V1 manual checks must include:
+
+- Add Trade flow
+- Holdings accuracy after adding trade
+- Dashboard total update
+- Cash addition/withdrawal
+- Value masking toggle
+- App restart persistence through MMKV
+- Navigation between tabs
+- Empty states
+- Basic Android device UI check
+- Android preview APK install on real device
+- No backend/auth/cloud added
+
+---
+
+### Test Scripts
+
+Ensure package.json includes these scripts:
+
+"scripts": {
+  "typecheck": "tsc --noEmit",
+  "test": "jest",
+  "start": "expo start",
+  "android": "expo run:android",
+  "doctor": "expo doctor"
+}
+
+If scripts already exist, preserve them and add missing scripts only.
+
+---
+
+### Testing Rules
+
+- Every issue must run:
+  - npm run typecheck
+  - npm test
+- UI/navigation issues must include component tests where practical.
+- Domain issues must include unit tests.
+- Release/build issues must include manual verification instructions.
+- E2E runs only before release or milestone verification.
+- Manual test gaps must be documented.
+
+---
+
+⏱️ LONG-RUNNING COMMAND RULES
+
+Do not leave long-running commands running indefinitely.
+
+For commands like:
+
+- npx expo start
+- npm run start
+- npx expo run:android
+
+Use them only as smoke checks.
+
+If a command starts a dev server successfully:
+
+- Capture the success output.
+- Stop the process.
+- Document the result.
+
+Do not wait forever for manual interaction.
+
+---
+
+🤖 CI TESTING BOUNDARY
+
+GitHub Actions should not require an Android emulator for normal PR checks.
+
+Required PR checks:
+- Install dependencies
+- Typecheck
+- Unit tests
+- Component tests where applicable
+- Expo doctor
+
+Emulator/device testing is manual or release-gate only.
+
+If Android emulator testing is added later, it must be separate from default PR checks.
+
+---
+
+📦 DEPENDENCY RULES
+
+Do not add new runtime dependencies unless required by the approved stack.
+
+Approved stack:
+
+- Expo / React Native
+- Expo Router
+- TypeScript
+- Zustand
+- MMKV
+- React Native Reanimated
+- Victory Native or chosen chart library
+- React Hook Form
+- Zod
+- Jest
+- React Native Testing Library
+- Maestro for E2E
+- EAS CLI / Expo tooling for builds
+
+If a new dependency is needed:
+
+- Document why.
+- Prefer existing project dependencies first.
+- Do not add analytics, cloud, auth, or backend SDKs.
+- Do not add packages that conflict with Expo-managed workflow unless explicitly justified.
+
+---
+
+🚀 ANDROID RELEASE PROCESS
+
+Define a release process for CogVest Android.
+
+The app is Android-first, Expo-based, and local-first.
+
+Create:
+
+docs/release/
+- android-release-process.md
+- v1-release-checklist.md
+
+Update:
+
+- docs/roadmap/cogvest-version-roadmap.md
+- docs/testing/v1-testing-plan.md
+- docs/issues/v1-issue-drafts.md
+
+---
+
+### Release Goals
+
+Support three Android build types:
+
+1. Development build
+
+Purpose:
+- Local testing during development.
+
+Commands:
+- npx expo run:android
+
+Or, if using EAS development build:
+- eas build --platform android --profile development
+
+2. Preview / Internal build
+
+Purpose:
+- Installable APK for manual testing on real Android devices.
+
+Output:
+- APK
+
+Command:
+- eas build --platform android --profile preview
+
+3. Production build
+
+Purpose:
+- Google Play Store release.
+
+Output:
+- AAB
+
+Command:
+- eas build --platform android --profile production
+
+---
+
+### EAS Setup
+
+Add or verify:
+
+- eas.json
+- app.json or app.config.ts Android config
+- Android package name
+- app version
+- versionCode
+- app icon
+- adaptive icon
+- splash screen
+- runtime version / update policy if expo-updates is used
+
+Recommended Android package:
+
+com.abdulshaikh.cogvest
+
+If this package name is already taken or unsuitable, document alternatives.
+
+---
+
+### eas.json Profiles
+
+Create or document these profiles:
+
+development:
+- developmentClient: true
+- distribution: internal
+- Android build type: apk
+
+preview:
+- distribution: internal
+- Android build type: apk
+
+production:
+- distribution: store
+- Android build type: app-bundle / AAB
+
+Example structure:
+
+{
+  "cli": {
+    "version": ">= 13.0.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "distribution": "store",
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
+  }
+}
+
+---
+
+### GitHub Build Automation
+
+Add GitHub/EAS automation planning.
+
+Preferred approach:
+
+- Use EAS Build for Android builds.
+- Use GitHub Actions or EAS Workflows to trigger builds.
+
+Create workflow files if appropriate:
+
+.github/workflows/android-preview.yml
+.github/workflows/android-production.yml
+
+If GitHub Actions should not be created yet, create documented workflow drafts under:
+
+docs/release/github-actions-drafts.md
+
+---
+
+### Android Preview Build Workflow
+
+Trigger:
+
+- pull request to main
+- manual workflow_dispatch
+
+Steps:
+
+- checkout repo
+- setup Node
+- install dependencies
+- run typecheck
+- run tests
+- run expo doctor
+- trigger EAS preview build for Android
+
+Required secrets:
+
+- EXPO_TOKEN
+
+Command:
+
+- eas build --platform android --profile preview --non-interactive
+
+Output:
+
+- EAS build URL
+- APK install URL if available
+
+---
+
+### Android Production Build Workflow
+
+Trigger:
+
+- GitHub release tag like v1.0.0
+- manual workflow_dispatch
+
+Steps:
+
+- checkout repo
+- setup Node
+- install dependencies
+- run typecheck
+- run tests
+- run expo doctor
+- trigger EAS production build for Android
+
+Required secrets:
+
+- EXPO_TOKEN
+
+Command:
+
+- eas build --platform android --profile production --non-interactive
+
+Output:
+
+- AAB artifact through EAS Build
+- production build URL
+
+Do not auto-submit to Google Play in V1 unless explicitly configured.
+
+---
+
+### Google Play Submission
+
+For V1:
+
+- Do NOT auto-submit by default.
+- Build production AAB.
+- Manually upload to Google Play Console internal testing track.
+
+For later versions:
+
+- Document optional EAS Submit setup.
+- If auto-submit is added later, use EAS Submit and a Google service account.
+- Document required secrets separately.
+
+---
+
+### Release Checklist
+
+V1 release checklist must include:
+
+Code quality:
+- npm install succeeds
+- npm run typecheck passes
+- npm test passes
+- npx expo doctor passes
+
+Runtime:
+- app starts with npx expo start
+- Android preview APK installs on real device
+- Add Trade works
+- Holdings update
+- Dashboard total updates
+- Cash tracking works
+- Value masking works
+- MMKV persistence works after app restart
+
+Release config:
+- app name is CogVest
+- Android package name is set
+- versionCode is incremented
+- versionName is set
+- icon exists
+- adaptive icon exists
+- splash screen exists
+- privacy note exists in docs
+- no backend/auth/cloud added
+
+Build:
+- preview APK build succeeds
+- production AAB build succeeds
+- EAS build URLs are recorded
+
+Store readiness:
+- Play Console internal testing notes drafted
+- basic app description drafted
+- screenshots planned or generated
+- privacy/data safety notes drafted
+
+---
+
+🔐 SECRETS / ENVIRONMENT RULES
+
+Do not commit secrets.
+
+Never commit:
+- EXPO_TOKEN
+- Google Play service account JSON
+- API keys
+- keystores
+- passwords
+- signing credentials
+- local .env files containing secrets
+
+Document required secrets in:
+
+docs/release/android-release-process.md
+
+Use GitHub Actions secrets for CI/CD secrets.
+
+If a secret is required but unavailable:
+
+- Do not block planning work.
+- Document the secret name.
+- Document where it must be configured.
+- Provide manual setup steps.
+
+---
+
+💸 BUILD / CI COST CONTROL
+
+Do not trigger real EAS builds unless explicitly asked.
+
+For this planning task:
+
+- Create EAS config guidance.
+- Create workflow drafts.
+- Document commands.
+- Do not run paid/cloud builds automatically.
+- Do not trigger preview or production builds.
+
+For implementation/release issues:
+
+- Run local checks first.
+- Trigger preview/production builds only when release gate requires it and the user explicitly approves.
+
+---
+
+🔏 ANDROID SIGNING / CREDENTIALS
+
+Document Android signing strategy.
+
+For V1:
+
+- Prefer Expo-managed credentials through EAS unless explicitly changed.
+- Do not generate or commit keystores into the repo.
+- Document how credentials are managed.
+- Document recovery risk if signing credentials are lost.
+- Document where signing credentials are controlled in Expo/EAS.
+
+---
+
+🏪 STORE READINESS DOCS
+
+Create or draft:
+
+docs/release/play-store-listing-draft.md
+docs/release/privacy-policy-notes.md
+
+Include:
+
+- App short description
+- App long description
+- Internal testing release notes
+- Data safety notes
+- Privacy policy notes
+- Statement that financial data is stored locally
+- Statement that no login/cloud sync exists in V1
+- Statement that quote APIs receive only asset/ticker identifiers
+- Draft screenshots requirement
+- Draft support/contact note if applicable
+
+---
+
+🏷️ VERSIONING RULES
+
+Document versioning in:
+
+docs/release/android-release-process.md
+
+Use:
+
+- versionName for user-facing app version, e.g. 0.1.0
+- versionCode as monotonically increasing Android integer
+
+Before every production build:
+
+- increment versionCode
+- update versionName if needed
+- document release notes
+- tag release consistently, e.g. v0.1.0
+
+---
+
+🧳 LOCAL-FIRST BACKUP RISK
+
+Because CogVest is local-first, document backup/export risk.
+
+V1 may ship without export/import, but docs must clearly mark:
+
+- data is stored on device only
+- uninstalling the app may delete data
+- clearing app storage may delete data
+- export/import is planned for a later version
+- users should treat V1 as local-device-only until backup/export exists
+
+---
+
+🚫 NO FAKE IMPLEMENTATIONS
+
+Do not mark work complete with placeholder logic unless the issue explicitly asks for a placeholder.
+
+Avoid:
+
+- Hardcoded portfolio values.
+- Fake passing tests that do not verify behavior.
+- TODO-only components.
+- Mock data in production paths.
+- Silently skipped tests.
+- Empty files created only to satisfy structure.
+- Stubbed services pretending to be complete.
+
+If mock data is used, keep it inside tests, demo fixtures, or clearly named mock files.
+
+If a placeholder is necessary, document:
+
+- Why it exists.
+- Where it lives.
+- What issue will replace it.
+
+---
+
+♿ ACCESSIBILITY BASICS
+
+All interactive controls must have:
+
+- Accessible labels where appropriate.
+- Clear pressed/disabled/loading states.
+- Adequate touch target size.
+- Readable contrast in dark theme.
+
+Important controls:
+
+- Add Trade button
+- Buy/Sell toggle
+- Conviction selector
+- Value masking eye toggle
+- Cash add/withdraw buttons
+- Bottom tab items
+
+---
+
+✅ ISSUE DEFINITION OF DONE
+
+An issue is not complete unless:
+
+- Code is implemented.
+- Relevant tests are added or updated.
+- npm run typecheck passes.
+- npm test passes.
+- Manual test steps are documented.
+- No unrelated files were changed.
+- No out-of-scope features were added.
+- No fake implementation was used unless explicitly allowed.
+- Any skipped/untested areas are documented.
+
+---
+
+🚦 VERSION RELEASE GATES
+
+Each version spec must include a release gate.
+
+---
+
+### V1 Release Gate
+
+V1 has two release gates.
+
+V1 dev-complete cannot be considered done unless:
+
+- npm install succeeds
+- npm run typecheck passes
+- npm test passes
+- npx expo doctor passes
+- app launches with npx expo start
+- Add Trade works manually
+- Holdings update after trade
+- Dashboard total updates after holdings/cash changes
+- Cash entry updates cash total
+- Value masking works
+- App data persists after restart
+- Android preview APK builds successfully
+- Android preview APK installs on real device
+- No backend/auth/cloud was added
+- Secrets are not committed
+- V1 GitHub milestone issues are complete or intentionally deferred with notes
+
+V1 release-candidate cannot be considered done unless:
+
+- V1 dev-complete gate passes
+- Android production AAB builds successfully
+- EAS production build URL is recorded
+- Play Console internal testing upload is ready/manual
+- Store listing draft and privacy notes are reviewed
+
+---
+
+### V2 Release Gate
+
+V2 cannot be considered done unless:
+
+- V1 release gate still passes
+- Minimal Mode works across all V2-supported screens
+- Behaviour insight cards render correctly
+- Patience/frequency analysis has unit tests
+- Basic LTCG tracker has unit tests
+- Insight detail screen is manually tested
+- Existing V1 data remains compatible
+
+---
+
+### V3 Release Gate
+
+V3 cannot be considered done unless:
+
+- V1 and V2 gates still pass
+- Historical charts load or gracefully fallback
+- Import/export works with test files
+- Advanced LTCG FIFO logic has comprehensive tests
+- Quote caching has tests
+- Performance is acceptable on Android
+- Data migration risks are documented
+- Optional Play Store submission process is documented or configured
+
+---
+
+💾 LOCAL DATA VERSIONING
+
+For each version, document whether the persisted local data shape changes.
+
+If the data model changes:
+
+- Document migration requirements.
+- Avoid destructive storage resets.
+- Keep persisted raw data backward-compatible where possible.
+- Do not persist derived state.
+- Document how older local data should behave after app update.
+
+---
+
+🔒 PRIVACY / SECURITY RULES
+
+CogVest stores sensitive financial data locally.
+
+Do not:
+
+- Log portfolio values unnecessarily.
+- Log raw trades in console.
+- Send user portfolio/trade data to any external service.
+- Add analytics SDKs without explicit approval.
+- Add crash/reporting SDKs without explicit approval.
+- Add backend/cloud/auth functionality.
+
+Quote APIs may receive only ticker/asset identifiers.
+
+Quote APIs must never receive:
+
+- User quantity held
+- User trade history
+- User portfolio value
+- User notes
+- Conviction score
+- Behaviour metadata
+
+---
+
+🧠 CORE PRODUCT CONSTRAINTS
+
+Preserve:
+
+- Android-first
+- Local-first
+- No backend
+- No auth
+- No cloud sync
+- INR-first
+- TypeScript strict mode
+- Functional components with hooks only
+- Pure domain functions in src/domain/
+- No business logic inside UI components
+- Persist raw data only
+- Derive everything else
+- Behaviour fields are optional
+- Minimal Mode never removes core functionality
+
+Do not move advanced features into V1 just because they exist in the master spec.
+
+V1 must remain small enough to ship in 2–3 weeks.
+
+---
+
+📊 OUTPUT
+
+After completing the work, provide:
+
+1. Version summary:
+   - What is included in V1
+   - What moved to V2
+   - What moved to V3
+
+2. Files summary:
+   - Roadmap files created
+   - Design files created
+   - Testing files created
+   - Release files created
+   - Prompt files created
+   - Issue draft files created
+
+3. GitHub structure summary:
+   - Labels created
+   - Milestones created
+   - V1 issues created
+   - V2/V3 placeholder issues created, if any
+   - Any GitHub operations that could not be completed
+
+4. Figma output:
+   - Figma links, OR
+   - fallback design docs created
+
+5. Testing summary:
+   - Testing strategy per version
+   - V1 release gate
+   - Automated vs manual testing boundaries
+
+6. Release process summary:
+   - EAS profiles created or drafted
+   - GitHub workflows created or drafted
+   - Android build types defined
+   - V1 release checklist created
+   - Required secrets documented
+   - Signing/credentials approach documented
+   - Manual Play Console upload process documented
+   - Store readiness docs created
+
+7. Superpowers usage summary:
+   - Which Superpowers workflows/tools were used
+   - Which were unavailable, if any
+   - Fallback actions taken
+
+8. Conflicts / ambiguities:
+   - Any contradictions in original spec
+   - Any scope risks
+   - Any assumptions made
+
+9. PR summary:
+   - Branch name
+   - Commit summary
+   - PR link if created
+   - PR title/body if manual creation is required
+
+---
+
+🎯 FINAL GOAL
+
+Enable CogVest to:
+
+- Ship V1 in 2–3 weeks
+- Avoid overengineering
+- Keep V2/V3 flexible
+- Preserve the behavioural investing identity
+- Build incrementally without breaking architecture
+- Build Android APK/AAB releases safely through EAS/GitHub
+
+Focus on execution, not perfection.

--- a/docs/release/android-release-process.md
+++ b/docs/release/android-release-process.md
@@ -1,0 +1,128 @@
+# Android Release Process
+
+## Build Types
+
+### Development Build
+
+Purpose: local development and native integration checks.
+
+Commands:
+
+```bash
+npx expo run:android
+eas build --platform android --profile development
+```
+
+### Preview Build
+
+Purpose: installable APK for manual testing on real Android devices.
+
+Command:
+
+```bash
+eas build --platform android --profile preview
+```
+
+Output: APK.
+
+### Production Build
+
+Purpose: Google Play Store release candidate.
+
+Command:
+
+```bash
+eas build --platform android --profile production
+```
+
+Output: AAB.
+
+## V1 Gate Split
+
+V1 dev-complete requires:
+- `npm run typecheck`
+- `npm test`
+- `npx expo doctor`
+- app starts with `npx expo start`
+- core manual flows pass
+- preview APK builds
+- preview APK installs on a real Android device
+
+V1 release-candidate requires:
+- production AAB builds successfully
+- EAS build URL is recorded
+- Play Console internal testing upload is ready/manual
+
+## Android Identity
+
+Recommended package name:
+
+```text
+com.abdulshaikh.cogvest
+```
+
+Before production build:
+- confirm package name
+- set app name to `CogVest`
+- increment `versionCode`
+- set `versionName`
+- verify icon, adaptive icon, and splash screen
+
+## EAS Profiles
+
+Recommended `eas.json`:
+
+```json
+{
+  "cli": {
+    "version": ">= 13.0.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "distribution": "store",
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
+  }
+}
+```
+
+## Required Secrets
+
+Do not commit secrets.
+
+GitHub Actions secrets:
+- `EXPO_TOKEN`
+
+Future Play submission secrets:
+- Google Play service account JSON, only if EAS Submit is configured.
+
+## Signing Strategy
+
+Use Expo-managed Android credentials through EAS for V1 unless explicitly changed. Do not commit keystores. Document who controls the Expo account and how signing credential recovery is handled.
+
+## Play Store Submission
+
+V1 does not auto-submit. Build the production AAB and manually upload it to the Google Play Console internal testing track.
+
+Future versions may add EAS Submit after manual release flow is proven.
+
+## Versioning
+
+- `versionName`: user-facing app version, e.g. `0.1.0`.
+- `versionCode`: monotonically increasing Android integer.
+- Git tag format: `v0.1.0`.

--- a/docs/release/github-actions-drafts.md
+++ b/docs/release/github-actions-drafts.md
@@ -1,0 +1,68 @@
+# GitHub Actions Drafts
+
+These workflows are drafts. Do not trigger EAS cloud builds unless explicitly approved.
+
+## Android Preview Build
+
+Path: `.github/workflows/android-preview.yml`
+
+```yaml
+name: Android Preview Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test
+      - run: npx expo doctor
+      - run: npx eas-cli build --platform android --profile preview --non-interactive
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+```
+
+## Android Production Build
+
+Path: `.github/workflows/android-production.yml`
+
+```yaml
+name: Android Production Build
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  production:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test
+      - run: npx expo doctor
+      - run: npx eas-cli build --platform android --profile production --non-interactive
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+```
+
+## Boundary
+
+Default PR checks should not require an Android emulator. Device testing is release-gate/manual.

--- a/docs/release/play-store-listing-draft.md
+++ b/docs/release/play-store-listing-draft.md
@@ -1,0 +1,34 @@
+# Play Store Listing Draft
+
+## Short Description
+
+Local-first portfolio tracker for INR investments and investing behaviour.
+
+## Long Description
+
+CogVest is an Android-first portfolio tracker for crypto, Indian stocks, ETFs, and cash. It helps you track holdings, portfolio value, allocation, cash, and trade context locally on your device.
+
+V1 is local-first. There is no login, backend, cloud sync, or brokerage integration. Quote services receive only asset identifiers such as ticker or coin ID.
+
+## Internal Testing Release Notes
+
+Initial V1 preview:
+- Add buy/sell trades.
+- Track holdings and dashboard value.
+- Track cash additions and withdrawals.
+- Toggle value masking.
+- Capture optional conviction ratings.
+- Local-only MMKV persistence.
+
+## Screenshots Needed
+
+- Dashboard filled.
+- Dashboard masked.
+- Add Trade.
+- Holdings filled.
+- Cash.
+- Settings.
+
+## Support Contact
+
+To be added before Play Console submission.

--- a/docs/release/privacy-policy-notes.md
+++ b/docs/release/privacy-policy-notes.md
@@ -1,0 +1,51 @@
+# Privacy Policy Notes
+
+## Local-First Data
+
+CogVest V1 stores portfolio data locally on the user's Android device.
+
+Stored locally:
+- assets
+- trades
+- quantities
+- prices
+- cash entries
+- notes
+- conviction ratings
+- preferences
+
+## No Account System
+
+V1 has:
+- no login
+- no backend
+- no cloud sync
+- no social features
+- no brokerage integration
+- no analytics SDK
+
+## Quote API Data
+
+Quote APIs may receive only:
+- stock/ETF ticker
+- crypto coin ID
+
+Quote APIs must not receive:
+- quantity held
+- trade history
+- portfolio value
+- user notes
+- conviction score
+- behaviour metadata
+
+## Data Loss Risk
+
+Because V1 is local-only:
+- uninstalling the app may delete data
+- clearing app storage may delete data
+- device loss may lose data
+- export/import is planned for a later version
+
+## Secrets
+
+Do not commit tokens, keystores, service-account JSON, passwords, or local secret files.

--- a/docs/release/v1-release-checklist.md
+++ b/docs/release/v1-release-checklist.md
@@ -1,0 +1,46 @@
+# V1 Release Checklist
+
+## Dev-Complete Gate
+
+- [ ] `npm install` succeeds.
+- [ ] `npm run typecheck` passes.
+- [ ] `npm test` passes.
+- [ ] `npx expo doctor` passes.
+- [ ] App starts with `npx expo start`.
+- [ ] Add Trade works manually.
+- [ ] Holdings update after trade.
+- [ ] Dashboard total updates after holdings/cash changes.
+- [ ] Cash entry updates cash total.
+- [ ] Value masking works.
+- [ ] App data persists after restart.
+- [ ] Preview APK builds successfully.
+- [ ] Preview APK installs on real Android device.
+- [ ] No backend/auth/cloud was added.
+- [ ] Secrets are not committed.
+
+## Release-Candidate Gate
+
+- [ ] Production AAB builds successfully.
+- [ ] EAS production build URL recorded.
+- [ ] Play Console internal testing upload ready/manual.
+- [ ] Store listing draft reviewed.
+- [ ] Privacy notes reviewed.
+- [ ] Screenshots planned or generated.
+
+## Build URL Log
+
+Preview APK:
+
+```text
+Record preview EAS build URL during release verification.
+```
+
+Production AAB:
+
+```text
+Record production EAS build URL during release-candidate verification.
+```
+
+## Manual QA Notes
+
+Record device model, Android version, and any issues found during preview APK testing.

--- a/docs/roadmap/cogvest-version-roadmap.md
+++ b/docs/roadmap/cogvest-version-roadmap.md
@@ -104,3 +104,6 @@ Issues created:
 - V1 detailed issues: #1-#16
 - V2 placeholder issues: #17-#21
 - V3 placeholder issues: #22-#26
+
+Planning PR:
+- https://github.com/abdul-shaikh-dev/CogVest/pull/27

--- a/docs/roadmap/cogvest-version-roadmap.md
+++ b/docs/roadmap/cogvest-version-roadmap.md
@@ -1,0 +1,106 @@
+# CogVest Version Roadmap
+
+## Source References
+
+- Master spec: `docs/cogvest-master-spec.md`
+- Original full prompt set: `docs/cogvest-codex-prompts.md`
+- Planning prompt: `docs/prompts/versioned-roadmap-planning-prompt.md`
+- Figma mockups: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d
+- Visual references: `docs/cogvest_standard_mode.png`, `docs/cogvest_minimal_mode.png`
+
+## Version Strategy
+
+CogVest will ship in three product versions instead of one large build. V1 proves the local-first tracker and Android release path. V2 adds the behaviour-aware differentiation. V3 adds advanced market, tax, backup, and polish features after core usage is validated.
+
+## V1: Shippable MVP
+
+Target: 2-3 weeks.
+
+Goal: replace a spreadsheet for day-to-day local portfolio tracking on Android.
+
+Included:
+- Expo/React Native foundation with TypeScript strict mode.
+- Local MMKV persistence through Zustand.
+- Add Trade with buy/sell, quantity, price, date, fees, notes, and optional conviction.
+- Live quote fetching for current prices on app open and pull-to-refresh.
+- Manual price fallback when quotes fail.
+- Holdings derived from trades.
+- Basic dashboard with total value, allocation, and quote freshness.
+- Cash add/withdraw tracking.
+- Simple settings for value masking and app metadata.
+- Value masking across INR wealth values.
+- Basic conviction insight state: rated-trade count and not-enough-data guidance.
+- Android preview APK process and release-candidate production AAB plan.
+
+Excluded:
+- Minimal Mode.
+- LTCG UI or tax badges.
+- Historical charts.
+- Advanced asset search.
+- Patience and trade-frequency analysis.
+- Full behaviour insight engine.
+- Import/export.
+- Backend, auth, cloud sync, analytics, push notifications.
+- Automatic Play Store submission.
+
+Release gates:
+- V1 dev-complete: typecheck, tests, Expo doctor, app launch, manual core flows, preview APK build, preview APK install on real Android device.
+- V1 release-candidate: production AAB build succeeds, EAS URL recorded, Play Console internal testing upload ready/manual.
+
+## V2: Behaviour Layer
+
+Goal: make CogVest meaningfully behaviour-aware without destabilising the MVP.
+
+Included:
+- Improved conviction analytics.
+- Patience analysis.
+- Trade frequency analysis.
+- Behaviour insight cards.
+- Insight detail screen.
+- Basic LTCG tracker for Indian stocks/ETFs.
+- Minimal Mode across core screens.
+- Better onboarding nudges.
+- More complete settings.
+
+Excluded:
+- Historical price charts.
+- Advanced search.
+- Advanced FIFO lot-level LTCG.
+- Import/export.
+- Play Store auto-submit.
+
+## V3: Advanced and Polish
+
+Goal: mature CogVest into a robust personal investing system.
+
+Included:
+- Historical charts.
+- Advanced asset search.
+- Import/export and local backup flows.
+- Advanced FIFO multi-lot LTCG.
+- Quote caching improvements.
+- Advanced dashboard widgets.
+- UI polish, animation, and performance hardening.
+- Optional Play Store submission automation.
+
+## Issue Creation Policy
+
+V1 issues are detailed and execution-ready. V2 and V3 remain flexible through specs, prompt files, milestones, and placeholder issues until V1 is validated.
+
+## GitHub Artifacts
+
+Labels created:
+- `v1`, `v2`, `v3`
+- `frontend`, `domain`, `store`, `infra`, `testing`, `design`, `docs`, `release`
+- `feature`, `bug`, `chore`, `refactor`
+- `priority-high`, `priority-medium`, `priority-low`
+
+Milestones created:
+- CogVest V1 MVP
+- CogVest V2 Behaviour
+- CogVest V3 Advanced
+
+Issues created:
+- V1 detailed issues: #1-#16
+- V2 placeholder issues: #17-#21
+- V3 placeholder issues: #22-#26

--- a/docs/roadmap/v1-codex-prompts.md
+++ b/docs/roadmap/v1-codex-prompts.md
@@ -1,0 +1,231 @@
+# CogVest V1 Codex Prompts
+
+Use these prompts in order. Each issue should remain independently testable and should not add V2/V3 scope.
+
+## [V1] Scaffold Expo Android app
+
+Create the Expo SDK 52+ TypeScript app with Expo Router tabs, Android-only config, strict TypeScript, Jest, and baseline scripts.
+
+Files:
+- `app/_layout.tsx`
+- `app/(tabs)/_layout.tsx`
+- `app/(tabs)/dashboard.tsx`
+- `app/(tabs)/holdings.tsx`
+- `app/(tabs)/add-trade.tsx`
+- `app/(tabs)/cash.tsx`
+- `app/settings.tsx`
+- `package.json`
+- `tsconfig.json`
+- `jest.config.js`
+
+Acceptance:
+- Tabs render.
+- `npm run typecheck`, `npm test`, and `npx expo start` work.
+
+## [V1] Add theme and common UI primitives
+
+Create CogVest tokens and common UI primitives for dark Android UI.
+
+Files:
+- `src/theme/*`
+- `src/components/common/AppText.tsx`
+- `src/components/common/AppButton.tsx`
+- `src/components/common/ScreenContainer.tsx`
+- `src/components/common/MaskedValue.tsx`
+- `src/components/common/EmptyState.tsx`
+
+Acceptance:
+- No shadows; subtle borders; primary green only for intended semantic actions.
+- MaskedValue masks INR wealth values.
+
+## [V1] Define types, store, and persistence
+
+Create canonical TypeScript types, Zustand store slices, selectors, and MMKV persistence.
+
+Files:
+- `src/types/*`
+- `src/store/usePortfolioStore.ts`
+- `src/store/selectors.ts`
+- `src/services/storage/mmkv.ts`
+- `src/utils/id.ts`
+
+Acceptance:
+- Persist raw assets, trades, cash entries, preferences.
+- Do not persist derived holdings/allocation/dashboard totals.
+- Store action tests pass.
+
+## [V1] Implement domain calculations and formatters
+
+Implement pure calculations for V1.
+
+Files:
+- `src/domain/calculations/holdings.ts`
+- `src/domain/calculations/allocation.ts`
+- `src/domain/calculations/pnl.ts`
+- `src/domain/calculations/conviction.ts`
+- `src/domain/formatters/currency.ts`
+- `src/domain/formatters/dates.ts`
+- `src/domain/validators/trade.ts`
+
+Acceptance:
+- Unit tests cover weighted average, partial sells, zero totals, allocation, portfolio total, INR formatting, and conviction readiness.
+
+## [V1] Add live quote services
+
+Implement current quote fetching only.
+
+Files:
+- `src/services/quotes/yahooFinance.ts`
+- `src/services/quotes/coinGecko.ts`
+- `src/services/quotes/quoteResolver.ts`
+- `src/services/quotes/useQuoteRefresh.ts`
+
+Acceptance:
+- Yahoo handles Indian stock/ETF current quotes.
+- CoinGecko handles crypto current quotes.
+- Failures return null/empty and do not throw into UI.
+- Manual price fallback remains available.
+
+## [V1] Build Add Trade form validation
+
+Create form schema and validation logic before UI integration.
+
+Files:
+- `src/domain/validators/trade.ts`
+- `src/features/trades/tradeForm.ts`
+- `src/features/trades/__tests__/tradeForm.test.ts`
+
+Acceptance:
+- Price and quantity must be positive.
+- Future dates are rejected.
+- Sell quantity cannot exceed current holding.
+- Conviction remains optional.
+
+## [V1] Build Add Trade screen
+
+Implement fast trade entry with live/manual price and optional conviction.
+
+Files:
+- `app/(tabs)/add-trade.tsx`
+- `src/components/forms/ConvictionSelector.tsx`
+- `src/components/forms/AssetPicker.tsx`
+- `src/components/forms/TradeReviewSheet.tsx`
+
+Acceptance:
+- Standard buy can be logged in under 45 seconds.
+- New assets can be created.
+- Confirmed trade persists.
+
+## [V1] Build Holdings derivation and screen
+
+Derive holdings from trades and quotes, then render empty/filled states.
+
+Files:
+- `src/features/holdings/useHoldings.ts`
+- `src/components/cards/HoldingCard.tsx`
+- `app/(tabs)/holdings.tsx`
+
+Acceptance:
+- Holdings are not hardcoded.
+- Values update after trades and quote refresh.
+- No LTCG UI appears in V1.
+
+## [V1] Build Dashboard MVP
+
+Render total value, allocation, quote freshness, value masking, and conviction nudge.
+
+Files:
+- `src/features/dashboard/useDashboard.ts`
+- `src/components/cards/PortfolioValueCard.tsx`
+- `src/components/cards/AllocationCard.tsx`
+- `src/components/cards/ConvictionNudgeCard.tsx`
+- `app/(tabs)/dashboard.tsx`
+
+Acceptance:
+- Dashboard total equals holdings plus cash.
+- Allocation derives from holdings/cash.
+- No Minimal Mode or LTCG appears in V1.
+
+## [V1] Build Cash screen
+
+Implement local cash additions and withdrawals.
+
+Files:
+- `app/(tabs)/cash.tsx`
+- `src/features/cash/useCash.ts`
+- `src/components/cards/CashEntryRow.tsx`
+
+Acceptance:
+- Cash total equals additions minus withdrawals.
+- Cash updates dashboard total.
+
+## [V1] Build Settings and value masking
+
+Implement simple settings and global masking preference.
+
+Files:
+- `app/settings.tsx`
+- `src/features/settings/usePreferences.ts`
+- Update all V1 value renderers.
+
+Acceptance:
+- Masking affects all INR wealth values.
+- Quantities, percentages, and market prices are not masked.
+- No Minimal Mode toggle in V1.
+
+## [V1] Configure Android app identity and icons
+
+Configure Android metadata for preview and release builds.
+
+Files:
+- `app.json` or `app.config.ts`
+- asset placeholders if needed
+
+Acceptance:
+- App name is CogVest.
+- Android package is documented as `com.abdulshaikh.cogvest`.
+
+## [V1] Configure EAS build profiles
+
+Add EAS profiles for development, preview APK, and production AAB.
+
+Files:
+- `eas.json`
+- `docs/release/android-release-process.md`
+
+Acceptance:
+- Preview profile outputs APK.
+- Production profile outputs AAB.
+
+## [V1] Add Android preview workflow draft
+
+Draft GitHub workflow for preview APK builds.
+
+Files:
+- `docs/release/github-actions-drafts.md`
+
+Acceptance:
+- Workflow includes install, typecheck, tests, Expo doctor, and EAS preview build.
+
+## [V1] Add Android production workflow draft
+
+Draft production AAB workflow without auto-submit.
+
+Files:
+- `docs/release/github-actions-drafts.md`
+
+Acceptance:
+- Workflow triggers on release tag/manual dispatch.
+- Requires `EXPO_TOKEN`.
+
+## [V1] Verify preview APK on device
+
+Run the V1 dev-complete release gate.
+
+Files:
+- `docs/release/v1-release-checklist.md`
+
+Acceptance:
+- Preview APK builds.
+- Preview APK installs on real Android device.
+- EAS URL and manual test notes are recorded.

--- a/docs/roadmap/v1-mvp-spec.md
+++ b/docs/roadmap/v1-mvp-spec.md
@@ -1,0 +1,144 @@
+# CogVest V1 MVP Spec
+
+## Goal
+
+Ship a usable Android portfolio tracker that replaces a spreadsheet for local day-to-day tracking.
+
+## Target User Value
+
+The user can record trades quickly, see current holdings and portfolio value in INR, track cash, mask sensitive values, and begin collecting conviction context without needing login, backend, or cloud sync.
+
+## Included Features
+
+- App scaffold with Expo Router tabs.
+- Theme, typography, spacing, and reusable common components.
+- Domain types for assets, trades, cash, quotes, holdings, preferences.
+- Pure domain calculations for holdings, allocation, portfolio total, day change, formatters, and basic conviction readiness.
+- Zustand store with MMKV persistence for raw local data.
+- Quote services for Yahoo Finance and CoinGecko current prices.
+- Quote refresh on app open and pull-to-refresh.
+- Manual current-price fallback if quote fetching fails.
+- Add Trade screen with optional conviction.
+- Holdings screen derived from trades and current quotes.
+- Dashboard with total value, allocation, quote freshness, and basic conviction nudge.
+- Cash screen for additions and withdrawals.
+- Simple settings with value masking.
+- Empty states with direct CTAs.
+- Android preview APK build documentation and V1 release checklist.
+
+## Explicitly Excluded Features
+
+- Minimal Mode.
+- LTCG UI or tax badges.
+- Historical charts.
+- Advanced asset search.
+- Patience analysis.
+- Trade frequency analysis.
+- Full behaviour engine.
+- Import/export.
+- Backend, auth, cloud sync, analytics, push notifications.
+- Automatic Google Play submission.
+
+## Screens Included
+
+- Dashboard.
+- Holdings.
+- Add Trade.
+- Cash.
+- Settings.
+
+History can be a simple trade list if it fits V1 timing; otherwise trade rows appear within Holdings/Add Trade validation support and History moves to V2.
+
+## Data Model Changes
+
+Persist raw data only:
+- assets
+- trades
+- cashEntries
+- preferences
+- last successful quote cache
+
+Do not persist holdings, allocation, dashboard totals, or insights.
+
+## Domain Calculations Required
+
+- `calculateHolding`
+- `calculateAllocation`
+- `portfolioTotal`
+- `portfolioDayChange`
+- `formatINR`
+- `daysHeld`
+- `validateTradeInput`
+- `getConvictionReadiness`
+
+## Acceptance Criteria
+
+- A buy trade creates or updates a holding.
+- A sell trade cannot exceed available units.
+- Current prices refresh from live quote services when possible.
+- Manual price fallback keeps the app usable when quote APIs fail.
+- Dashboard total equals holdings current value plus cash balance.
+- Cash additions and withdrawals update dashboard total.
+- Value masking hides INR wealth values but not quantities or percentages.
+- Conviction is optional and stored only when selected.
+- Basic conviction state shows rated-trade count or not-enough-data guidance.
+- Data persists after app restart.
+- No backend/auth/cloud is added.
+
+## Test Plan
+
+- Unit tests for domain calculations, formatters, validators, selectors, and store actions.
+- Component tests for empty states, value masking, conviction selector, and Add Trade validation.
+- Manual Android checks for navigation, trade entry, holdings, dashboard, cash, masking, and persistence.
+
+## Manual QA Checklist
+
+- Add a buy trade for BTC.
+- Add a buy trade for RELIANCE.
+- Add a sell within available quantity.
+- Attempt a sell above available quantity and confirm validation blocks it.
+- Add cash and withdraw cash.
+- Pull-to-refresh quotes.
+- Toggle value masking.
+- Restart app and confirm persisted raw data reloads.
+- Confirm no login, cloud, or backend appears.
+
+## Definition of Done
+
+- All V1 issues complete or intentionally deferred with notes.
+- `npm run typecheck` passes.
+- `npm test` passes.
+- `npx expo doctor` passes.
+- App launches with `npx expo start`.
+- Preview APK builds and installs on a real Android device.
+
+## Release Gate
+
+Dev-complete gate:
+- typecheck, tests, Expo doctor, app launch, manual V1 flows, preview APK build, preview APK device install.
+
+Release-candidate gate:
+- production AAB builds, EAS build URL recorded, Play Console internal testing upload ready/manual.
+
+## Release/Build Requirements
+
+- Android package name planned as `com.abdulshaikh.cogvest`.
+- EAS profiles documented for development, preview, and production.
+- Preview outputs APK.
+- Production outputs AAB.
+- `EXPO_TOKEN` documented but not committed.
+
+## Local Data/Versioning Impact
+
+V1 establishes the first persisted schema. Optional fields should remain backward-compatible.
+
+## Privacy/Security Notes
+
+Portfolio values, quantities, trades, notes, and conviction stay local. Quote APIs receive only ticker or coin identifiers.
+
+## Known Risks/Deferred Decisions
+
+- Yahoo/CoinGecko informal API reliability.
+- Real-time quote source limits.
+- History screen may be scoped down if V1 timeline tightens.
+- Export/import deferred creates local-device data loss risk.

--- a/docs/roadmap/v2-behaviour-spec.md
+++ b/docs/roadmap/v2-behaviour-spec.md
@@ -1,0 +1,105 @@
+# CogVest V2 Behaviour Spec
+
+## Goal
+
+Layer behaviour-aware investing feedback and Minimal Mode onto the stable V1 tracker.
+
+## Target User Value
+
+The user sees patterns in conviction, patience, trading frequency, and tax-relevant holding duration while using a calmer Minimal Mode when desired.
+
+## Included Features
+
+- Minimal Mode across Dashboard, Holdings, Add Trade, Cash, Settings, and History/Asset Detail if present.
+- Improved conviction analytics.
+- Patience analysis using intended hold periods.
+- Trade frequency analysis.
+- Behaviour insight cards and insight detail screen.
+- Basic LTCG tracker for Indian stocks/ETFs.
+- Settings for display mode and Minimal Mode preferences.
+- Onboarding nudges for behaviour metadata.
+
+## Explicitly Excluded Features
+
+- Historical charts.
+- Advanced asset search.
+- Advanced FIFO multi-lot LTCG.
+- Import/export.
+- Automatic Play Store submission.
+
+## Screens Included
+
+- Dashboard with behaviour insight card.
+- Insight detail.
+- Settings with Minimal Mode preferences.
+- Holdings with basic LTCG states.
+- Add Trade with intended hold period.
+- History or Asset Detail if V1 deferred them.
+
+## Data Model Changes
+
+- Persist optional intended hold values on trades.
+- Persist display mode and Minimal Mode preferences.
+- Persist insight dismissal metadata if implemented.
+- Keep all insight outputs derived.
+
+## Domain Calculations Required
+
+- `analyseConviction`
+- `analysePatienceFromSells`
+- `analyseTradeFrequency`
+- `generateInsights`
+- `calculateBasicLtcgStatus`
+
+## Acceptance Criteria
+
+- Minimal Mode hides daily noise without removing core actions.
+- Behaviour fields remain optional.
+- Insights never sound scolding.
+- Basic LTCG appears only for Indian stocks/ETFs.
+- V1 persisted data remains compatible.
+
+## Test Plan
+
+- Unit tests for conviction, patience, frequency, insight generation, and basic LTCG.
+- Component tests for Minimal Mode rendering and insight cards.
+- Manual tests for mode switching and data compatibility.
+
+## Manual QA Checklist
+
+- Switch Standard/Minimal Mode.
+- Confirm Add Trade still works in Minimal Mode.
+- Add intended hold period and later sell to test patience analysis.
+- Add enough rated trades for conviction insight.
+- Verify LTCG hidden for crypto and visible for Indian stock/ETF.
+
+## Definition of Done
+
+- V1 release gate still passes.
+- V2 behaviour and Minimal Mode test coverage passes.
+- Existing V1 local data opens without destructive reset.
+
+## Release Gate
+
+- V1 gate still passes.
+- Minimal Mode works across supported screens.
+- Behaviour insights render and can be dismissed or navigated.
+- Patience/frequency/basic LTCG have tests.
+
+## Release/Build Requirements
+
+- Preview APK generated for V2 validation.
+- Production AAB optional unless V2 is a store release.
+
+## Local Data/Versioning Impact
+
+Adds optional persisted preferences and optional trade metadata. Migration should default missing fields safely.
+
+## Privacy/Security Notes
+
+Behaviour metadata never leaves the device. Quote APIs still receive only identifiers.
+
+## Known Risks/Deferred Decisions
+
+- Insight thresholds may need tuning after V1 data exists.
+- Basic LTCG may need clearer disclaimers before production release.

--- a/docs/roadmap/v2-codex-prompts.md
+++ b/docs/roadmap/v2-codex-prompts.md
@@ -1,0 +1,31 @@
+# CogVest V2 Codex Prompts
+
+V2 prompts are intentionally high-level placeholders until V1 is validated.
+
+## [V2] Implement Minimal Mode settings
+
+Add display mode and Minimal Mode preferences. Ensure core actions remain available.
+
+## [V2] Apply Minimal Mode across screens
+
+Reduce day-change noise, colour emphasis, and information density across supported screens.
+
+## [V2] Add intended hold capture
+
+Extend Add Trade with optional intended hold period and persistence.
+
+## [V2] Implement behaviour analytics
+
+Add conviction analytics, patience analysis, and trade frequency analysis as pure functions with tests.
+
+## [V2] Build insight cards and detail screen
+
+Surface observational, non-scolding insights and allow users to view details.
+
+## [V2] Add basic LTCG tracker
+
+Show basic Indian stock/ETF LTCG status. Keep advanced FIFO for V3.
+
+## [V2] Add onboarding nudges
+
+Encourage conviction and intended hold input without making either required.

--- a/docs/roadmap/v3-codex-prompts.md
+++ b/docs/roadmap/v3-codex-prompts.md
@@ -1,0 +1,31 @@
+# CogVest V3 Codex Prompts
+
+V3 prompts are placeholders until V1/V2 scope is validated.
+
+## [V3] Add historical charts
+
+Implement asset historical charts with graceful API failure states.
+
+## [V3] Build advanced asset search
+
+Improve Yahoo/CoinGecko discovery, logo support, exchange metadata, and recent assets.
+
+## [V3] Implement import/export
+
+Add local backup/export and import validation.
+
+## [V3] Implement advanced FIFO LTCG
+
+Add lot-level FIFO matching and detailed LTCG states.
+
+## [V3] Harden quote caching
+
+Improve stale quote display, cache TTL, and offline behaviour.
+
+## [V3] Polish Android UX
+
+Add animation, performance passes, accessibility checks, and final store-readiness polish.
+
+## [V3] Evaluate Play Store automation
+
+Optionally configure EAS Submit after manual release process is stable.

--- a/docs/roadmap/v3-polish-and-advanced-spec.md
+++ b/docs/roadmap/v3-polish-and-advanced-spec.md
@@ -1,0 +1,102 @@
+# CogVest V3 Advanced and Polish Spec
+
+## Goal
+
+Add advanced market, tax, backup, and polish features after V1/V2 validate the product direction.
+
+## Target User Value
+
+The user can inspect historical performance, discover assets more easily, export local data, and rely on stronger tax/quote/release hardening.
+
+## Included Features
+
+- Historical asset charts.
+- Advanced asset search.
+- Import/export and local backup flows.
+- Advanced FIFO multi-lot LTCG.
+- Quote caching improvements and stale-state UI.
+- Advanced dashboard widgets.
+- UI polish, animations, and performance hardening.
+- Optional Play Store submission automation.
+
+## Explicitly Excluded Features
+
+- Backend account system unless a later roadmap explicitly approves it.
+- Cloud sync unless a later roadmap explicitly approves it.
+- Brokerage integrations.
+- Social features.
+
+## Screens Included
+
+- Asset Detail with historical charts.
+- Advanced Asset Search.
+- Import/Export.
+- Advanced LTCG lot detail.
+- Advanced dashboard widgets.
+
+## Data Model Changes
+
+- Export/import file schema.
+- Quote cache metadata.
+- Optional local data schema versioning.
+- Lot-level derived views remain derived from raw trades.
+
+## Domain Calculations Required
+
+- Historical chart transforms.
+- FIFO lot matching.
+- Import validation.
+- Export serialization.
+- Quote cache freshness checks.
+
+## Acceptance Criteria
+
+- Import/export round trips V1/V2 raw data.
+- FIFO LTCG handles partial sells and multiple lots.
+- Historical charts gracefully fallback on API failure.
+- UI remains performant on Android.
+
+## Test Plan
+
+- Unit tests for FIFO, import/export, quote cache, chart transforms.
+- Component tests for fallback states.
+- Limited Maestro release-flow coverage.
+
+## Manual QA Checklist
+
+- Export data, reinstall, import data.
+- Check chart fallback offline.
+- Validate multi-lot LTCG examples.
+- Review Android performance on a real device.
+
+## Definition of Done
+
+- V1 and V2 gates still pass.
+- Advanced features have tests and manual release notes.
+- Data migration risks are documented.
+
+## Release Gate
+
+- V1/V2 gates still pass.
+- Import/export works with sample files.
+- FIFO tests cover boundaries.
+- Performance is acceptable on Android.
+
+## Release/Build Requirements
+
+- Production AAB for store release.
+- Optional EAS Submit documented or configured.
+
+## Local Data/Versioning Impact
+
+V3 may require explicit schema versioning and migration. Destructive resets are not allowed.
+
+## Privacy/Security Notes
+
+Export files contain sensitive financial data and must be clearly marked as user-controlled local files.
+
+## Known Risks/Deferred Decisions
+
+- Import format scope.
+- Chart API limits and caching.
+- Whether Play Store submission automation is worth maintaining.

--- a/docs/superpowers/plans/2026-04-25-versioned-roadmap-plan.md
+++ b/docs/superpowers/plans/2026-04-25-versioned-roadmap-plan.md
@@ -93,7 +93,9 @@
 **Files:**
 - All generated docs.
 
-- [ ] Run markdown consistency scans.
-- [ ] Commit branch.
-- [ ] Push `roadmap/versioned-planning`.
-- [ ] Open PR or provide manual PR body if unavailable.
+- [x] Run markdown consistency scans.
+- [x] Commit branch.
+- [x] Push `roadmap/versioned-planning`.
+- [x] Open PR or provide manual PR body if unavailable.
+
+PR: https://github.com/abdul-shaikh-dev/CogVest/pull/27

--- a/docs/superpowers/plans/2026-04-25-versioned-roadmap-plan.md
+++ b/docs/superpowers/plans/2026-04-25-versioned-roadmap-plan.md
@@ -1,0 +1,99 @@
+# CogVest Versioned Roadmap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the all-in CogVest spec into versioned roadmap, prompt, design, testing, release, and GitHub execution artifacts.
+
+**Architecture:** Documentation is the source of truth. Version specs drive prompt files, prompt files map to issue drafts, and issue drafts map to GitHub issues. External state is created only after markdown drafts are coherent.
+
+**Tech Stack:** Markdown docs, GitHub labels/milestones/issues, Figma design file, Expo/EAS release planning.
+
+---
+
+### Task 1: Branch and Scope Confirmation
+
+**Files:**
+- Read: `docs/prompts/versioned-roadmap-planning-prompt.md`
+- Read: `docs/cogvest-master-spec.md`
+- Read: `docs/cogvest-codex-prompts.md`
+
+- [x] Create branch `roadmap/versioned-planning` from current `main`.
+- [x] Confirm V1/V2/V3 scope decisions with the user.
+- [x] Record V1 release gate split.
+
+### Task 2: Figma Design Output
+
+**Files:**
+- Create/update: `docs/design/v1-ui-mockup-plan.md`
+- Create/update: `docs/design/v2-ui-mockup-plan.md`
+- Create/update: `docs/design/v3-ui-mockup-plan.md`
+
+- [x] Create a real Figma file.
+- [x] Add design system page.
+- [x] Add V1 page.
+- [x] Add V2/V3 page within Starter plan page limit.
+- [x] Link Figma file in roadmap/design docs.
+
+### Task 3: Versioned Roadmap Specs
+
+**Files:**
+- Create: `docs/roadmap/cogvest-version-roadmap.md`
+- Create: `docs/roadmap/v1-mvp-spec.md`
+- Create: `docs/roadmap/v2-behaviour-spec.md`
+- Create: `docs/roadmap/v3-polish-and-advanced-spec.md`
+
+- [x] Define V1, V2, V3 goals.
+- [x] List included and excluded features.
+- [x] Define release gates and local data impact.
+- [x] Document risks and deferred decisions.
+
+### Task 4: Versioned Prompt Files
+
+**Files:**
+- Create: `docs/roadmap/v1-codex-prompts.md`
+- Create: `docs/roadmap/v2-codex-prompts.md`
+- Create: `docs/roadmap/v3-codex-prompts.md`
+
+- [x] Break V1 into small implementation issues.
+- [x] Keep V2/V3 prompts flexible.
+- [x] Ensure prompts exclude out-of-version scope.
+
+### Task 5: Testing and Release Docs
+
+**Files:**
+- Create: `docs/testing/v1-testing-plan.md`
+- Create: `docs/testing/v2-testing-plan.md`
+- Create: `docs/testing/v3-testing-plan.md`
+- Create: `docs/release/android-release-process.md`
+- Create: `docs/release/v1-release-checklist.md`
+- Create: `docs/release/github-actions-drafts.md`
+- Create: `docs/release/play-store-listing-draft.md`
+- Create: `docs/release/privacy-policy-notes.md`
+
+- [x] Define automated and manual testing boundaries.
+- [x] Keep emulator/device testing out of default PR checks.
+- [x] Define EAS preview APK and production AAB flow.
+- [x] Document secrets and signing strategy.
+
+### Task 6: Issue Drafts and GitHub State
+
+**Files:**
+- Create: `docs/issues/v1-issue-drafts.md`
+- Create: `docs/issues/v2-placeholder-issues.md`
+- Create: `docs/issues/v3-placeholder-issues.md`
+
+- [x] Draft detailed V1 issues.
+- [x] Draft V2/V3 placeholder issues.
+- [x] Create labels.
+- [x] Create milestones.
+- [x] Create GitHub issues.
+
+### Task 7: Commit, Push, and PR
+
+**Files:**
+- All generated docs.
+
+- [ ] Run markdown consistency scans.
+- [ ] Commit branch.
+- [ ] Push `roadmap/versioned-planning`.
+- [ ] Open PR or provide manual PR body if unavailable.

--- a/docs/superpowers/specs/2026-04-25-versioned-roadmap-design.md
+++ b/docs/superpowers/specs/2026-04-25-versioned-roadmap-design.md
@@ -1,0 +1,40 @@
+# CogVest Versioned Roadmap Design
+
+## Approved Decisions
+
+- V1 includes live quote fetching, manual fallback prices, and lightweight conviction capture.
+- V1 excludes LTCG UI, Minimal Mode, historical charts, patience, frequency, and full behaviour insights.
+- V2 adds Minimal Mode, basic LTCG, improved behaviour insights, patience, and frequency.
+- V3 adds historical charts, advanced asset search, import/export, advanced FIFO LTCG, quote-cache hardening, and release polish.
+- Figma generation should be attempted first; fallback design docs are still created for implementation reference.
+- GitHub labels, milestones, and V1 issues should be created for real after docs are coherent.
+- Work starts from current `main` on branch `roadmap/versioned-planning`.
+- V1 release gates are split into dev-complete and release-candidate gates.
+
+## Approach
+
+The roadmap decomposes the existing all-in product plan into three shippable versions. V1 is intentionally narrow enough for a 2-3 week Android MVP while preserving CogVest's identity through live quotes, conviction input, value masking, and local-first portfolio tracking. V2 introduces the behaviour layer and Minimal Mode once core data flows are stable. V3 keeps advanced financial/product polish flexible until V1 and V2 usage validates the direction.
+
+## External Outputs
+
+Figma file: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d
+
+Figma Starter plan limits the file to three pages, so the real mockup file uses:
+- CogVest Design System
+- CogVest V1 MVP
+- CogVest V2 and V3
+
+## GitHub Structure
+
+Labels:
+- version: `v1`, `v2`, `v3`
+- area: `frontend`, `domain`, `store`, `infra`, `testing`, `design`, `docs`, `release`
+- type: `feature`, `bug`, `chore`, `refactor`
+- priority: `priority-high`, `priority-medium`, `priority-low`
+
+Milestones:
+- CogVest V1 MVP
+- CogVest V2 Behaviour
+- CogVest V3 Advanced
+
+V1 gets detailed execution issues. V2 and V3 get placeholder issues only.

--- a/docs/testing/v1-testing-plan.md
+++ b/docs/testing/v1-testing-plan.md
@@ -1,0 +1,67 @@
+# V1 Testing Plan
+
+## Automated Tests
+
+Run on every V1 issue:
+
+```bash
+npm run typecheck
+npm test
+```
+
+Run before release gate:
+
+```bash
+npx expo doctor
+npx expo start
+```
+
+## Unit Tests
+
+Cover:
+- `calculateHolding`
+- `calculateAllocation`
+- `portfolioTotal`
+- `portfolioDayChange`
+- `formatINR`
+- trade validation
+- conviction readiness
+- selectors
+- Zustand store actions
+- value masking logic
+
+## Component Tests
+
+Cover:
+- Empty Dashboard.
+- Empty Holdings.
+- Add Trade validation messages.
+- Conviction selector select/deselect.
+- MaskedValue display.
+- Cash add/withdraw rows.
+
+## Manual Android QA
+
+- Add buy trade.
+- Add sell trade.
+- Validate oversell error.
+- Confirm holdings update.
+- Confirm dashboard total updates.
+- Add and withdraw cash.
+- Toggle value masking.
+- Restart app and confirm MMKV persistence.
+- Pull-to-refresh quotes.
+- Confirm no backend/auth/cloud.
+
+## E2E Scope
+
+Maestro is optional for V1 development but recommended before release:
+- add trade
+- holdings update
+- dashboard total
+- cash flow
+- value masking
+
+## Known Test Boundaries
+
+Default CI should not require Android emulator. Device/emulator testing is manual or release-gate only.

--- a/docs/testing/v2-testing-plan.md
+++ b/docs/testing/v2-testing-plan.md
@@ -1,0 +1,26 @@
+# V2 Testing Plan
+
+## Automated Tests
+
+- V1 tests continue to pass.
+- Unit tests for conviction analytics, patience, trade frequency, basic LTCG, and insight generation.
+- Component tests for Minimal Mode and insight cards.
+
+## Manual QA
+
+- Toggle Minimal Mode from Settings.
+- Confirm day-change noise is hidden.
+- Confirm Add Trade and Cash remain available.
+- Add intended hold, sell later, verify patience insight.
+- Generate enough rated trades for conviction insight.
+- Verify LTCG appears for Indian stock/ETF and never for crypto.
+
+## Data Compatibility
+
+Open existing V1 persisted data without destructive reset. Missing V2 fields must default safely.
+
+## Release Gate
+
+- V1 gate still passes.
+- Minimal Mode works on supported screens.
+- Behaviour insight tone remains non-scolding.

--- a/docs/testing/v3-testing-plan.md
+++ b/docs/testing/v3-testing-plan.md
@@ -1,0 +1,25 @@
+# V3 Testing Plan
+
+## Automated Tests
+
+- V1 and V2 tests continue to pass.
+- Unit tests for FIFO lot matching, import/export round trip, quote cache freshness, and chart transforms.
+- Component tests for chart loading/error/stale states.
+
+## Manual QA
+
+- Export local data and import into clean app state.
+- Validate historical chart fallback on API failure.
+- Review advanced asset search results.
+- Verify multi-lot LTCG examples.
+- Run Android performance pass on real device.
+
+## E2E Scope
+
+Add limited Maestro flows for import/export and advanced asset search if stable enough.
+
+## Release Gate
+
+- V1/V2 gates still pass.
+- Data migration risk is documented.
+- Import/export works with sample files.


### PR DESCRIPTION
## Summary
- Split CogVest into V1 MVP, V2 Behaviour, and V3 Advanced roadmap docs.
- Added version-specific specs, Codex prompt files, testing plans, design plans, release docs, and issue drafts.
- Added Superpowers design/plan docs for the roadmap execution.

## Version Split
- V1: live quotes, Add Trade, holdings, dashboard, cash, value masking, lightweight conviction, Android preview/release planning.
- V2: Minimal Mode, improved behaviour insights, patience/frequency, insight detail, basic LTCG.
- V3: historical charts, advanced search, import/export, advanced FIFO LTCG, quote cache hardening, polish.

## GitHub Structure
- Created labels: v1/v2/v3, area labels, type labels, priority labels.
- Created milestones: CogVest V1 MVP, CogVest V2 Behaviour, CogVest V3 Advanced.
- Created V1 issues #1-#16, V2 placeholder issues #17-#21, V3 placeholder issues #22-#26.

## Figma
- Created real Figma file: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d
- Starter plan page limit required a 3-page structure: design system, V1 MVP, combined V2/V3.
- Fallback design docs are included under docs/design/.

## Testing and Release
- Added per-version testing plans.
- Added Android release process, GitHub Actions workflow drafts, Play Store listing draft, privacy notes, and V1 release checklist.
- V1 gate split: dev-complete requires preview APK build/install; release-candidate requires production AAB.

## Unresolved Decisions
- V1 History screen remains optional/timeline-dependent.
- Play Store auto-submit remains explicitly out of V1.