### PR TITLE
ci: add default PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Typecheck, test, and Expo doctor
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test -- --runInBand
+
+      - name: Expo doctor
+        run: npm run doctor

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^29.5.14",
         "@types/react": "~19.1.0",
+        "expo-doctor": "^1.18.19",
         "jest": "^29.7.0",
         "jest-expo": "~54.0.16",
         "react-test-renderer": "19.1.0",
@@ -6967,6 +6968,16 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-doctor": {
+      "version": "1.18.19",
+      "resolved": "https://registry.npmjs.org/expo-doctor/-/expo-doctor-1.18.19.tgz",
+      "integrity": "sha512-rCqPhHc4cR76C7s/RBDTYXiJ1658ZyIeOQVQPqetTQ3LIo7jIhlvh3Kdomq34CToq+hHgg3AzVTS4VhY81t8oQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "expo-doctor": "build/index.js"
       }
     },
     "node_modules/expo-font": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",
-    "doctor": "npx expo-doctor",
+    "doctor": "expo-doctor",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },
@@ -50,6 +50,7 @@
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.14",
     "@types/react": "~19.1.0",
+    "expo-doctor": "^1.18.19",
     "jest": "^29.7.0",
     "jest-expo": "~54.0.16",
     "react-test-renderer": "19.1.0",


### PR DESCRIPTION
## Summary
- Add a default GitHub Actions CI workflow for PRs into main and pushes to main.
- Run the V1 default quality gates in CI: npm ci, typecheck, Jest, and Expo doctor.
- Pin expo-doctor as a dev dependency and use the local binary from npm run doctor.

## Validation
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm audit --audit-level=high

Closes #34