### PR TITLE
feat: add portfolio calculations

### DIFF
--- a/src/domain/calculations/__tests__/holdings.test.ts
+++ b/src/domain/calculations/__tests__/holdings.test.ts
@@ -1,0 +1,234 @@
+import {
+  calculateAllocation,
+  calculateCashBalance,
+  calculateHolding,
+  calculateHoldings,
+  calculatePortfolioDayChange,
+  calculatePortfolioTotal,
+  daysHeld,
+  getConvictionReadiness,
+} from "@/src/domain/calculations";
+import type { Asset, CashEntry, Quote, Trade } from "@/src/types";
+
+const reliance: Asset = {
+  assetClass: "stock",
+  currency: "INR",
+  id: "asset-reliance",
+  name: "Reliance Industries",
+  symbol: "RELIANCE",
+  ticker: "RELIANCE.NS",
+};
+
+const bitcoin: Asset = {
+  assetClass: "crypto",
+  currency: "USD",
+  id: "asset-btc",
+  name: "Bitcoin",
+  symbol: "BTC",
+  ticker: "bitcoin",
+};
+
+function trade(overrides: Partial<Trade>): Trade {
+  return {
+    assetId: reliance.id,
+    date: "2026-04-20T00:00:00.000Z",
+    id: `trade-${Math.random()}`,
+    pricePerUnit: 100,
+    quantity: 1,
+    totalValue: 100,
+    type: "buy",
+    ...overrides,
+  };
+}
+
+describe("holding calculations", () => {
+  it("calculates weighted average cost for buy trades", () => {
+    const holding = calculateHolding({
+      asset: reliance,
+      currentPrice: 120,
+      trades: [
+        trade({ pricePerUnit: 100, quantity: 10, totalValue: 1000 }),
+        trade({ pricePerUnit: 200, quantity: 5, totalValue: 1000 }),
+      ],
+    });
+
+    expect(holding.totalUnits).toBe(15);
+    expect(holding.averageCostPrice).toBeCloseTo(133.333333, 5);
+    expect(holding.totalInvested).toBeCloseTo(2000, 5);
+    expect(holding.currentValue).toBe(1800);
+    expect(holding.unrealisedPnL).toBeCloseTo(-200, 5);
+    expect(holding.unrealisedPnLPct).toBeCloseTo(-10, 5);
+  });
+
+  it("keeps average cost stable after a partial sell", () => {
+    const holding = calculateHolding({
+      asset: reliance,
+      currentPrice: 150,
+      trades: [
+        trade({ pricePerUnit: 100, quantity: 10, totalValue: 1000 }),
+        trade({ pricePerUnit: 200, quantity: 10, totalValue: 2000 }),
+        trade({
+          pricePerUnit: 175,
+          quantity: 5,
+          totalValue: 875,
+          type: "sell",
+        }),
+      ],
+    });
+
+    expect(holding.totalUnits).toBe(15);
+    expect(holding.averageCostPrice).toBe(150);
+    expect(holding.totalInvested).toBe(2250);
+    expect(holding.currentValue).toBe(2250);
+    expect(holding.unrealisedPnL).toBe(0);
+  });
+
+  it("returns an empty holding for fully sold positions", () => {
+    const holding = calculateHolding({
+      asset: reliance,
+      currentPrice: 150,
+      trades: [
+        trade({ pricePerUnit: 100, quantity: 4, totalValue: 400 }),
+        trade({
+          pricePerUnit: 120,
+          quantity: 4,
+          totalValue: 480,
+          type: "sell",
+        }),
+      ],
+    });
+
+    expect(holding.totalUnits).toBe(0);
+    expect(holding.totalInvested).toBe(0);
+    expect(holding.currentValue).toBe(0);
+    expect(holding.unrealisedPnLPct).toBe(0);
+  });
+
+  it("derives holdings from assets, trades, and quote cache", () => {
+    const quote: Quote = {
+      assetId: reliance.id,
+      asOf: "2026-04-26T00:00:00.000Z",
+      currency: "INR",
+      price: 125,
+      source: "yahoo",
+    };
+
+    const holdings = calculateHoldings({
+      assets: [reliance, bitcoin],
+      quoteCache: { [reliance.id]: quote },
+      trades: [trade({ assetId: reliance.id, quantity: 2, totalValue: 200 })],
+    });
+
+    expect(holdings).toHaveLength(1);
+    expect(holdings[0]?.asset).toEqual(reliance);
+    expect(holdings[0]?.currentPrice).toBe(125);
+  });
+});
+
+describe("portfolio calculations", () => {
+  const cashEntries: CashEntry[] = [
+    {
+      amount: 10000,
+      date: "2026-04-20T00:00:00.000Z",
+      id: "cash-1",
+      label: "Deposit",
+      type: "addition",
+    },
+    {
+      amount: 1500,
+      date: "2026-04-21T00:00:00.000Z",
+      id: "cash-2",
+      label: "Withdraw",
+      type: "withdrawal",
+    },
+  ];
+
+  it("calculates cash balance and portfolio total", () => {
+    const holding = calculateHolding({
+      asset: reliance,
+      currentPrice: 120,
+      trades: [trade({ quantity: 10, totalValue: 1000 })],
+    });
+
+    expect(calculateCashBalance(cashEntries)).toBe(8500);
+    expect(calculatePortfolioTotal([holding], cashEntries)).toBe(9700);
+  });
+
+  it("calculates day change from holding values and quote change", () => {
+    const holding = calculateHolding({
+      asset: reliance,
+      currentPrice: 120,
+      trades: [trade({ quantity: 10, totalValue: 1000 })],
+    });
+
+    expect(calculatePortfolioDayChange([holding])).toEqual({
+      absolute: 0,
+      percentage: 0,
+    });
+
+    const changedHolding = {
+      ...holding,
+      dayChangePct: 20,
+    };
+
+    expect(calculatePortfolioDayChange([changedHolding])).toEqual({
+      absolute: 200,
+      percentage: 20,
+    });
+  });
+
+  it("groups allocation by asset class including cash", () => {
+    const stockHolding = calculateHolding({
+      asset: reliance,
+      currentPrice: 120,
+      trades: [trade({ quantity: 10, totalValue: 1000 })],
+    });
+    const cryptoHolding = calculateHolding({
+      asset: bitcoin,
+      currentPrice: 50000,
+      trades: [
+        trade({
+          assetId: bitcoin.id,
+          pricePerUnit: 50000,
+          quantity: 0.1,
+          totalValue: 5000,
+        }),
+      ],
+    });
+
+    const allocation = calculateAllocation({
+      cashBalance: 3800,
+      holdings: [stockHolding, cryptoHolding],
+    });
+
+    expect(allocation).toEqual([
+      { assetClass: "crypto", percentage: 50, value: 5000 },
+      { assetClass: "cash", percentage: 38, value: 3800 },
+      { assetClass: "stock", percentage: 12, value: 1200 },
+    ]);
+  });
+});
+
+describe("date and conviction calculations", () => {
+  it("calculates days held between two ISO dates", () => {
+    expect(
+      daysHeld("2026-04-20T00:00:00.000Z", "2026-04-26T00:00:00.000Z"),
+    ).toBe(6);
+  });
+
+  it("reports conviction readiness from rated trades", () => {
+    expect(
+      getConvictionReadiness([
+        trade({ conviction: 5 }),
+        trade({ conviction: 2 }),
+        trade({ conviction: undefined }),
+      ]),
+    ).toEqual({
+      highConvictionCount: 1,
+      isReady: false,
+      lowConvictionCount: 1,
+      ratedTradeCount: 2,
+      requiredTradeCount: 5,
+    });
+  });
+});

