### PR TITLE
feat: add live quote services

### DIFF
--- a/src/services/quotes/__tests__/quotes.test.ts
+++ b/src/services/quotes/__tests__/quotes.test.ts
@@ -1,0 +1,232 @@
+import {
+  fetchCoinGeckoQuote,
+  fetchYahooQuote,
+  refreshQuotes,
+  resolveQuote,
+} from "@/src/services/quotes";
+import type { Asset } from "@/src/types";
+
+const reliance: Asset = {
+  assetClass: "stock",
+  currency: "INR",
+  exchange: "NSE",
+  id: "asset-reliance",
+  name: "Reliance Industries",
+  symbol: "RELIANCE",
+  ticker: "RELIANCE.NS",
+};
+
+const niftyBees: Asset = {
+  assetClass: "etf",
+  currency: "INR",
+  exchange: "NSE",
+  id: "asset-niftybees",
+  name: "Nippon India ETF Nifty Bees",
+  symbol: "NIFTYBEES",
+  ticker: "NIFTYBEES.NS",
+};
+
+const bitcoin: Asset = {
+  assetClass: "crypto",
+  currency: "INR",
+  exchange: "CRYPTO",
+  id: "asset-btc",
+  name: "Bitcoin",
+  symbol: "BTC",
+  ticker: "bitcoin",
+};
+
+function response(payload: unknown, ok = true): Response {
+  return {
+    json: jest.fn().mockResolvedValue(payload),
+    ok,
+    status: ok ? 200 : 500,
+  } as unknown as Response;
+}
+
+describe("Yahoo quote service", () => {
+  it("maps a Yahoo chart response to an INR quote", async () => {
+    const fetcher = jest.fn().mockResolvedValue(
+      response({
+        chart: {
+          result: [
+            {
+              meta: {
+                chartPreviousClose: 2850,
+                currency: "INR",
+                regularMarketPrice: 2910,
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = await fetchYahooQuote({
+      asset: reliance,
+      fetcher,
+      now: () => "2026-04-26T10:00:00.000Z",
+    });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://query1.finance.yahoo.com/v8/finance/chart/RELIANCE.NS?range=1d&interval=1d",
+    );
+    expect(result).toEqual({
+      ok: true,
+      quote: {
+        assetId: reliance.id,
+        asOf: "2026-04-26T10:00:00.000Z",
+        currency: "INR",
+        dayChangeAbs: 60,
+        dayChangePct: 2.11,
+        price: 2910,
+        source: "yahoo",
+      },
+    });
+  });
+
+  it("returns an error result instead of throwing on Yahoo failure", async () => {
+    const result = await fetchYahooQuote({
+      asset: reliance,
+      fetcher: jest.fn().mockResolvedValue(response({}, false)),
+    });
+
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("CoinGecko quote service", () => {
+  it("maps a CoinGecko simple price response to an INR quote", async () => {
+    const fetcher = jest.fn().mockResolvedValue(
+      response({
+        bitcoin: {
+          inr: 5800000,
+          inr_24h_change: 1.234,
+        },
+      }),
+    );
+
+    const result = await fetchCoinGeckoQuote({
+      asset: bitcoin,
+      fetcher,
+      now: () => "2026-04-26T10:00:00.000Z",
+    });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=inr&include_24hr_change=true",
+    );
+    expect(result).toEqual({
+      ok: true,
+      quote: {
+        assetId: bitcoin.id,
+        asOf: "2026-04-26T10:00:00.000Z",
+        currency: "INR",
+        dayChangePct: 1.23,
+        price: 5800000,
+        source: "coingecko",
+      },
+    });
+  });
+});
+
+describe("quote resolver", () => {
+  it("chooses Yahoo for stocks and ETFs", async () => {
+    const fetcher = jest.fn().mockResolvedValue(
+      response({
+        chart: {
+          result: [
+            {
+              meta: {
+                chartPreviousClose: 100,
+                currency: "INR",
+                regularMarketPrice: 101,
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    const stockResult = await resolveQuote({ asset: reliance, fetcher });
+    const etfResult = await resolveQuote({ asset: niftyBees, fetcher });
+
+    expect(stockResult.ok).toBe(true);
+    expect(etfResult.ok).toBe(true);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("chooses CoinGecko for crypto", async () => {
+    const fetcher = jest.fn().mockResolvedValue(
+      response({
+        bitcoin: {
+          inr: 5800000,
+        },
+      }),
+    );
+
+    const result = await resolveQuote({ asset: bitcoin, fetcher });
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.quote.source).toBe("coingecko");
+  });
+
+  it("uses manual fallback when provider fetch fails", async () => {
+    const result = await resolveQuote({
+      asset: reliance,
+      fetcher: jest.fn().mockResolvedValue(response({}, false)),
+      manualPrice: 2800,
+      now: () => "2026-04-26T10:00:00.000Z",
+    });
+
+    expect(result).toEqual({
+      error: "Yahoo quote request failed with status 500.",
+      fallbackQuote: {
+        assetId: reliance.id,
+        asOf: "2026-04-26T10:00:00.000Z",
+        currency: "INR",
+        price: 2800,
+        source: "manual",
+      },
+      ok: false,
+    });
+  });
+
+  it("refreshes multiple quotes and separates failures from quote cache", async () => {
+    const fetcher = jest
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          chart: {
+            result: [
+              {
+                meta: {
+                  chartPreviousClose: 100,
+                  currency: "INR",
+                  regularMarketPrice: 101,
+                },
+              },
+            ],
+          },
+        }),
+      )
+      .mockResolvedValueOnce(response({}, false));
+
+    const result = await refreshQuotes({
+      assets: [reliance, niftyBees],
+      fetcher,
+      manualPrices: {
+        [niftyBees.id]: 250,
+      },
+      now: () => "2026-04-26T10:00:00.000Z",
+    });
+
+    expect(result.quoteCache[reliance.id]?.source).toBe("yahoo");
+    expect(result.quoteCache[niftyBees.id]?.source).toBe("manual");
+    expect(result.failures).toEqual([
+      {
+        assetId: niftyBees.id,
+        error: "Yahoo quote request failed with status 500.",
+      },
+    ]);
+  });
+});

--- a/src/services/quotes/__tests__/useQuoteRefresh.test.tsx
+++ b/src/services/quotes/__tests__/useQuoteRefresh.test.tsx
@@ -1,0 +1,65 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import { useQuoteRefresh } from "@/src/services/quotes";
+import type { Asset } from "@/src/types";
+
+const reliance: Asset = {
+  assetClass: "stock",
+  currency: "INR",
+  exchange: "NSE",
+  id: "asset-reliance",
+  name: "Reliance Industries",
+  symbol: "RELIANCE",
+  ticker: "RELIANCE.NS",
+};
+
+function response(payload: unknown): Response {
+  return {
+    json: jest.fn().mockResolvedValue(payload),
+    ok: true,
+    status: 200,
+  } as unknown as Response;
+}
+
+describe("useQuoteRefresh", () => {
+  it("refreshes quotes and exposes quote cache and failures", async () => {
+    const fetcher = jest.fn().mockResolvedValue(
+      response({
+        chart: {
+          result: [
+            {
+              meta: {
+                chartPreviousClose: 100,
+                currency: "INR",
+                regularMarketPrice: 101,
+              },
+            },
+          ],
+        },
+      }),
+    );
+    const { result } = renderHook(() =>
+      useQuoteRefresh({
+        assets: [reliance],
+        fetcher,
+        now: () => "2026-04-26T10:00:00.000Z",
+      }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.isRefreshing).toBe(false);
+    expect(result.current.failures).toEqual([]);
+    expect(result.current.quoteCache[reliance.id]).toEqual({
+      assetId: reliance.id,
+      asOf: "2026-04-26T10:00:00.000Z",
+      currency: "INR",
+      dayChangeAbs: 1,
+      dayChangePct: 1,
+      price: 101,
+      source: "yahoo",
+    });
+  });
+});

--- a/src/services/quotes/coinGecko.ts
+++ b/src/services/quotes/coinGecko.ts
@@ -1,0 +1,76 @@
+import type { QuoteProviderInput, QuoteResult } from "./types";
+import {
+  coinGeckoSimplePriceUrl,
+  defaultNow,
+  getDefaultFetcher,
+  roundQuoteNumber,
+} from "./utils";
+
+type CoinGeckoSimplePriceResponse = Record<
+  string,
+  {
+    inr?: number;
+    inr_24h_change?: number;
+  }
+>;
+
+export function buildCoinGeckoSimplePriceUrl(coinId: string) {
+  const params = new URLSearchParams({
+    ids: coinId,
+    vs_currencies: "inr",
+    include_24hr_change: "true",
+  });
+
+  return `${coinGeckoSimplePriceUrl}?${params.toString()}`;
+}
+
+export async function fetchCoinGeckoQuote({
+  asset,
+  fetcher = getDefaultFetcher(),
+  now = defaultNow,
+}: QuoteProviderInput): Promise<QuoteResult> {
+  try {
+    const response = await fetcher(buildCoinGeckoSimplePriceUrl(asset.ticker));
+
+    if (!response.ok) {
+      return {
+        error: `CoinGecko quote request failed with status ${response.status}.`,
+        ok: false,
+      };
+    }
+
+    const payload = (await response.json()) as CoinGeckoSimplePriceResponse;
+    const coinPrice = payload[asset.ticker];
+    const price = coinPrice?.inr;
+
+    if (typeof price !== "number") {
+      return {
+        error: "CoinGecko quote response did not include an INR price.",
+        ok: false,
+      };
+    }
+
+    return {
+      ok: true,
+      quote: {
+        assetId: asset.id,
+        asOf: now(),
+        currency: "INR",
+        dayChangePct:
+          typeof coinPrice.inr_24h_change === "number"
+            ? roundQuoteNumber(coinPrice.inr_24h_change)
+            : undefined,
+        price,
+        source: "coingecko",
+      },
+    };
+  } catch (error) {
+    return {
+      error:
+        error instanceof Error
+          ? error.message
+          : "CoinGecko quote request failed.",
+      ok: false,
+    };
+  }
+}

--- a/src/services/quotes/index.ts
+++ b/src/services/quotes/index.ts
@@ -1,1 +1,19 @@
-export {};
+export {
+  buildCoinGeckoSimplePriceUrl,
+  fetchCoinGeckoQuote,
+} from "./coinGecko";
+export { refreshQuotes, resolveQuote } from "./quoteResolver";
+export type {
+  QuoteFailure,
+  QuoteFetcher,
+  QuoteProviderInput,
+  QuoteRefreshFailure,
+  QuoteRefreshResult,
+  QuoteResult,
+  QuoteSuccess,
+  RefreshQuotesInput,
+  ResolveQuoteInput,
+} from "./types";
+export { useQuoteRefresh } from "./useQuoteRefresh";
+export { createManualQuote } from "./utils";
+export { buildYahooChartUrl, fetchYahooQuote } from "./yahooFinance";

--- a/src/services/quotes/quoteResolver.ts
+++ b/src/services/quotes/quoteResolver.ts
@@ -1,0 +1,74 @@
+import type { QuoteCache } from "@/src/types";
+
+import type {
+  QuoteRefreshFailure,
+  QuoteResult,
+  RefreshQuotesInput,
+  ResolveQuoteInput,
+} from "./types";
+import { fetchCoinGeckoQuote } from "./coinGecko";
+import { fetchYahooQuote } from "./yahooFinance";
+import { createManualQuote } from "./utils";
+
+export async function resolveQuote({
+  asset,
+  fetcher,
+  manualPrice,
+  now,
+}: ResolveQuoteInput): Promise<QuoteResult> {
+  const result =
+    asset.assetClass === "crypto"
+      ? await fetchCoinGeckoQuote({ asset, fetcher, now })
+      : await fetchYahooQuote({ asset, fetcher, now });
+
+  if (result.ok || manualPrice === undefined) {
+    return result;
+  }
+
+  return {
+    ...result,
+    fallbackQuote: createManualQuote({ asset, now, price: manualPrice }),
+  };
+}
+
+export async function refreshQuotes({
+  assets,
+  fetcher,
+  manualPrices = {},
+  now,
+}: RefreshQuotesInput) {
+  const quoteCache: QuoteCache = {};
+  const failures: QuoteRefreshFailure[] = [];
+
+  for (const asset of assets) {
+    if (asset.assetClass === "cash") {
+      continue;
+    }
+
+    const result = await resolveQuote({
+      asset,
+      fetcher,
+      manualPrice: manualPrices[asset.id],
+      now,
+    });
+
+    if (result.ok) {
+      quoteCache[asset.id] = result.quote;
+      continue;
+    }
+
+    failures.push({
+      assetId: asset.id,
+      error: result.error,
+    });
+
+    if (result.fallbackQuote) {
+      quoteCache[asset.id] = result.fallbackQuote;
+    }
+  }
+
+  return {
+    failures,
+    quoteCache,
+  };
+}

--- a/src/services/quotes/types.ts
+++ b/src/services/quotes/types.ts
@@ -1,0 +1,48 @@
+import type { Asset, Quote, QuoteCache } from "@/src/types";
+
+export type QuoteFetcher = (
+  input: string,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export type QuoteNow = () => string;
+
+export type QuoteSuccess = {
+  ok: true;
+  quote: Quote;
+};
+
+export type QuoteFailure = {
+  error: string;
+  fallbackQuote?: Quote;
+  ok: false;
+};
+
+export type QuoteResult = QuoteSuccess | QuoteFailure;
+
+export type QuoteProviderInput = {
+  asset: Asset;
+  fetcher?: QuoteFetcher;
+  now?: QuoteNow;
+};
+
+export type ResolveQuoteInput = QuoteProviderInput & {
+  manualPrice?: number;
+};
+
+export type RefreshQuotesInput = {
+  assets: Asset[];
+  fetcher?: QuoteFetcher;
+  manualPrices?: Record<string, number>;
+  now?: QuoteNow;
+};
+
+export type QuoteRefreshFailure = {
+  assetId: string;
+  error: string;
+};
+
+export type QuoteRefreshResult = {
+  failures: QuoteRefreshFailure[];
+  quoteCache: QuoteCache;
+};

--- a/src/services/quotes/useQuoteRefresh.ts
+++ b/src/services/quotes/useQuoteRefresh.ts
@@ -1,0 +1,39 @@
+import { useState } from "react";
+
+import type { QuoteCache } from "@/src/types";
+
+import { refreshQuotes } from "./quoteResolver";
+import type {
+  QuoteRefreshFailure,
+  RefreshQuotesInput,
+} from "./types";
+
+type UseQuoteRefreshInput = RefreshQuotesInput;
+
+export function useQuoteRefresh(input: UseQuoteRefreshInput) {
+  const [quoteCache, setQuoteCache] = useState<QuoteCache>({});
+  const [failures, setFailures] = useState<QuoteRefreshFailure[]>([]);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  async function refresh() {
+    setIsRefreshing(true);
+
+    try {
+      const result = await refreshQuotes(input);
+
+      setQuoteCache(result.quoteCache);
+      setFailures(result.failures);
+
+      return result;
+    } finally {
+      setIsRefreshing(false);
+    }
+  }
+
+  return {
+    failures,
+    isRefreshing,
+    quoteCache,
+    refresh,
+  };
+}

--- a/src/services/quotes/utils.ts
+++ b/src/services/quotes/utils.ts
@@ -1,0 +1,44 @@
+import type { Asset, Quote } from "@/src/types";
+
+import type { QuoteFetcher, QuoteNow } from "./types";
+
+export const yahooChartBaseUrl =
+  "https://query1.finance.yahoo.com/v8/finance/chart";
+export const coinGeckoSimplePriceUrl =
+  "https://api.coingecko.com/api/v3/simple/price";
+
+export function defaultNow() {
+  return new Date().toISOString();
+}
+
+export function getDefaultFetcher(): QuoteFetcher {
+  if (typeof fetch !== "function") {
+    throw new Error("Global fetch is not available.");
+  }
+
+  return fetch;
+}
+
+export function roundQuoteNumber(value: number, decimals = 2) {
+  const factor = 10 ** decimals;
+
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+export function createManualQuote({
+  asset,
+  now = defaultNow,
+  price,
+}: {
+  asset: Asset;
+  now?: QuoteNow;
+  price: number;
+}): Quote {
+  return {
+    assetId: asset.id,
+    asOf: now(),
+    currency: "INR",
+    price,
+    source: "manual",
+  };
+}

--- a/src/services/quotes/yahooFinance.ts
+++ b/src/services/quotes/yahooFinance.ts
@@ -1,0 +1,88 @@
+import type { QuoteProviderInput, QuoteResult } from "./types";
+import {
+  defaultNow,
+  getDefaultFetcher,
+  roundQuoteNumber,
+  yahooChartBaseUrl,
+} from "./utils";
+
+type YahooChartResponse = {
+  chart?: {
+    result?: Array<{
+      meta?: {
+        chartPreviousClose?: number;
+        currency?: string;
+        regularMarketPrice?: number;
+      };
+    }>;
+  };
+};
+
+export function buildYahooChartUrl(ticker: string) {
+  return `${yahooChartBaseUrl}/${encodeURIComponent(
+    ticker,
+  )}?range=1d&interval=1d`;
+}
+
+export async function fetchYahooQuote({
+  asset,
+  fetcher = getDefaultFetcher(),
+  now = defaultNow,
+}: QuoteProviderInput): Promise<QuoteResult> {
+  try {
+    const response = await fetcher(buildYahooChartUrl(asset.ticker));
+
+    if (!response.ok) {
+      return {
+        error: `Yahoo quote request failed with status ${response.status}.`,
+        ok: false,
+      };
+    }
+
+    const payload = (await response.json()) as YahooChartResponse;
+    const meta = payload.chart?.result?.[0]?.meta;
+    const price = meta?.regularMarketPrice;
+
+    if (typeof price !== "number") {
+      return {
+        error: "Yahoo quote response did not include a current price.",
+        ok: false,
+      };
+    }
+
+    const previousClose = meta?.chartPreviousClose;
+    const dayChangeAbs =
+      typeof previousClose === "number" ? price - previousClose : undefined;
+    const dayChangePct =
+      typeof previousClose === "number" && previousClose !== 0
+        ? (dayChangeAbs! / previousClose) * 100
+        : undefined;
+
+    return {
+      ok: true,
+      quote: {
+        assetId: asset.id,
+        asOf: now(),
+        currency: "INR",
+        dayChangeAbs:
+          dayChangeAbs === undefined
+            ? undefined
+            : roundQuoteNumber(dayChangeAbs),
+        dayChangePct:
+          dayChangePct === undefined
+            ? undefined
+            : roundQuoteNumber(dayChangePct),
+        price,
+        source: "yahoo",
+      },
+    };
+  } catch (error) {
+    return {
+      error:
+        error instanceof Error
+          ? error.message
+          : "Yahoo quote request failed.",
+      ok: false,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Add Yahoo Finance chart quote client for Indian stocks and ETFs.
- Add CoinGecko simple price quote client for crypto INR prices.
- Add quote resolver that chooses provider by asset class and returns manual fallback quotes on provider failure.
- Add batch quote refresh helper with quote cache and failure collection.
- Add useQuoteRefresh hook for app-open/pull-to-refresh integration in later screens.

## Validation
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm audit --audit-level=high
- npx expo start --offline --port 8085 startup smoke

## Notes
- Network calls are covered with injected fetch mocks; no live external APIs are called by tests.
- Full npm audit still reports the known 13 moderate Expo transitive uuid findings; high-severity audit gate passes.

Closes #5