### PR TITLE
feat: add UI primitives

### DIFF
--- a/src/components/common/AppButton.tsx
+++ b/src/components/common/AppButton.tsx
@@ -1,0 +1,97 @@
+import type { ComponentProps } from "react";
+import {
+  Pressable,
+  StyleSheet,
+  type PressableProps,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native";
+
+import { colors, interaction, radii, spacing } from "@/src/theme";
+
+import { AppText } from "./AppText";
+
+type ButtonVariant = "primary" | "secondary" | "ghost";
+
+type AppButtonProps = Omit<PressableProps, "children" | "style"> & {
+  style?: StyleProp<ViewStyle>;
+  textColor?: ComponentProps<typeof AppText>["color"];
+  title: string;
+  variant?: ButtonVariant;
+};
+
+export function getButtonInteractionStyle({
+  disabled,
+  pressed,
+}: {
+  disabled?: boolean;
+  pressed: boolean;
+}) {
+  if (disabled) {
+    return styles.disabled;
+  }
+
+  if (pressed) {
+    return styles.pressed;
+  }
+
+  return undefined;
+}
+
+export function AppButton({
+  disabled,
+  style,
+  textColor,
+  title,
+  variant = "primary",
+  ...props
+}: AppButtonProps) {
+  const isDisabled = Boolean(disabled);
+  const resolvedTextColor =
+    textColor ?? (variant === "primary" ? "inverse" : "primary");
+
+  return (
+    <Pressable
+      {...props}
+      disabled={disabled}
+      style={({ pressed }) => [
+        styles.base,
+        styles[variant],
+        getButtonInteractionStyle({ disabled: isDisabled, pressed }),
+        style,
+      ]}
+    >
+      <AppText color={resolvedTextColor} variant="body" weight="bold">
+        {title}
+      </AppText>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  base: {
+    alignItems: "center",
+    borderRadius: radii.button,
+    justifyContent: "center",
+    minHeight: 48,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.cardInner,
+  },
+  disabled: {
+    opacity: interaction.disabledOpacity,
+  },
+  ghost: {
+    backgroundColor: "transparent",
+  },
+  primary: {
+    backgroundColor: colors.primary,
+  },
+  pressed: {
+    opacity: interaction.pressedOpacity,
+  },
+  secondary: {
+    backgroundColor: colors.surface.elevated,
+    borderColor: colors.border.subtle,
+    borderWidth: 1,
+  },
+});

--- a/src/components/common/AppText.tsx
+++ b/src/components/common/AppText.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+import type { TextProps, TextStyle } from "react-native";
+import { StyleSheet, Text } from "react-native";
+
+import { colors, typography } from "@/src/theme";
+
+type TextVariant = "caption" | "body" | "title" | "hero";
+type TextColor = keyof typeof colors.text | "primary";
+
+export type AppTextProps = TextProps & {
+  align?: TextStyle["textAlign"];
+  children: ReactNode;
+  color?: TextColor;
+  variant?: TextVariant;
+  weight?: keyof typeof typography.weights;
+};
+
+export function AppText({
+  align,
+  children,
+  color = "primary",
+  style,
+  variant = "body",
+  weight = "regular",
+  ...props
+}: AppTextProps) {
+  return (
+    <Text
+      {...props}
+      style={[
+        styles.base,
+        styles[variant],
+        {
+          color: colors.text[color],
+          fontWeight: typography.weights[weight],
+          textAlign: align,
+        },
+        style,
+      ]}
+    >
+      {children}
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  base: {
+    letterSpacing: 0.1,
+  },
+  body: {
+    fontSize: typography.sizes.body,
+    lineHeight: 24,
+  },
+  caption: {
+    fontSize: typography.sizes.caption,
+    lineHeight: 16,
+  },
+  hero: {
+    fontSize: typography.sizes.hero,
+    lineHeight: 40,
+  },
+  title: {
+    fontSize: typography.sizes.title,
+    lineHeight: 28,
+  },
+});

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -1,0 +1,47 @@
+import { StyleSheet, View } from "react-native";
+
+import { colors, radii, shadows, spacing } from "@/src/theme";
+
+import { AppButton } from "./AppButton";
+import { AppText } from "./AppText";
+
+type EmptyStateProps = {
+  actionLabel?: string;
+  message: string;
+  onAction?: () => void;
+  title: string;
+};
+
+export function EmptyState({
+  actionLabel,
+  message,
+  onAction,
+  title,
+}: EmptyStateProps) {
+  return (
+    <View style={styles.card}>
+      <AppText align="center" variant="title" weight="bold">
+        {title}
+      </AppText>
+      <AppText align="center" color="secondary">
+        {message}
+      </AppText>
+      {actionLabel && onAction ? (
+        <AppButton title={actionLabel} onPress={onAction} />
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    ...shadows.none,
+    alignItems: "center",
+    backgroundColor: colors.surface.card,
+    borderColor: colors.border.subtle,
+    borderRadius: radii.card,
+    borderWidth: 1,
+    gap: spacing.cardInner,
+    padding: spacing.md,
+  },
+});

--- a/src/components/common/MaskedValue.tsx
+++ b/src/components/common/MaskedValue.tsx
@@ -1,0 +1,28 @@
+import type { ComponentProps } from "react";
+
+import { AppText } from "./AppText";
+
+export const MASKED_INR_VALUE = "₹**** **,***.**";
+
+type MaskedValueType = "wealth" | "price" | "quantity" | "percentage";
+
+type MaskedValueProps = Omit<ComponentProps<typeof AppText>, "children"> & {
+  masked?: boolean;
+  value: string;
+  valueType?: MaskedValueType;
+};
+
+export function MaskedValue({
+  masked = false,
+  value,
+  valueType = "wealth",
+  ...textProps
+}: MaskedValueProps) {
+  const shouldMask = masked && valueType === "wealth";
+
+  return (
+    <AppText {...textProps}>
+      {shouldMask ? MASKED_INR_VALUE : value}
+    </AppText>
+  );
+}

--- a/src/components/common/PlaceholderScreen.tsx
+++ b/src/components/common/PlaceholderScreen.tsx
@@ -1,24 +1,28 @@
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, View } from "react-native";
+
+import { colors, spacing } from "@/src/theme";
+
+import { AppText } from "./AppText";
+import { ScreenContainer } from "./ScreenContainer";
 
 export function PlaceholderScreen({ title }: { title: string }) {
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>{title}</Text>
-    </View>
+    <ScreenContainer>
+      <View style={styles.container}>
+        <AppText variant="hero" weight="bold">
+          {title}
+        </AppText>
+      </View>
+    </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     alignItems: "center",
-    backgroundColor: "#1C1B1F",
+    backgroundColor: colors.background,
     flex: 1,
     justifyContent: "center",
-    padding: 16,
-  },
-  title: {
-    color: "#E6E1E5",
-    fontSize: 28,
-    fontWeight: "700",
+    padding: spacing.md,
   },
 });

