### PR TITLE
feat: add raw portfolio store

### DIFF
--- a/src/services/storage/__tests__/memoryJsonStorage.test.ts
+++ b/src/services/storage/__tests__/memoryJsonStorage.test.ts
@@ -1,0 +1,20 @@
+import { createMemoryJsonStorage } from "@/src/services/storage";
+
+describe("memory JSON storage", () => {
+  it("stores JSON-compatible values by key", () => {
+    const storage = createMemoryJsonStorage();
+
+    storage.setItem("cogvest:test", { enabled: true });
+
+    expect(storage.getItem("cogvest:test")).toEqual({ enabled: true });
+  });
+
+  it("removes values by key", () => {
+    const storage = createMemoryJsonStorage();
+    storage.setItem("cogvest:test", { enabled: true });
+
+    storage.removeItem("cogvest:test");
+
+    expect(storage.getItem("cogvest:test")).toBeNull();
+  });
+});

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -1,1 +1,67 @@
-export {};
+export type JsonValue =
+  | boolean
+  | null
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export type JsonStorage = {
+  getItem: <T extends JsonValue>(key: string) => T | null;
+  removeItem: (key: string) => void;
+  setItem: <T extends JsonValue>(key: string, value: T) => void;
+};
+
+export function createMemoryJsonStorage(
+  initialValues: Record<string, JsonValue> = {},
+): JsonStorage {
+  const values = new Map<string, JsonValue>(Object.entries(initialValues));
+
+  return {
+    getItem: <T extends JsonValue>(key: string) => {
+      return (values.get(key) as T | undefined) ?? null;
+    },
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    setItem: <T extends JsonValue>(key: string, value: T) => {
+      values.set(key, value);
+    },
+  };
+}
+
+type MmkvLikeStorage = {
+  getString: (key: string) => string | undefined;
+  remove: (key: string) => boolean;
+  set: (key: string, value: string) => void;
+};
+
+function createDefaultMmkvStorage(): MmkvLikeStorage {
+  const { createMMKV } = require(
+    "react-native-mmkv",
+  ) as typeof import("react-native-mmkv");
+
+  return createMMKV();
+}
+
+export function createMmkvJsonStorage(
+  storage: MmkvLikeStorage = createDefaultMmkvStorage(),
+): JsonStorage {
+  return {
+    getItem: <T extends JsonValue>(key: string) => {
+      const rawValue = storage.getString(key);
+
+      if (!rawValue) {
+        return null;
+      }
+
+      return JSON.parse(rawValue) as T;
+    },
+    removeItem: (key: string) => {
+      storage.remove(key);
+    },
+    setItem: <T extends JsonValue>(key: string, value: T) => {
+      storage.set(key, JSON.stringify(value));
+    },
+  };
+}