--- a/src/domain/calculations/holdings.ts
+++ b/src/domain/calculations/holdings.ts
@@ -1,0 +1,234 @@
+import type {
+  Asset,
+  AssetClass,
+  CashEntry,
+  Holding,
+  QuoteCache,
+  Trade,
+} from "@/src/types";
+
+type CalculateHoldingInput = {
+  asset: Asset;
+  currentPrice: number;
+  trades: Trade[];
+};
+
+type CalculateHoldingsInput = {
+  assets: Asset[];
+  quoteCache: QuoteCache;
+  trades: Trade[];
+};
+
+export type AllocationItem = {
+  assetClass: AssetClass;
+  percentage: number;
+  value: number;
+};
+
+export type PortfolioDayChange = {
+  absolute: number;
+  percentage: number;
+};
+
+export type ConvictionReadiness = {
+  highConvictionCount: number;
+  isReady: boolean;
+  lowConvictionCount: number;
+  ratedTradeCount: number;
+  requiredTradeCount: number;
+};
+
+const defaultConvictionTradeCount = 5;
+
+function round(value: number, decimals = 2) {
+  const factor = 10 ** decimals;
+
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+function sortTradesByDate(trades: Trade[]) {
+  return [...trades].sort(
+    (left, right) =>
+      new Date(left.date).getTime() - new Date(right.date).getTime(),
+  );
+}
+
+export function calculateHolding({
+  asset,
+  currentPrice,
+  trades,
+}: CalculateHoldingInput): Holding {
+  let averageCostPrice = 0;
+  let totalUnits = 0;
+
+  for (const trade of sortTradesByDate(trades)) {
+    if (trade.type === "buy") {
+      const existingCost = totalUnits * averageCostPrice;
+      const buyCost = trade.pricePerUnit * trade.quantity + (trade.fees ?? 0);
+      const nextUnits = totalUnits + trade.quantity;
+
+      averageCostPrice = nextUnits > 0 ? (existingCost + buyCost) / nextUnits : 0;
+      totalUnits = nextUnits;
+      continue;
+    }
+
+    totalUnits = Math.max(0, totalUnits - trade.quantity);
+
+    if (totalUnits === 0) {
+      averageCostPrice = 0;
+    }
+  }
+
+  const totalInvested = totalUnits * averageCostPrice;
+  const currentValue = totalUnits * currentPrice;
+  const unrealisedPnL = currentValue - totalInvested;
+  const unrealisedPnLPct =
+    totalInvested === 0 ? 0 : (unrealisedPnL / totalInvested) * 100;
+
+  return {
+    asset,
+    averageCostPrice,
+    currentPrice,
+    currentValue,
+    totalInvested,
+    totalUnits,
+    unrealisedPnL,
+    unrealisedPnLPct,
+  };
+}
+
+export function calculateHoldings({
+  assets,
+  quoteCache,
+  trades,
+}: CalculateHoldingsInput) {
+  return assets
+    .map((asset) => {
+      const assetTrades = trades.filter((trade) => trade.assetId === asset.id);
+
+      if (assetTrades.length === 0) {
+        return null;
+      }
+
+      const currentPrice = quoteCache[asset.id]?.price ?? 0;
+      const holding = calculateHolding({
+        asset,
+        currentPrice,
+        trades: assetTrades,
+      });
+
+      return holding.totalUnits > 0 ? holding : null;
+    })
+    .filter((holding): holding is Holding => holding !== null);
+}
+
+export function calculateCashBalance(cashEntries: CashEntry[]) {
+  return cashEntries.reduce((balance, entry) => {
+    if (entry.type === "withdrawal") {
+      return balance - entry.amount;
+    }
+
+    return balance + entry.amount;
+  }, 0);
+}
+
+export function calculatePortfolioTotal(
+  holdings: Holding[],
+  cashEntries: CashEntry[],
+) {
+  const holdingsValue = holdings.reduce(
+    (total, holding) => total + holding.currentValue,
+    0,
+  );
+
+  return holdingsValue + calculateCashBalance(cashEntries);
+}
+
+export function calculatePortfolioDayChange(
+  holdings: Holding[],
+): PortfolioDayChange {
+  const currentValue = holdings.reduce(
+    (total, holding) => total + holding.currentValue,
+    0,
+  );
+  const absolute = holdings.reduce((total, holding) => {
+    if (!holding.dayChangePct) {
+      return total;
+    }
+
+    const previousValue = holding.currentValue / (1 + holding.dayChangePct / 100);
+
+    return total + (holding.currentValue - previousValue);
+  }, 0);
+  const previousValue = currentValue - absolute;
+  const percentage = previousValue === 0 ? 0 : (absolute / previousValue) * 100;
+
+  return {
+    absolute: round(absolute),
+    percentage: round(percentage),
+  };
+}
+
+export function calculateAllocation({
+  cashBalance,
+  holdings,
+}: {
+  cashBalance: number;
+  holdings: Holding[];
+}): AllocationItem[] {
+  const values = new Map<AssetClass, number>();
+
+  for (const holding of holdings) {
+    values.set(
+      holding.asset.assetClass,
+      (values.get(holding.asset.assetClass) ?? 0) + holding.currentValue,
+    );
+  }
+
+  if (cashBalance > 0) {
+    values.set("cash", (values.get("cash") ?? 0) + cashBalance);
+  }
+
+  const total = [...values.values()].reduce((sum, value) => sum + value, 0);
+
+  if (total === 0) {
+    return [];
+  }
+
+  return [...values.entries()]
+    .map(([assetClass, value]) => ({
+      assetClass,
+      percentage: round((value / total) * 100),
+      value,
+    }))
+    .sort((left, right) => right.value - left.value);
+}
+
+export function daysHeld(fromIsoDate: string, toIsoDate = new Date().toISOString()) {
+  const millisecondsPerDay = 24 * 60 * 60 * 1000;
+  const fromTime = new Date(fromIsoDate).getTime();
+  const toTime = new Date(toIsoDate).getTime();
+
+  return Math.max(0, Math.floor((toTime - fromTime) / millisecondsPerDay));
+}
+
+export function getConvictionReadiness(
+  trades: Trade[],
+  requiredTradeCount = defaultConvictionTradeCount,
+): ConvictionReadiness {
+  const ratedTrades = trades.filter((trade) => trade.conviction !== undefined);
+  const highConvictionCount = ratedTrades.filter(
+    (trade) => trade.conviction !== undefined && trade.conviction >= 4,
+  ).length;
+  const lowConvictionCount = ratedTrades.filter(
+    (trade) => trade.conviction !== undefined && trade.conviction <= 2,
+  ).length;
+
+  return {
+    highConvictionCount,
+    isReady: ratedTrades.length >= requiredTradeCount,
+    lowConvictionCount,
+    ratedTradeCount: ratedTrades.length,
+    requiredTradeCount,
+  };
+}

--- a/src/domain/calculations/index.ts
+++ b/src/domain/calculations/index.ts
@@ -1,1 +1,11 @@
-export {};
+export {
+  calculateAllocation,
+  calculateCashBalance,
+  calculateHolding,
+  calculateHoldings,
+  calculatePortfolioDayChange,
+  calculatePortfolioTotal,
+  daysHeld,
+  getConvictionReadiness,
+} from "./holdings";
+export type { AllocationItem, ConvictionReadiness, PortfolioDayChange } from "./holdings";

--- a/src/domain/formatters/__tests__/formatters.test.ts
+++ b/src/domain/formatters/__tests__/formatters.test.ts
@@ -1,0 +1,20 @@
+import { formatDate, formatINR, formatPercentage } from "@/src/domain/formatters";
+
+describe("formatters", () => {
+  it("formats INR values with Indian grouping", () => {
+    expect(formatINR(1234567.8)).toBe("₹12,34,567.80");
+  });
+
+  it("formats negative INR values", () => {
+    expect(formatINR(-4500)).toBe("-₹4,500.00");
+  });
+
+  it("formats percentages with sign and two decimals", () => {
+    expect(formatPercentage(12.345)).toBe("+12.35%");
+    expect(formatPercentage(-2)).toBe("-2.00%");
+  });
+
+  it("formats ISO dates for India locale", () => {
+    expect(formatDate("2026-04-26T00:00:00.000Z")).toBe("26 Apr 2026");
+  });
+});

--- a/src/domain/formatters/formatters.ts
+++ b/src/domain/formatters/formatters.ts
@@ -1,0 +1,25 @@
+export function formatINR(value: number) {
+  const sign = value < 0 ? "-" : "";
+  const absoluteValue = Math.abs(value);
+  const formatted = new Intl.NumberFormat("en-IN", {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  }).format(absoluteValue);
+
+  return `${sign}₹${formatted}`;
+}
+
+export function formatPercentage(value: number) {
+  const sign = value > 0 ? "+" : "";
+
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+export function formatDate(isoDate: string) {
+  return new Intl.DateTimeFormat("en-IN", {
+    day: "2-digit",
+    month: "short",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(new Date(isoDate));
+}

--- a/src/domain/formatters/index.ts
+++ b/src/domain/formatters/index.ts
@@ -1,1 +1,1 @@
-export {};
+export { formatDate, formatINR, formatPercentage } from "./formatters";

--- a/src/domain/validators/__tests__/trade.test.ts
+++ b/src/domain/validators/__tests__/trade.test.ts
@@ -1,0 +1,52 @@
+import { validateSellQuantity, validateTradeInput } from "@/src/domain/validators";
+import type { Trade } from "@/src/types";
+
+const existingBuy: Trade = {
+  assetId: "asset-1",
+  date: "2026-04-20T00:00:00.000Z",
+  id: "trade-1",
+  pricePerUnit: 100,
+  quantity: 5,
+  totalValue: 500,
+  type: "buy",
+};
+
+describe("trade validators", () => {
+  it("allows sell quantity within available units", () => {
+    expect(validateSellQuantity([existingBuy], 3)).toEqual({
+      availableQuantity: 5,
+      isValid: true,
+    });
+  });
+
+  it("rejects sell quantity above available units", () => {
+    expect(validateSellQuantity([existingBuy], 6)).toEqual({
+      availableQuantity: 5,
+      isValid: false,
+      message: "Sell quantity exceeds available units.",
+    });
+  });
+
+  it("validates positive trade quantity and price", () => {
+    expect(
+      validateTradeInput({
+        date: "2026-04-20T00:00:00.000Z",
+        pricePerUnit: 100,
+        quantity: 1,
+        type: "buy",
+      }),
+    ).toEqual({ isValid: true });
+
+    expect(
+      validateTradeInput({
+        date: "2026-04-20T00:00:00.000Z",
+        pricePerUnit: 0,
+        quantity: -1,
+        type: "buy",
+      }),
+    ).toEqual({
+      errors: ["Quantity must be greater than zero.", "Price must be greater than zero."],
+      isValid: false,
+    });
+  });
+});

--- a/src/domain/validators/index.ts
+++ b/src/domain/validators/index.ts
@@ -1,1 +1,5 @@
-export {};
+export {
+  getAvailableQuantity,
+  validateSellQuantity,
+  validateTradeInput,
+} from "./trade";

--- a/src/domain/validators/trade.ts
+++ b/src/domain/validators/trade.ts
@@ -1,0 +1,68 @@
+import type { Trade, TradeType } from "@/src/types";
+
+type ValidationResult =
+  | { isValid: true }
+  | { errors: string[]; isValid: false };
+
+type SellQuantityResult =
+  | { availableQuantity: number; isValid: true }
+  | { availableQuantity: number; isValid: false; message: string };
+
+type TradeInput = {
+  date: string;
+  pricePerUnit: number;
+  quantity: number;
+  type: TradeType;
+};
+
+export function getAvailableQuantity(trades: Trade[]) {
+  return trades.reduce((quantity, trade) => {
+    if (trade.type === "sell") {
+      return quantity - trade.quantity;
+    }
+
+    return quantity + trade.quantity;
+  }, 0);
+}
+
+export function validateSellQuantity(
+  trades: Trade[],
+  sellQuantity: number,
+): SellQuantityResult {
+  const availableQuantity = getAvailableQuantity(trades);
+
+  if (sellQuantity > availableQuantity) {
+    return {
+      availableQuantity,
+      isValid: false,
+      message: "Sell quantity exceeds available units.",
+    };
+  }
+
+  return {
+    availableQuantity,
+    isValid: true,
+  };
+}
+
+export function validateTradeInput(input: TradeInput): ValidationResult {
+  const errors: string[] = [];
+
+  if (input.quantity <= 0) {
+    errors.push("Quantity must be greater than zero.");
+  }
+
+  if (input.pricePerUnit <= 0) {
+    errors.push("Price must be greater than zero.");
+  }
+
+  if (Number.isNaN(new Date(input.date).getTime())) {
+    errors.push("Date must be valid.");
+  }
+
+  if (errors.length > 0) {
+    return { errors, isValid: false };
+  }
+
+  return { isValid: true };
+}


### PR DESCRIPTION
## Summary
- Add pure holding calculations for weighted average cost, partial sells, current value, and unrealised P&L.
- Add holdings derivation from raw assets/trades/quote cache without store access.
- Add cash balance, portfolio total, day change, allocation, days-held, and conviction readiness helpers.
- Add INR, percentage, and date formatters.
- Add lightweight trade validation helpers for positive inputs and sell quantity checks.

## Validation
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm audit --audit-level=high
- npx expo start --offline --port 8084 startup smoke

## Notes
- Full npm audit still reports the known 13 moderate Expo transitive uuid findings; high-severity audit gate passes.

Closes #4