--- a/src/components/common/ScreenContainer.tsx
+++ b/src/components/common/ScreenContainer.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+import { SafeAreaView, ScrollView, StyleSheet, View } from "react-native";
+
+import { colors, spacing } from "@/src/theme";
+
+type ScreenContainerProps = {
+  children: ReactNode;
+  scroll?: boolean;
+  testID?: string;
+};
+
+export function ScreenContainer({
+  children,
+  scroll = false,
+  testID,
+}: ScreenContainerProps) {
+  if (scroll) {
+    return (
+      <SafeAreaView style={styles.safe} testID={testID}>
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          style={styles.scroll}
+        >
+          {children}
+        </ScrollView>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} testID={testID}>
+      <View style={styles.content}>{children}</View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    flex: 1,
+    paddingHorizontal: spacing.screenHorizontal,
+  },
+  safe: {
+    backgroundColor: colors.background,
+    flex: 1,
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    paddingHorizontal: spacing.screenHorizontal,
+  },
+});

--- a/src/components/common/__tests__/commonComponents.test.tsx
+++ b/src/components/common/__tests__/commonComponents.test.tsx
@@ -1,0 +1,75 @@
+import { render } from "@testing-library/react-native";
+
+import {
+  AppButton,
+  AppText,
+  EmptyState,
+  MaskedValue,
+} from "@/src/components/common";
+import { getButtonInteractionStyle } from "@/src/components/common/AppButton";
+import { colors, interaction } from "@/src/theme";
+
+describe("common UI primitives", () => {
+  it("renders AppText with CogVest text colors", () => {
+    const { getByText } = render(
+      <AppText color="secondary">Local-first portfolio tracker</AppText>,
+    );
+
+    expect(getByText("Local-first portfolio tracker")).toHaveStyle({
+      color: colors.text.secondary,
+    });
+  });
+
+  it("uses the standard press opacity during interaction", () => {
+    expect(
+      getButtonInteractionStyle({ disabled: false, pressed: true }),
+    ).toEqual({ opacity: interaction.pressedOpacity });
+    expect(
+      getButtonInteractionStyle({ disabled: false, pressed: false }),
+    ).toBeUndefined();
+  });
+
+  it("uses disabled opacity instead of pressed feedback", () => {
+    const { getByTestId } = render(
+      <AppButton
+        disabled
+        testID="disabled-button"
+        title="Add Trade"
+        onPress={jest.fn()}
+      />,
+    );
+    expect(getByTestId("disabled-button")).toHaveStyle({
+      opacity: interaction.disabledOpacity,
+    });
+    expect(
+      getButtonInteractionStyle({ disabled: true, pressed: true }),
+    ).toEqual({ opacity: interaction.disabledOpacity });
+  });
+
+  it("masks INR wealth values without masking percentages", () => {
+    const { getByText } = render(
+      <>
+        <MaskedValue masked value="₹1,23,456.78" valueType="wealth" />
+        <MaskedValue masked value="12.4%" valueType="percentage" />
+      </>,
+    );
+
+    expect(getByText("₹**** **,***.**")).toBeTruthy();
+    expect(getByText("12.4%")).toBeTruthy();
+  });
+
+  it("renders an empty state action when provided", () => {
+    const { getByText } = render(
+      <EmptyState
+        title="No holdings yet"
+        message="Holdings are created from confirmed trades."
+        actionLabel="Add Trade"
+        onAction={jest.fn()}
+      />,
+    );
+
+    expect(getByText("No holdings yet")).toBeTruthy();
+    expect(getByText("Holdings are created from confirmed trades.")).toBeTruthy();
+    expect(getByText("Add Trade")).toBeTruthy();
+  });
+});

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,1 +1,7 @@
 export {};