--- a/src/store/__tests__/portfolioStore.test.ts
+++ b/src/store/__tests__/portfolioStore.test.ts
@@ -1,0 +1,134 @@
+import {
+  createPortfolioStore,
+  createDefaultPreferences,
+  portfolioStorageKey,
+  quoteCacheStorageKey,
+} from "@/src/store";
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import type { Asset, CashEntry, Quote, Trade } from "@/src/types";
+
+const asset: Asset = {
+  assetClass: "stock",
+  currency: "INR",
+  exchange: "NSE",
+  id: "asset-reliance",
+  name: "Reliance Industries",
+  symbol: "RELIANCE",
+  ticker: "RELIANCE.NS",
+};
+
+const trade: Trade = {
+  assetId: asset.id,
+  date: "2026-04-26T00:00:00.000Z",
+  id: "trade-1",
+  pricePerUnit: 2900,
+  quantity: 2,
+  totalValue: 5800,
+  type: "buy",
+};
+
+const cashEntry: CashEntry = {
+  amount: 10000,
+  date: "2026-04-26T00:00:00.000Z",
+  id: "cash-1",
+  label: "Broker cash",
+  type: "addition",
+};
+
+const quote: Quote = {
+  asOf: "2026-04-26T10:00:00.000Z",
+  assetId: asset.id,
+  currency: "INR",
+  price: 2912.5,
+  source: "yahoo",
+};
+
+describe("portfolio store", () => {
+  it("starts with empty raw data and V1 preferences", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+
+    expect(store.getState().assets).toEqual([]);
+    expect(store.getState().trades).toEqual([]);
+    expect(store.getState().cashEntries).toEqual([]);
+    expect(store.getState().preferences).toEqual(createDefaultPreferences());
+  });
+
+  it("adds, updates, and removes raw portfolio records", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+
+    store.getState().addAsset(asset);
+    store.getState().addTrade(trade);
+    store.getState().addCashEntry(cashEntry);
+    store.getState().updatePreferences({ maskWealthValues: true });
+
+    expect(store.getState().assets).toEqual([asset]);
+    expect(store.getState().trades).toEqual([trade]);
+    expect(store.getState().cashEntries).toEqual([cashEntry]);
+    expect(store.getState().preferences.maskWealthValues).toBe(true);
+
+    store.getState().removeTrade(trade.id);
+    store.getState().removeCashEntry(cashEntry.id);
+    store.getState().removeAsset(asset.id);
+
+    expect(store.getState().assets).toEqual([]);
+    expect(store.getState().trades).toEqual([]);
+    expect(store.getState().cashEntries).toEqual([]);
+  });
+
+  it("persists only raw portfolio data under the portfolio key", () => {
+    const storage = createMemoryJsonStorage();
+    const store = createPortfolioStore({ storage });
+
+    store.getState().addAsset(asset);
+    store.getState().addTrade(trade);
+    store.getState().addCashEntry(cashEntry);
+
+    const persisted = storage.getItem(portfolioStorageKey);
+
+    expect(persisted).toEqual({
+      assets: [asset],
+      cashEntries: [cashEntry],
+      preferences: createDefaultPreferences(),
+      schemaVersion: 1,
+      trades: [trade],
+    });
+    expect(persisted).not.toHaveProperty("holdings");
+    expect(persisted).not.toHaveProperty("allocation");
+    expect(persisted).not.toHaveProperty("dashboardTotal");
+  });
+
+  it("persists quotes separately from the main raw portfolio snapshot", () => {
+    const storage = createMemoryJsonStorage();
+    const store = createPortfolioStore({ storage });
+
+    store.getState().addAsset(asset);
+    store.getState().upsertQuote(quote);
+
+    expect(storage.getItem(portfolioStorageKey)).not.toHaveProperty("quotes");
+    expect(storage.getItem(quoteCacheStorageKey)).toEqual({
+      [asset.id]: quote,
+    });
+  });
+
+  it("rehydrates raw portfolio data and quote cache from storage", () => {
+    const storage = createMemoryJsonStorage();
+    storage.setItem(portfolioStorageKey, {
+      assets: [asset],
+      cashEntries: [cashEntry],
+      preferences: { ...createDefaultPreferences(), maskWealthValues: true },
+      schemaVersion: 1,
+      trades: [trade],
+    });
+    storage.setItem(quoteCacheStorageKey, {
+      [asset.id]: quote,
+    });
+
+    const store = createPortfolioStore({ storage });
+
+    expect(store.getState().assets).toEqual([asset]);
+    expect(store.getState().trades).toEqual([trade]);
+    expect(store.getState().cashEntries).toEqual([cashEntry]);
+    expect(store.getState().preferences.maskWealthValues).toBe(true);
+    expect(store.getState().quoteCache[asset.id]).toEqual(quote);
+  });
+});

