### PR TITLE
[V1] Build Holdings screen

### DIFF
--- a/app/(tabs)/holdings.tsx
+++ b/app/(tabs)/holdings.tsx
@@ -1,5 +1,13 @@
-import { PlaceholderScreen } from "@/src/components/common/PlaceholderScreen";
+import { router } from "expo-router";
+
+import { HoldingsScreen as HoldingsFeatureScreen } from "@/src/features/holdings";
 
 export default function HoldingsScreen() {
-  return <PlaceholderScreen title="Holdings" />;
+  return (
+    <HoldingsFeatureScreen
+      onAddTrade={() => {
+        router.push("/(tabs)/add-trade");
+      }}
+    />
+  );
 }

--- a/src/components/cards/HoldingCard.tsx
+++ b/src/components/cards/HoldingCard.tsx
@@ -1,0 +1,105 @@
+import { StyleSheet, View } from "react-native";
+
+import { formatDate, formatINR, formatPercentage } from "@/src/domain/formatters";
+import { colors, radii, shadows, spacing } from "@/src/theme";
+import type { Holding } from "@/src/types";
+
+import { AppText, MaskedValue } from "../common";
+
+type HoldingCardProps = {
+  holding: Holding;
+};
+
+function formatQuantity(value: number) {
+  return Number.isInteger(value) ? value.toString() : value.toFixed(4);
+}
+
+function formatPnL(holding: Holding) {
+  const amount = formatINR(holding.unrealisedPnL);
+  const percentage = formatPercentage(holding.unrealisedPnLPct);
+
+  return `${holding.unrealisedPnL > 0 ? "+" : ""}${amount} (${percentage})`;
+}
+
+export function HoldingCard({ holding }: HoldingCardProps) {
+  const isProfit = holding.unrealisedPnL >= 0;
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <View style={styles.identity}>
+          <AppText variant="title" weight="bold">
+            {holding.asset.name}
+          </AppText>
+          <AppText color="secondary">{holding.asset.symbol}</AppText>
+        </View>
+        <View style={styles.valueBlock}>
+          <MaskedValue
+            align="right"
+            value={formatINR(holding.currentValue)}
+            weight="bold"
+          />
+          <AppText
+            align="right"
+            color={isProfit ? "primary" : "primary"}
+            style={isProfit ? styles.profit : styles.loss}
+          >
+            {formatPnL(holding)}
+          </AppText>
+        </View>
+      </View>
+
+      <View style={styles.metrics}>
+        <AppText color="secondary">Qty {formatQuantity(holding.totalUnits)}</AppText>
+        <AppText color="secondary">
+          Avg {formatINR(holding.averageCostPrice)}
+        </AppText>
+        <AppText color="secondary">
+          Current {formatINR(holding.currentPrice)}
+        </AppText>
+      </View>
+
+      <AppText color="muted" variant="caption">
+        {holding.lastUpdated
+          ? `Updated ${formatDate(holding.lastUpdated)}`
+          : "Quote not refreshed yet"}
+      </AppText>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    ...shadows.none,
+    backgroundColor: colors.surface.card,
+    borderColor: colors.border.subtle,
+    borderRadius: radii.card,
+    borderWidth: 1,
+    gap: spacing.cardInner,
+    padding: spacing.md,
+  },
+  header: {
+    flexDirection: "row",
+    gap: spacing.cardInner,
+    justifyContent: "space-between",
+  },
+  identity: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  loss: {
+    color: colors.loss,
+  },
+  metrics: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.sm,
+  },
+  profit: {
+    color: colors.profit,
+  },
+  valueBlock: {
+    alignItems: "flex-end",
+    gap: spacing.xs,
+  },
+});

--- a/src/components/cards/index.ts
+++ b/src/components/cards/index.ts
@@ -1,1 +1,1 @@
-export {};
+export { HoldingCard } from "./HoldingCard";

--- a/src/components/common/ScreenContainer.tsx
+++ b/src/components/common/ScreenContainer.tsx
@@ -1,17 +1,25 @@
 import type { ReactNode } from "react";
