### PR TITLE
feat: build add trade screen

### DIFF
--- a/app/(tabs)/add-trade.tsx
+++ b/app/(tabs)/add-trade.tsx
@@ -1,5 +1,5 @@
-import { PlaceholderScreen } from "@/src/components/common/PlaceholderScreen";
+import { AddTradeForm } from "@/src/features/trades";
 
 export default function AddTradeScreen() {
-  return <PlaceholderScreen title="Add Trade" />;
+  return <AddTradeForm />;
 }

--- a/src/components/common/ScreenContainer.tsx
+++ b/src/components/common/ScreenContainer.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
-import { SafeAreaView, ScrollView, StyleSheet, View } from "react-native";
+import { ScrollView, StyleSheet, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 import { colors, spacing } from "@/src/theme";
 

--- a/src/components/forms/FormTextField.tsx
+++ b/src/components/forms/FormTextField.tsx
@@ -1,0 +1,74 @@
+import type { KeyboardTypeOptions } from "react-native";
+import { StyleSheet, TextInput, View } from "react-native";
+
+import { AppText } from "@/src/components/common";
+import { colors, radii, spacing } from "@/src/theme";
+
+type FormTextFieldProps = {
+  error?: string;
+  keyboardType?: KeyboardTypeOptions;
+  label: string;
+  multiline?: boolean;
+  onChangeText: (value: string) => void;
+  placeholder?: string;
+  value: string;
+};
+
+export function FormTextField({
+  error,
+  keyboardType,
+  label,
+  multiline = false,
+  onChangeText,
+  placeholder,
+  value,
+}: FormTextFieldProps) {
+  return (
+    <View style={styles.container}>
+      <AppText color="secondary" variant="caption" weight="medium">
+        {label}
+      </AppText>
+      <TextInput
+        accessibilityLabel={label}
+        keyboardType={keyboardType}
+        multiline={multiline}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor={colors.text.muted}
+        style={[styles.input, multiline && styles.multiline, error && styles.invalid]}
+        value={value}
+      />
+      {error ? (
+        <AppText selectable style={styles.errorText} variant="caption">
+          {error}
+        </AppText>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.xs,
+  },
+  input: {
+    backgroundColor: colors.surface.elevated,
+    borderColor: colors.border.subtle,
+    borderRadius: radii.card,
+    borderWidth: 1,
+    color: colors.text.primary,
+    minHeight: 48,
+    paddingHorizontal: spacing.cardInner,
+    paddingVertical: spacing.sm,
+  },
+  invalid: {
+    borderColor: colors.loss,
+  },
+  errorText: {
+    color: colors.loss,
+  },
+  multiline: {
+    minHeight: 88,
+    textAlignVertical: "top",
+  },
+});

--- a/src/components/forms/index.ts
+++ b/src/components/forms/index.ts
@@ -1,1 +1,1 @@
-export {};
+export { FormTextField } from "./FormTextField";

--- a/src/features/trades/__tests__/AddTradeForm.test.tsx
+++ b/src/features/trades/__tests__/AddTradeForm.test.tsx
@@ -1,0 +1,124 @@
+import * as Haptics from "expo-haptics";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+
+import { AddTradeForm } from "@/src/features/trades/add-trade-form";
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import { createPortfolioStore } from "@/src/store";
+import type { Asset, Trade } from "@/src/types";
+
+jest.mock("expo-haptics", () => ({
+  notificationAsync: jest.fn(),
+  NotificationFeedbackType: {
+    Success: "success",
+  },
+}));
+
+const existingAsset: Asset = {
+  assetClass: "stock",
+  currency: "INR",
+  exchange: "NSE",
+  id: "asset-reliance",
+  name: "Reliance Industries",
+  symbol: "RELIANCE",
+  ticker: "RELIANCE.NS",
+};
+
+const existingBuy: Trade = {
+  assetId: existingAsset.id,
+  date: "2026-04-20",
+  id: "trade-existing",
+  pricePerUnit: 100,
+  quantity: 1,
+  totalValue: 100,
+  type: "buy",
+};
+
+describe("AddTradeForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates a manual asset and persists a reviewed buy trade", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const { getByLabelText, getByText } = render(<AddTradeForm store={store} />);
+
+    fireEvent.changeText(getByLabelText("Asset name"), "Reliance Industries");
+    fireEvent.changeText(getByLabelText("Symbol"), "RELIANCE");
+    fireEvent.changeText(getByLabelText("Ticker"), "RELIANCE.NS");
+    fireEvent.changeText(getByLabelText("Quantity"), "2");
+    fireEvent.changeText(getByLabelText("Price per unit"), "100");
+    fireEvent.changeText(getByLabelText("Fees"), "5");
+    fireEvent.changeText(getByLabelText("Trade date"), "2026-04-20");
+    fireEvent.changeText(getByLabelText("Conviction"), "4");
+    fireEvent.changeText(getByLabelText("Note"), "Core portfolio add");
+
+    fireEvent.press(getByText("Review Trade"));
+    expect(getByText("Review buy")).toBeTruthy();
+    expect(getByText("Total: ₹205.00")).toBeTruthy();
+
+    fireEvent.press(getByText("Confirm Trade"));
+
+    await waitFor(() => {
+      expect(store.getState().assets).toHaveLength(1);
+      expect(store.getState().trades).toHaveLength(1);
+    });
+
+    expect(store.getState().assets[0]).toMatchObject({
+      name: "Reliance Industries",
+      symbol: "RELIANCE",
+      ticker: "RELIANCE.NS",
+    });
+    expect(store.getState().trades[0]).toMatchObject({
+      assetId: store.getState().assets[0].id,
+      conviction: 4,
+      fees: 5,
+      notes: "Core portfolio add",
+      pricePerUnit: 100,
+      quantity: 2,
+      totalValue: 205,
+      type: "buy",
+    });
+    expect(store.getState().quoteCache[store.getState().assets[0].id]).toMatchObject({
+      price: 100,
+      source: "manual",
+    });
+    expect(Haptics.notificationAsync).toHaveBeenCalledWith("success");
+    expect(getByText("Trade logged.")).toBeTruthy();
+  });
+
+  it("shows an actionable error for invalid sell quantity", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset(existingAsset);
+    store.getState().addTrade(existingBuy);
+
+    const { getByLabelText, getByText } = render(<AddTradeForm store={store} />);
+
+    fireEvent.press(getByText("Sell"));
+    fireEvent.press(getByText("RELIANCE"));
+    fireEvent.changeText(getByLabelText("Quantity"), "2");
+    fireEvent.changeText(getByLabelText("Price per unit"), "100");
+    fireEvent.changeText(getByLabelText("Trade date"), "2026-04-20");
+    fireEvent.press(getByText("Review Trade"));
+
+    expect(getByText("Sell quantity exceeds available units.")).toBeTruthy();
+    expect(store.getState().trades).toEqual([existingBuy]);
+  });
+
+  it("prefills existing asset price from the quote cache", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset(existingAsset);
+    store.getState().upsertQuote({
+      asOf: "2026-04-20T10:00:00.000Z",
+      assetId: existingAsset.id,
+      currency: "INR",
+      price: 123.45,
+      source: "yahoo",
+    });
+
+    const { getByDisplayValue, getByText } = render(<AddTradeForm store={store} />);
+
+    fireEvent.press(getByText("RELIANCE"));
+
+    expect(getByDisplayValue("123.45")).toBeTruthy();
+  });
+});