--- a/src/store/__tests__/selectors.test.ts
+++ b/src/store/__tests__/selectors.test.ts
@@ -1,0 +1,87 @@
+import {
+  selectAssetById,
+  selectCashBalance,
+  selectQuoteForAsset,
+  selectTradesForAsset,
+} from "@/src/store";
+import type { Asset, CashEntry, Quote, Trade } from "@/src/types";
+
+const stock: Asset = {
+  assetClass: "stock",
+  currency: "INR",
+  id: "asset-1",
+  name: "Reliance Industries",
+  symbol: "RELIANCE",
+  ticker: "RELIANCE.NS",
+};
+
+const crypto: Asset = {
+  assetClass: "crypto",
+  currency: "USD",
+  id: "asset-2",
+  name: "Bitcoin",
+  symbol: "BTC",
+  ticker: "bitcoin",
+};
+
+const trades: Trade[] = [
+  {
+    assetId: stock.id,
+    date: "2026-04-26T00:00:00.000Z",
+    id: "trade-1",
+    pricePerUnit: 100,
+    quantity: 2,
+    totalValue: 200,
+    type: "buy",
+  },
+  {
+    assetId: crypto.id,
+    date: "2026-04-26T00:00:00.000Z",
+    id: "trade-2",
+    pricePerUnit: 50000,
+    quantity: 0.1,
+    totalValue: 5000,
+    type: "buy",
+  },
+];
+
+const cashEntries: CashEntry[] = [
+  {
+    amount: 5000,
+    date: "2026-04-26T00:00:00.000Z",
+    id: "cash-1",
+    label: "Deposit",
+    type: "addition",
+  },
+  {
+    amount: 1200,
+    date: "2026-04-26T00:00:00.000Z",
+    id: "cash-2",
+    label: "Withdrawal",
+    type: "withdrawal",
+  },
+];
+
+const quote: Quote = {
+  assetId: stock.id,
+  asOf: "2026-04-26T10:00:00.000Z",
+  currency: "INR",
+  price: 110,
+  source: "manual",
+};
+
+describe("portfolio selectors", () => {
+  it("selects assets and trades by asset ID", () => {
+    expect(selectAssetById([stock, crypto], stock.id)).toEqual(stock);
+    expect(selectTradesForAsset(trades, stock.id)).toEqual([trades[0]]);
+  });
+
+  it("calculates cash balance from raw cash entries", () => {
+    expect(selectCashBalance(cashEntries)).toBe(3800);
+  });
+
+  it("selects cached quote by asset ID", () => {
+    expect(selectQuoteForAsset({ [stock.id]: quote }, stock.id)).toEqual(quote);
+    expect(selectQuoteForAsset({ [stock.id]: quote }, crypto.id)).toBeNull();
+  });
+});

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,1 +1,216 @@
-export {};
+import { createStore, type StoreApi } from "zustand/vanilla";
+
+import type { JsonStorage, JsonValue } from "@/src/services/storage";
+import { createMmkvJsonStorage } from "@/src/services/storage";
+import type {
+  Asset,
+  CashEntry,
+  Preferences,
+  Quote,
+  QuoteCache,
+  Trade,
+} from "@/src/types";
+
+export {
+  selectAssetById,
+  selectCashBalance,
+  selectQuoteForAsset,
+  selectTradesForAsset,
+} from "./selectors";
+
+export const portfolioStorageKey = "cogvest:v1:portfolio";
+export const quoteCacheStorageKey = "cogvest:v1:quote-cache";
+export const portfolioSchemaVersion = 1;
+
+export type RawPortfolioSnapshot = {
+  assets: Asset[];
+  cashEntries: CashEntry[];
+  preferences: Preferences;
+  schemaVersion: typeof portfolioSchemaVersion;
+  trades: Trade[];
+};
+
+export type PortfolioStoreState = RawPortfolioSnapshot & {
+  addAsset: (asset: Asset) => void;
+  addCashEntry: (cashEntry: CashEntry) => void;
+  addTrade: (trade: Trade) => void;
+  clearQuoteCache: () => void;
+  quoteCache: QuoteCache;
+  removeAsset: (assetId: string) => void;
+  removeCashEntry: (cashEntryId: string) => void;
+  removeTrade: (tradeId: string) => void;
+  updateAsset: (asset: Asset) => void;
+  updateCashEntry: (cashEntry: CashEntry) => void;
+  updatePreferences: (preferences: Partial<Preferences>) => void;
+  updateTrade: (trade: Trade) => void;
+  upsertQuote: (quote: Quote) => void;
+};
+
+type CreatePortfolioStoreOptions = {
+  storage?: JsonStorage;
+};
+
+export function createDefaultPreferences(): Preferences {
+  return {
+    defaultChartRange: "1M",
+    hasCompletedOnboarding: false,
+    maskWealthValues: false,
+  };
+}
+
+export function createEmptyPortfolioSnapshot(): RawPortfolioSnapshot {
+  return {
+    assets: [],
+    cashEntries: [],
+    preferences: createDefaultPreferences(),
+    schemaVersion: portfolioSchemaVersion,
+    trades: [],
+  };
+}
+
+function readPortfolioSnapshot(storage: JsonStorage): RawPortfolioSnapshot {
+  const stored = storage.getItem<RawPortfolioSnapshot & JsonValue>(
+    portfolioStorageKey,
+  );
+
+  if (!stored || stored.schemaVersion !== portfolioSchemaVersion) {
+    return createEmptyPortfolioSnapshot();
+  }
+
+  return {
+    assets: stored.assets ?? [],
+    cashEntries: stored.cashEntries ?? [],
+    preferences: {
+      ...createDefaultPreferences(),
+      ...stored.preferences,
+    },
+    schemaVersion: portfolioSchemaVersion,
+    trades: stored.trades ?? [],
+  };
+}
+
+function readQuoteCache(storage: JsonStorage): QuoteCache {
+  return storage.getItem<QuoteCache & JsonValue>(quoteCacheStorageKey) ?? {};
+}
+
+function selectRawSnapshot(
+  state: PortfolioStoreState,
+): RawPortfolioSnapshot {
+  return {
+    assets: state.assets,
+    cashEntries: state.cashEntries,
+    preferences: state.preferences,
+    schemaVersion: portfolioSchemaVersion,
+    trades: state.trades,
+  };
+}
+
+function persistPortfolio(
+  storage: JsonStorage,
+  state: PortfolioStoreState,
+) {
+  storage.setItem(portfolioStorageKey, selectRawSnapshot(state) as JsonValue);
+}
+
+function persistQuoteCache(storage: JsonStorage, quoteCache: QuoteCache) {
+  storage.setItem(quoteCacheStorageKey, quoteCache as JsonValue);
+}
+
+export function createPortfolioStore({
+  storage = createMmkvJsonStorage(),
+}: CreatePortfolioStoreOptions = {}): StoreApi<PortfolioStoreState> {
+  const snapshot = readPortfolioSnapshot(storage);
+  const quoteCache = readQuoteCache(storage);
+
+  return createStore<PortfolioStoreState>((set, get) => ({
+    ...snapshot,
+    addAsset: (asset) => {
+      set((state) => ({ assets: [...state.assets, asset] }));
+      persistPortfolio(storage, get());
+    },
+    addCashEntry: (cashEntry) => {
+      set((state) => ({ cashEntries: [...state.cashEntries, cashEntry] }));
+      persistPortfolio(storage, get());
+    },
+    addTrade: (trade) => {
+      set((state) => ({ trades: [...state.trades, trade] }));
+      persistPortfolio(storage, get());
+    },
+    clearQuoteCache: () => {
+      set({ quoteCache: {} });
+      storage.removeItem(quoteCacheStorageKey);
+    },
+    quoteCache,
+    removeAsset: (assetId) => {
+      set((state) => ({
+        assets: state.assets.filter((asset) => asset.id !== assetId),
+      }));
+      persistPortfolio(storage, get());
+    },
+    removeCashEntry: (cashEntryId) => {
+      set((state) => ({
+        cashEntries: state.cashEntries.filter(
+          (cashEntry) => cashEntry.id !== cashEntryId,
+        ),
+      }));
+      persistPortfolio(storage, get());
+    },
+    removeTrade: (tradeId) => {
+      set((state) => ({
+        trades: state.trades.filter((trade) => trade.id !== tradeId),
+      }));
+      persistPortfolio(storage, get());
+    },
+    schemaVersion: portfolioSchemaVersion,
+    updateAsset: (asset) => {
+      set((state) => ({
+        assets: state.assets.map((currentAsset) =>
+          currentAsset.id === asset.id ? asset : currentAsset,
+        ),
+      }));
+      persistPortfolio(storage, get());
+    },
+    updateCashEntry: (cashEntry) => {
+      set((state) => ({
+        cashEntries: state.cashEntries.map((currentEntry) =>
+          currentEntry.id === cashEntry.id ? cashEntry : currentEntry,
+        ),
+      }));
+      persistPortfolio(storage, get());
+    },
+    updatePreferences: (preferences) => {
+      set((state) => ({
+        preferences: {
+          ...state.preferences,
+          ...preferences,
+        },
+      }));
+      persistPortfolio(storage, get());
+    },
+    updateTrade: (trade) => {
+      set((state) => ({
+        trades: state.trades.map((currentTrade) =>
+          currentTrade.id === trade.id ? trade : currentTrade,
+        ),
+      }));
+      persistPortfolio(storage, get());
+    },
+    upsertQuote: (quote) => {
+      set((state) => ({
+        quoteCache: {
+          ...state.quoteCache,
+          [quote.assetId]: quote,
+        },
+      }));
+      persistQuoteCache(storage, get().quoteCache);
+    },
+  }));
+}
+
+let runtimePortfolioStore: StoreApi<PortfolioStoreState> | undefined;
+
+export function getPortfolioStore() {
+  runtimePortfolioStore ??= createPortfolioStore();
+
+  return runtimePortfolioStore;
+}

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -1,0 +1,23 @@
+import type { Asset, CashEntry, QuoteCache, Trade } from "@/src/types";
+
+export function selectAssetById(assets: Asset[], assetId: string) {
+  return assets.find((asset) => asset.id === assetId) ?? null;
+}
+
+export function selectTradesForAsset(trades: Trade[], assetId: string) {
+  return trades.filter((trade) => trade.assetId === assetId);
+}
+
+export function selectCashBalance(cashEntries: CashEntry[]) {
+  return cashEntries.reduce((balance, entry) => {
+    if (entry.type === "withdrawal") {
+      return balance - entry.amount;
+    }
+
+    return balance + entry.amount;
+  }, 0);
+}
+
+export function selectQuoteForAsset(quoteCache: QuoteCache, assetId: string) {
+  return quoteCache[assetId] ?? null;
+}