-import { ScrollView, StyleSheet, View } from "react-native";
+import type { ReactElement } from "react";
+import {
+  ScrollView,
+  StyleSheet,
+  View,
+  type RefreshControlProps,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { colors, spacing } from "@/src/theme";
 
 type ScreenContainerProps = {
   children: ReactNode;
+  refreshControl?: ReactElement<RefreshControlProps>;
   scroll?: boolean;
   testID?: string;
 };
 
 export function ScreenContainer({
   children,
+  refreshControl,
   scroll = false,
   testID,
 }: ScreenContainerProps) {
@@ -20,6 +28,7 @@ export function ScreenContainer({
       <SafeAreaView style={styles.safe} testID={testID}>
         <ScrollView
           contentContainerStyle={styles.scrollContent}
+          refreshControl={refreshControl}
           style={styles.scroll}
         >
           {children}

--- a/src/features/holdings/HoldingsScreen.tsx
+++ b/src/features/holdings/HoldingsScreen.tsx
@@ -1,0 +1,110 @@
+import { RefreshControl, StyleSheet, View } from "react-native";
+import type { StoreApi } from "zustand/vanilla";
+
+import { HoldingCard } from "@/src/components/cards";
+import { AppButton, AppText, EmptyState, ScreenContainer } from "@/src/components/common";
+import type { RefreshQuotesInput, QuoteRefreshResult } from "@/src/services/quotes";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import { colors, spacing } from "@/src/theme";
+
+import { useHoldings } from "./useHoldings";
+
+type RefreshQuotes = (
+  input: RefreshQuotesInput,
+) => Promise<QuoteRefreshResult>;
+
+type HoldingsScreenProps = {
+  onAddTrade?: () => void;
+  refreshQuotes?: RefreshQuotes;
+  store?: StoreApi<PortfolioStoreState>;
+};
+
+export function HoldingsScreen({
+  onAddTrade,
+  refreshQuotes,
+  store = getPortfolioStore(),
+}: HoldingsScreenProps) {
+  const { failures, holdings, isRefreshing, refresh } = useHoldings({
+    refreshQuotes,
+    store,
+  });
+
+  return (
+    <ScreenContainer
+      refreshControl={
+        holdings.length > 0 ? (
+          <RefreshControl
+            refreshing={isRefreshing}
+            tintColor={colors.primary}
+            onRefresh={() => {
+              void refresh();
+            }}
+          />
+        ) : undefined
+      }
+      scroll
+      testID="holdings-screen"
+    >
+      <View style={styles.content}>
+        <View style={styles.header}>
+          <View>
+            <AppText color="secondary">Portfolio</AppText>
+            <AppText variant="hero" weight="bold">
+              Holdings
+            </AppText>
+          </View>
+          {holdings.length > 0 ? (
+            <AppButton
+              title="Refresh Quotes"
+              variant="secondary"
+              onPress={() => {
+                void refresh();
+              }}
+            />
+          ) : null}
+        </View>
+
+        {holdings.length === 0 ? (
+          <EmptyState
+            actionLabel={onAddTrade ? "Add Trade" : undefined}
+            message="Holdings are created automatically from your trades."
+            title="No holdings yet"
+            onAction={onAddTrade}
+          />
+        ) : (
+          <View
+            style={styles.list}
+            testID="holdings-list"
+          >
+            {holdings.map((holding) => (
+              <HoldingCard key={holding.asset.id} holding={holding} />
+            ))}
+          </View>
+        )}
+
+        {failures.length > 0 ? (
+          <AppText color="secondary">
+            Some quotes could not refresh. Manual prices remain in use.
+          </AppText>
+        ) : null}
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    gap: spacing.cardGap,
+    paddingBottom: spacing.lg,
+    paddingTop: spacing.md,
+  },
+  header: {
+    alignItems: "flex-start",
+    flexDirection: "row",
+    gap: spacing.cardInner,
+    justifyContent: "space-between",
+  },
+  list: {
+    gap: spacing.cardGap,
+  },
+});

--- a/src/features/holdings/__tests__/HoldingsScreen.test.tsx
+++ b/src/features/holdings/__tests__/HoldingsScreen.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+
+import { HoldingsScreen } from "@/src/features/holdings";
+import type { QuoteRefreshResult, RefreshQuotesInput } from "@/src/services/quotes";
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import { createPortfolioStore } from "@/src/store";
+import type { Asset, Trade } from "@/src/types";
+
+const asset: Asset = {
+  assetClass: "stock",
+  currency: "INR",
+  exchange: "NSE",
+  id: "asset-reliance",
+  name: "Reliance Industries",
+  symbol: "RELIANCE",
+  ticker: "RELIANCE.NS",
+};
+
+const buyTrade: Trade = {
+  assetId: asset.id,
+  date: "2026-04-20",
+  id: "trade-buy",
+  pricePerUnit: 100,
+  quantity: 2,
+  totalValue: 200,
+  type: "buy",
+};
+
+describe("HoldingsScreen", () => {
+  it("shows an empty state with an Add Trade action", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const onAddTrade = jest.fn();
+
+    const { getByText } = render(
+      <HoldingsScreen store={store} onAddTrade={onAddTrade} />,
+    );
+
+    expect(getByText("No holdings yet")).toBeTruthy();
+    expect(
+      getByText("Holdings are created automatically from your trades."),
+    ).toBeTruthy();
+
+    fireEvent.press(getByText("Add Trade"));
+
+    expect(onAddTrade).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows derived holding values, quote freshness, and no V1 LTCG UI", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset(asset);
+    store.getState().addTrade(buyTrade);
+    store.getState().upsertQuote({
+      asOf: "2026-04-20T10:00:00.000Z",
+      assetId: asset.id,
+      currency: "INR",
+      price: 125,
+      source: "yahoo",
+    });
+
+    const { getByText, queryByText } = render(<HoldingsScreen store={store} />);
+
+    expect(getByText("Reliance Industries")).toBeTruthy();
+    expect(getByText("RELIANCE")).toBeTruthy();
+    expect(getByText("Qty 2")).toBeTruthy();
+    expect(getByText("Avg ₹100.00")).toBeTruthy();
+    expect(getByText("₹250.00")).toBeTruthy();
+    expect(getByText("+₹50.00 (+25.00%)")).toBeTruthy();
+    expect(getByText("Updated 20 Apr 2026")).toBeTruthy();
+    expect(queryByText(/LTCG/i)).toBeNull();
+  });
+
+  it("refreshes holdings quotes from the screen action", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset(asset);
+    store.getState().addTrade(buyTrade);
+    store.getState().upsertQuote({
+      asOf: "2026-04-20T10:00:00.000Z",
+      assetId: asset.id,
+      currency: "INR",
+      price: 100,
+      source: "manual",
+    });
+    const refreshQuotes = jest
+      .fn<Promise<QuoteRefreshResult>, [RefreshQuotesInput]>()
+      .mockResolvedValue({
+        failures: [],
+        quoteCache: {
+          [asset.id]: {
+            asOf: "2026-04-21T10:00:00.000Z",
+            assetId: asset.id,
+            currency: "INR",
+            price: 150,
+            source: "yahoo",
+          },
+        },
+      });
+
+    const { getByText } = render(
+      <HoldingsScreen store={store} refreshQuotes={refreshQuotes} />,
+    );
+
+    fireEvent.press(getByText("Refresh Quotes"));
+
+    await waitFor(() => {
+      expect(getByText("₹300.00")).toBeTruthy();
+      expect(getByText("Updated 21 Apr 2026")).toBeTruthy();
+    });
+  });
+});

--- a/src/features/holdings/__tests__/useHoldings.test.tsx
+++ b/src/features/holdings/__tests__/useHoldings.test.tsx
@@ -1,0 +1,112 @@
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+
+import { useHoldings } from "@/src/features/holdings/useHoldings";
+import type { QuoteRefreshResult, RefreshQuotesInput } from "@/src/services/quotes";
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import { createPortfolioStore } from "@/src/store";
+import type { Asset, Trade } from "@/src/types";
+
+const asset: Asset = {
+  assetClass: "stock",
+  currency: "INR",
+  exchange: "NSE",
+  id: "asset-reliance",
+  name: "Reliance Industries",
+  symbol: "RELIANCE",
+  ticker: "RELIANCE.NS",
+};
+
+const buyTrade: Trade = {
+  assetId: asset.id,
+  date: "2026-04-20",
+  id: "trade-buy",
+  pricePerUnit: 100,
+  quantity: 2,
+  totalValue: 200,
+  type: "buy",
+};
+
+describe("useHoldings", () => {
+  it("derives holdings from raw trades and cached quotes", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset(asset);
+    store.getState().addTrade(buyTrade);
+    store.getState().upsertQuote({
+      asOf: "2026-04-20T10:00:00.000Z",
+      assetId: asset.id,
+      currency: "INR",
+      dayChangePct: 1.5,
+      price: 125,
+      source: "yahoo",
+    });
+
+    const { result } = renderHook(() => useHoldings({ store }));
+
+    expect(result.current.holdings).toHaveLength(1);
+    expect(result.current.holdings[0]).toMatchObject({
+      averageCostPrice: 100,
+      currentPrice: 125,
+      currentValue: 250,
+      dayChangePct: 1.5,
+      lastUpdated: "2026-04-20T10:00:00.000Z",
+      totalUnits: 2,
+      unrealisedPnL: 50,
+      unrealisedPnLPct: 25,
+    });
+  });
+
+  it("refreshes quotes and persists the updated values into the store", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset(asset);
+    store.getState().addTrade(buyTrade);
+    store.getState().upsertQuote({
+      asOf: "2026-04-20T10:00:00.000Z",
+      assetId: asset.id,
+      currency: "INR",
+      price: 100,
+      source: "manual",
+    });
+    const refreshQuotes = jest
+      .fn<Promise<QuoteRefreshResult>, [RefreshQuotesInput]>()
+      .mockResolvedValue({
+        failures: [],
+        quoteCache: {
+          [asset.id]: {
+            asOf: "2026-04-21T10:00:00.000Z",
+            assetId: asset.id,
+            currency: "INR",
+            dayChangePct: 2,
+            price: 140,
+            source: "yahoo",
+          },
+        },
+      });
+
+    const { result } = renderHook(() =>
+      useHoldings({ refreshQuotes, store }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(store.getState().quoteCache[asset.id]).toMatchObject({
+        price: 140,
+        source: "yahoo",
+      });
+    });
+    expect(refreshQuotes).toHaveBeenCalledWith({
+      assets: [asset],
+      manualPrices: {
+        [asset.id]: 100,
+      },
+    });
+    expect(result.current.holdings[0]).toMatchObject({
+      currentPrice: 140,
+      currentValue: 280,
+      dayChangePct: 2,
+      lastUpdated: "2026-04-21T10:00:00.000Z",
+    });
+  });
+});