--- a/src/features/trades/add-trade-form.tsx
+++ b/src/features/trades/add-trade-form.tsx
@@ -1,0 +1,477 @@
+import * as Haptics from "expo-haptics";
+import { useMemo, useState, useSyncExternalStore } from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import type { StoreApi } from "zustand/vanilla";
+
+import { AppButton, AppText, ScreenContainer } from "@/src/components/common";
+import { FormTextField } from "@/src/components/forms";
+import { validateTradeForm } from "@/src/features/trades/tradeForm";
+import { colors, interaction, radii, spacing } from "@/src/theme";
+import type { Asset, ConvictionScore, Trade, TradeType } from "@/src/types";
+import { createId } from "@/src/utils";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+
+type AddTradeFormProps = {
+  store?: StoreApi<PortfolioStoreState>;
+};
+
+type FieldErrors = Partial<Record<string, string>>;
+
+const manualAssetId = "__manual_asset__";
+
+function todayInputValue() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
+  return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+}
+
+export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps) {
+  const snapshot = usePortfolioSnapshot(store);
+  const [type, setType] = useState<TradeType>("buy");
+  const [selectedAssetId, setSelectedAssetId] = useState("");
+  const [assetName, setAssetName] = useState("");
+  const [symbol, setSymbol] = useState("");
+  const [ticker, setTicker] = useState("");
+  const [quantity, setQuantity] = useState("");
+  const [pricePerUnit, setPricePerUnit] = useState("");
+  const [fees, setFees] = useState("");
+  const [date, setDate] = useState(todayInputValue());
+  const [conviction, setConviction] = useState("");
+  const [notes, setNotes] = useState("");
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [reviewTrade, setReviewTrade] = useState<Trade | undefined>();
+  const [reviewAsset, setReviewAsset] = useState<Asset | undefined>();
+  const [successMessage, setSuccessMessage] = useState("");
+
+  const selectedAsset = useMemo(
+    () => snapshot.assets.find((asset) => asset.id === selectedAssetId),
+    [selectedAssetId, snapshot.assets],
+  );
+  const isManualAsset = !selectedAsset;
+
+  function resetReview() {
+    setReviewTrade(undefined);
+    setReviewAsset(undefined);
+    setSuccessMessage("");
+  }
+
+  function updateType(nextType: TradeType) {
+    setType(nextType);
+    resetReview();
+  }
+
+  function selectAsset(asset: Asset) {
+    const quote = snapshot.quoteCache[asset.id];
+
+    setSelectedAssetId(asset.id);
+    setAssetName(asset.name);
+    setSymbol(asset.symbol);
+    setTicker(asset.ticker);
+    if (quote) {
+      setPricePerUnit(quote.price.toString());
+    }
+    resetReview();
+  }
+
+  function buildManualAsset(): Asset {
+    return {
+      assetClass: "stock",
+      currency: "INR",
+      exchange: "NSE",
+      id: createId("asset"),
+      name: assetName.trim(),
+      symbol: symbol.trim().toUpperCase(),
+      ticker: ticker.trim().toUpperCase(),
+    };
+  }
+
+  function validateManualAsset() {
+    const nextErrors: FieldErrors = {};
+
+    if (isManualAsset && assetName.trim().length === 0) {
+      nextErrors.assetName = "Asset name is required.";
+    }
+
+    if (isManualAsset && symbol.trim().length === 0) {
+      nextErrors.symbol = "Symbol is required.";
+    }
+
+    if (isManualAsset && ticker.trim().length === 0) {
+      nextErrors.ticker = "Ticker is required.";
+    }
+
+    if (type === "sell" && isManualAsset) {
+      nextErrors.assetName = "Select an existing holding to sell.";
+    }
+
+    return nextErrors;
+  }
+
+  function handleReview() {
+    resetReview();
+    const manualErrors = validateManualAsset();
+    const formAssetId = selectedAsset?.id ?? manualAssetId;
+    const result = validateTradeForm(
+      {
+        assetId: formAssetId,
+        conviction,
+        date,
+        pricePerUnit,
+        quantity,
+        type,
+      },
+      snapshot.trades,
+    );
+
+    if (!result.isValid || Object.keys(manualErrors).length > 0) {
+      setErrors({
+        ...manualErrors,
+        ...result.isValid ? {} : result.errors,
+      });
+      return;
+    }
+
+    const asset = selectedAsset ?? buildManualAsset();
+    const feeValue = fees.trim().length > 0 ? Number(fees) : 0;
+
+    if (!Number.isFinite(feeValue) || feeValue < 0) {
+      setErrors({ fees: "Fees must be zero or greater." });
+      return;
+    }
+
+    const grossValue = result.value.quantity * result.value.pricePerUnit;
+    const totalValue =
+      result.value.type === "buy" ? grossValue + feeValue : grossValue - feeValue;
+
+    setErrors({});
+    setReviewAsset(asset);
+    setReviewTrade({
+      assetId: asset.id,
+      conviction: result.value.conviction as ConvictionScore | undefined,
+      date: result.value.date,
+      fees: feeValue || undefined,
+      id: createId("trade"),
+      notes: notes.trim() || undefined,
+      pricePerUnit: result.value.pricePerUnit,
+      quantity: result.value.quantity,
+      totalValue,
+      type: result.value.type,
+    });
+  }
+
+  async function handleConfirm() {
+    if (!reviewTrade || !reviewAsset) {
+      return;
+    }
+
+    if (!selectedAsset) {
+      store.getState().addAsset(reviewAsset);
+    }
+
+    store.getState().addTrade(reviewTrade);
+    store.getState().upsertQuote({
+      asOf: new Date().toISOString(),
+      assetId: reviewAsset.id,
+      currency: "INR",
+      price: reviewTrade.pricePerUnit,
+      source: "manual",
+    });
+    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    setSuccessMessage("Trade logged.");
+    setReviewTrade(undefined);
+  }
+
+  return (
+    <ScreenContainer scroll testID="add-trade-screen">
+      <View style={styles.header}>
+        <AppText variant="title" weight="bold">
+          Add Trade
+        </AppText>
+        <AppText color="secondary">
+          Log a buy or sell in under a minute. Holdings stay local.
+        </AppText>
+      </View>
+
+      <View style={styles.segmentedControl}>
+        {(["buy", "sell"] as const).map((tradeType) => (
+          <Pressable
+            accessibilityRole="button"
+            key={tradeType}
+            onPress={() => updateType(tradeType)}
+            style={({ pressed }) => [
+              styles.segment,
+              type === tradeType && styles.segmentActive,
+              pressed && styles.pressed,
+            ]}
+          >
+            <AppText
+              color={type === tradeType ? "inverse" : "secondary"}
+              weight="bold"
+            >
+              {tradeType === "buy" ? "Buy" : "Sell"}
+            </AppText>
+          </Pressable>
+        ))}
+      </View>
+
+      {snapshot.assets.length > 0 ? (
+        <View style={styles.card}>
+          <AppText color="secondary" variant="caption" weight="medium">
+            Existing assets
+          </AppText>
+          <View style={styles.assetGrid}>
+            {snapshot.assets.map((asset) => (
+              <Pressable
+                key={asset.id}
+                onPress={() => selectAsset(asset)}
+                style={({ pressed }) => [
+                  styles.assetChip,
+                  selectedAssetId === asset.id && styles.assetChipActive,
+                  pressed && styles.pressed,
+                ]}
+              >
+                <AppText weight="bold">{asset.symbol}</AppText>
+                <AppText color="secondary" variant="caption">
+                  {asset.name}
+                </AppText>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+      ) : null}
+
+      <View style={styles.card}>
+        <AppText variant="body" weight="bold">
+          Asset
+        </AppText>
+        <FormTextField
+          error={errors.assetName}
+          label="Asset name"
+          onChangeText={(value) => {
+            setAssetName(value);
+            setSelectedAssetId("");
+            resetReview();
+          }}
+          placeholder="Reliance Industries"
+          value={assetName}
+        />
+        <View style={styles.row}>
+          <View style={styles.flex}>
+            <FormTextField
+              error={errors.symbol}
+              label="Symbol"
+              onChangeText={(value) => {
+                setSymbol(value);
+                setSelectedAssetId("");
+                resetReview();
+              }}
+              placeholder="RELIANCE"
+              value={symbol}
+            />
+          </View>
+          <View style={styles.flex}>
+            <FormTextField
+              error={errors.ticker}
+              label="Ticker"
+              onChangeText={(value) => {
+                setTicker(value);
+                setSelectedAssetId("");
+                resetReview();
+              }}
+              placeholder="RELIANCE.NS"
+              value={ticker}
+            />
+          </View>
+        </View>
+      </View>
+
+      <View style={styles.card}>
+        <AppText variant="body" weight="bold">
+          Trade details
+        </AppText>
+        <View style={styles.row}>
+          <View style={styles.flex}>
+            <FormTextField
+              error={errors.quantity}
+              keyboardType="decimal-pad"
+              label="Quantity"
+              onChangeText={(value) => {
+                setQuantity(value);
+                resetReview();
+              }}
+              placeholder="2"
+              value={quantity}
+            />
+          </View>
+          <View style={styles.flex}>
+            <FormTextField
+              error={errors.pricePerUnit}
+              keyboardType="decimal-pad"
+              label="Price per unit"
+              onChangeText={(value) => {
+                setPricePerUnit(value);
+                resetReview();
+              }}
+              placeholder="100"
+              value={pricePerUnit}
+            />
+          </View>
+        </View>
+        <View style={styles.row}>
+          <View style={styles.flex}>
+            <FormTextField
+              error={errors.fees}
+              keyboardType="decimal-pad"
+              label="Fees"
+              onChangeText={(value) => {
+                setFees(value);
+                resetReview();
+              }}
+              placeholder="0"
+              value={fees}
+            />
+          </View>
+          <View style={styles.flex}>
+            <FormTextField
+              error={errors.date}
+              label="Trade date"
+              onChangeText={(value) => {
+                setDate(value);
+                resetReview();
+              }}
+              placeholder="YYYY-MM-DD"
+              value={date}
+            />
+          </View>
+        </View>
+        <FormTextField
+          error={errors.conviction}
+          keyboardType="number-pad"
+          label="Conviction"
+          onChangeText={(value) => {
+            setConviction(value);
+            resetReview();
+          }}
+          placeholder="Optional 1-5"
+          value={conviction}
+        />
+        <FormTextField
+          label="Note"
+          multiline
+          onChangeText={(value) => {
+            setNotes(value);
+            resetReview();
+          }}
+          placeholder="Optional note"
+          value={notes}
+        />
+      </View>
+
+      {reviewTrade && reviewAsset ? (
+        <View style={styles.reviewCard}>
+          <AppText variant="body" weight="bold">
+            Review {reviewTrade.type}
+          </AppText>
+          <AppText color="secondary">
+            {reviewAsset.symbol} · {reviewTrade.quantity} units @ ₹
+            {reviewTrade.pricePerUnit.toFixed(2)}
+          </AppText>
+          <AppText selectable weight="bold">
+            Total: ₹{reviewTrade.totalValue.toFixed(2)}
+          </AppText>
+        </View>
+      ) : null}
+
+      {successMessage ? (
+        <AppText selectable style={styles.successText}>
+          {successMessage}
+        </AppText>
+      ) : null}
+
+      <View style={styles.actions}>
+        <AppButton title="Review Trade" onPress={handleReview} />
+        <AppButton
+          disabled={!reviewTrade}
+          title="Confirm Trade"
+          onPress={handleConfirm}
+          variant="secondary"
+        />
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  actions: {
+    gap: spacing.sm,
+    paddingBottom: spacing.lg,
+  },
+  assetChip: {
+    backgroundColor: colors.surface.elevated,
+    borderColor: colors.border.subtle,
+    borderRadius: radii.card,
+    borderWidth: 1,
+    gap: spacing.xs,
+    padding: spacing.cardInner,
+    width: "48%",
+  },
+  assetChipActive: {
+    borderColor: colors.primary,
+  },
+  assetGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.sm,
+  },
+  card: {
+    backgroundColor: colors.surface.card,
+    borderColor: colors.border.subtle,
+    borderRadius: radii.card,
+    borderWidth: 1,
+    gap: spacing.cardInner,
+    padding: spacing.cardInner,
+  },
+  flex: {
+    flex: 1,
+  },
+  header: {
+    gap: spacing.xs,
+  },
+  pressed: {
+    opacity: interaction.pressedOpacity,
+  },
+  reviewCard: {
+    backgroundColor: colors.surface.elevated,
+    borderColor: colors.primary,
+    borderRadius: radii.card,
+    borderWidth: 1,
+    gap: spacing.xs,
+    padding: spacing.cardInner,
+  },
+  row: {
+    flexDirection: "row",
+    gap: spacing.sm,
+  },
+  segment: {
+    alignItems: "center",
+    borderRadius: radii.pill,
+    flex: 1,
+    paddingVertical: spacing.cardInner,
+  },
+  segmentActive: {
+    backgroundColor: colors.primary,
+  },
+  segmentedControl: {
+    backgroundColor: colors.surface.card,
+    borderColor: colors.border.subtle,
+    borderRadius: radii.pill,
+    borderWidth: 1,
+    flexDirection: "row",
+    padding: spacing.xs,
+  },
+  successText: {
+    color: colors.profit,
+  },
+});

--- a/src/features/trades/index.ts
+++ b/src/features/trades/index.ts
@@ -1,3 +1,4 @@
+export { AddTradeForm } from "./add-trade-form";
 export {
   createTradeFormSchema,
   tradeFormSchema,


### PR DESCRIPTION
## Summary
- Replace the Add Trade placeholder with a dark Material-style trade entry flow for buy/sell, manual asset creation, existing asset selection, cached price prefill, manual price override, fees, date, optional conviction, notes, review, and confirm.
- Persist confirmed trades and manual assets through the portfolio store, update the manual quote cache, and trigger success haptics.
- Add a reusable form text field and switch ScreenContainer to react-native-safe-area-context.

## Validation
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm audit --audit-level=high
- npx expo start --offline --port 8086 smoke: reached local Metro waiting state, then stopped

Closes #7