--- a/src/types/asset.ts
+++ b/src/types/asset.ts
@@ -1,0 +1,17 @@
+export type AssetClass = "crypto" | "stock" | "etf" | "cash";
+
+export type Currency = "INR" | "USD";
+
+export type AssetExchange = "NSE" | "BSE" | "CRYPTO";
+
+export type Asset = {
+  assetClass: AssetClass;
+  currency: Currency;
+  exchange?: AssetExchange;
+  id: string;
+  isTaxEligible?: boolean;
+  logoUrl?: string;
+  name: string;
+  symbol: string;
+  ticker: string;
+};

--- a/src/types/cash.ts
+++ b/src/types/cash.ts
@@ -1,0 +1,11 @@
+export type CashEntryType = "addition" | "withdrawal";
+
+export type CashEntry = {
+  amount: number;
+  date: string;
+  id: string;
+  institution?: string;
+  label: string;
+  notes?: string;
+  type: CashEntryType;
+};

--- a/src/types/holding.ts
+++ b/src/types/holding.ts
@@ -1,0 +1,17 @@
+import type { Asset } from "./asset";
+
+export type Holding = {
+  asset: Asset;
+  averageCostPrice: number;
+  currentPrice: number;
+  currentValue: number;
+  dayChangePct?: number;
+  daysToLtcg?: number;
+  heldDays?: number;
+  lastUpdated?: string;
+  ltcgEligible?: boolean;
+  totalInvested: number;
+  totalUnits: number;
+  unrealisedPnL: number;
+  unrealisedPnLPct: number;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,6 @@
-export {};
+export type { Asset, AssetClass, AssetExchange, Currency } from "./asset";
+export type { CashEntry, CashEntryType } from "./cash";
+export type { Holding } from "./holding";
+export type { ChartRange, Preferences } from "./preferences";
+export type { Quote, QuoteCache, QuoteSource } from "./quote";
+export type { ConvictionScore, Trade, TradeType } from "./trade";

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1,0 +1,7 @@
+export type ChartRange = "1D" | "1W" | "1M" | "3M" | "6M" | "1Y" | "ALL";
+
+export type Preferences = {
+  defaultChartRange: ChartRange;
+  hasCompletedOnboarding: boolean;
+  maskWealthValues: boolean;
+};

--- a/src/types/quote.ts
+++ b/src/types/quote.ts
@@ -1,0 +1,15 @@
+import type { Currency } from "./asset";
+
+export type QuoteSource = "yahoo" | "coingecko" | "manual";
+
+export type Quote = {
+  assetId: string;
+  asOf: string;
+  currency: Currency;
+  dayChangeAbs?: number;
+  dayChangePct?: number;
+  price: number;
+  source: QuoteSource;
+};
+
+export type QuoteCache = Record<string, Quote>;

--- a/src/types/trade.ts
+++ b/src/types/trade.ts
@@ -1,0 +1,18 @@
+export type TradeType = "buy" | "sell";
+
+export type ConvictionScore = 1 | 2 | 3 | 4 | 5;
+
+export type Trade = {
+  assetId: string;
+  conviction?: ConvictionScore;
+  date: string;
+  fees?: number;
+  id: string;
+  intendedHoldDays?: number;
+  notes?: string;
+  pricePerUnit: number;
+  quantity: number;
+  totalValue: number;
+  type: TradeType;
+  whyThisTrade?: string;
+};

--- a/src/utils/__tests__/id.test.ts
+++ b/src/utils/__tests__/id.test.ts
@@ -1,0 +1,11 @@
+import { createId } from "@/src/utils";
+
+describe("createId", () => {
+  it("prefixes IDs with the requested entity name", () => {
+    expect(createId("trade")).toMatch(/^trade_[a-z0-9]+_[a-z0-9]+$/);
+  });
+
+  it("creates different IDs across calls", () => {
+    expect(createId("asset")).not.toBe(createId("asset"));
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,6 @@
-export {};
+export function createId(prefix: string) {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).slice(2, 10);
+
+  return `${prefix}_${timestamp}_${random}`;
+}


### PR DESCRIPTION
## Summary
- Add V1 raw domain types for assets, trades, cash entries, quotes, holdings, and preferences.
- Add JSON storage adapters with MMKV-backed runtime storage and memory storage for tests.
- Add Zustand vanilla portfolio store with raw-data persistence and separate quote cache persistence.
- Add selectors for asset lookup, asset trades, cash balance, and quote cache lookup.
- Add local ID helper for future trade/asset/cash creation flows.

## Validation
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm audit --audit-level=high
- npx expo start --offline --port 8083 startup smoke

## Notes
- First Expo smoke attempt found port 8081 occupied, so verification used 8083 without killing unrelated local processes.
- Full npm audit still reports the known 13 moderate Expo transitive uuid findings; high-severity audit gate passes.