--- a/src/features/holdings/index.ts
+++ b/src/features/holdings/index.ts
@@ -1,1 +1,2 @@
-export {};
+export { HoldingsScreen } from "./HoldingsScreen";
+export { useHoldings } from "./useHoldings";

--- a/src/features/holdings/useHoldings.ts
+++ b/src/features/holdings/useHoldings.ts
@@ -1,0 +1,102 @@
+import { useState, useSyncExternalStore } from "react";
+import type { StoreApi } from "zustand/vanilla";
+
+import { calculateHoldings } from "@/src/domain/calculations";
+import {
+  refreshQuotes as defaultRefreshQuotes,
+  type QuoteRefreshFailure,
+  type QuoteRefreshResult,
+  type RefreshQuotesInput,
+} from "@/src/services/quotes";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import type { Holding } from "@/src/types";
+
+type RefreshQuotes = (
+  input: RefreshQuotesInput,
+) => Promise<QuoteRefreshResult>;
+
+type UseHoldingsInput = {
+  refreshQuotes?: RefreshQuotes;
+  store?: StoreApi<PortfolioStoreState>;
+};
+
+export type UseHoldingsResult = {
+  failures: QuoteRefreshFailure[];
+  holdings: Holding[];
+  isRefreshing: boolean;
+  refresh: () => Promise<QuoteRefreshResult>;
+};
+
+function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
+  return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+}
+
+function withQuoteMetadata(
+  holdings: Holding[],
+  quoteCache: PortfolioStoreState["quoteCache"],
+) {
+  return holdings.map((holding) => {
+    const quote = quoteCache[holding.asset.id];
+
+    return {
+      ...holding,
+      dayChangePct: quote?.dayChangePct,
+      lastUpdated: quote?.asOf,
+    };
+  });
+}
+
+function selectManualPrices(state: PortfolioStoreState) {
+  return Object.fromEntries(
+    Object.entries(state.quoteCache).map(([assetId, quote]) => [
+      assetId,
+      quote.price,
+    ]),
+  );
+}
+
+export function useHoldings({
+  refreshQuotes = defaultRefreshQuotes,
+  store = getPortfolioStore(),
+}: UseHoldingsInput = {}): UseHoldingsResult {
+  const snapshot = usePortfolioSnapshot(store);
+  const [failures, setFailures] = useState<QuoteRefreshFailure[]>([]);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const holdings = withQuoteMetadata(
+    calculateHoldings({
+      assets: snapshot.assets,
+      quoteCache: snapshot.quoteCache,
+      trades: snapshot.trades,
+    }),
+    snapshot.quoteCache,
+  );
+
+  async function refresh() {
+    setIsRefreshing(true);
+
+    try {
+      const currentState = store.getState();
+      const result = await refreshQuotes({
+        assets: currentState.assets,
+        manualPrices: selectManualPrices(currentState),
+      });
+
+      for (const quote of Object.values(result.quoteCache)) {
+        store.getState().upsertQuote(quote);
+      }
+
+      setFailures(result.failures);
+
+      return result;
+    } finally {
+      setIsRefreshing(false);
+    }
+  }
+
+  return {
+    failures,
+    holdings,
+    isRefreshing,
+    refresh,
+  };
+}


### PR DESCRIPTION
## Summary
- Add store-backed useHoldings derivation and quote refresh persistence.
- Add HoldingCard and Holdings screen empty/filled states.
- Wire the Holdings tab to the real screen with Add Trade navigation.

## Validation
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm audit --audit-level=high
- npx expo start --offline --port 8086

Closes #8