+export { AppButton } from "./AppButton";
+export { AppText } from "./AppText";
+export { EmptyState } from "./EmptyState";
+export { MASKED_INR_VALUE, MaskedValue } from "./MaskedValue";
+export { PlaceholderScreen } from "./PlaceholderScreen";
+export { ScreenContainer } from "./ScreenContainer";

--- a/src/theme/__tests__/theme.test.ts
+++ b/src/theme/__tests__/theme.test.ts
@@ -1,0 +1,21 @@
+import { colors, radii, spacing } from "@/src/theme";
+
+describe("theme tokens", () => {
+  it("matches the V1 CogVest dark palette", () => {
+    expect(colors.background).toBe("#1C1B1F");
+    expect(colors.surface.card).toBe("#2A2930");
+    expect(colors.surface.elevated).toBe("#312F36");
+    expect(colors.primary).toBe("#2E7D52");
+    expect(colors.text.primary).toBe("#E6E1E5");
+    expect(colors.text.secondary).toBe("#CAC4D0");
+    expect(colors.border.subtle).toBe("rgba(255,255,255,0.08)");
+  });
+
+  it("captures the V1 spacing and radius rules", () => {
+    expect(spacing.screenHorizontal).toBe(16);
+    expect(spacing.cardGap).toBe(10);
+    expect(spacing.cardInner).toBe(12);
+    expect(radii.card).toBe(12);
+    expect(radii.button).toBe(16);
+  });
+});

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,1 +1,64 @@
 export {};
+export const colors = {
+  background: "#1C1B1F",
+  primary: "#2E7D52",
+  profit: "#4CAF7A",
+  loss: "#D65A5A",
+  border: {
+    subtle: "rgba(255,255,255,0.08)",
+  },
+  surface: {
+    card: "#2A2930",
+    elevated: "#312F36",
+  },
+  text: {
+    primary: "#E6E1E5",
+    secondary: "#CAC4D0",
+    muted: "#938F99",
+    inverse: "#FFFFFF",
+  },
+} as const;
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  cardGap: 10,
+  cardInner: 12,
+  md: 16,
+  lg: 24,
+  xl: 32,
+  screenHorizontal: 16,
+} as const;
+
+export const radii = {
+  sm: 8,
+  card: 12,
+  button: 16,
+  pill: 999,
+} as const;
+
+export const typography = {
+  sizes: {
+    caption: 12,
+    body: 16,
+    title: 20,
+    hero: 32,
+  },
+  weights: {
+    regular: "400",
+    medium: "600",
+    bold: "700",
+  },
+} as const;
+
+export const interaction = {
+  pressedOpacity: 0.75,
+  disabledOpacity: 0.48,
+} as const;
+
+export const shadows = {
+  none: {
+    elevation: 0,
+    shadowOpacity: 0,
+  },
+} as const;


### PR DESCRIPTION
## Summary
- Add CogVest V1 theme tokens for dark surfaces, text, spacing, radii, typography, and interaction opacity.
- Add common primitives: AppText, AppButton, ScreenContainer, EmptyState, and MaskedValue.
- Update placeholder screens to use shared text/container primitives.
- Add tests for theme contract, masking behavior, and button interaction opacity.

## Validation
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm audit --audit-level=high
- npx expo start --offline --port 8081 startup smoke

## Notes
- Full npm audit still reports the known 13 moderate Expo transitive uuid findings; high-severity audit gate passes.