### PR TITLE
[V1] Build Dashboard MVP

### DIFF
--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -1,5 +1,13 @@
-import { PlaceholderScreen } from "@/src/components/common/PlaceholderScreen";
+import { router } from "expo-router";
+
+import { DashboardScreen as DashboardFeatureScreen } from "@/src/features/dashboard";
 
 export default function DashboardScreen() {
-  return <PlaceholderScreen title="Dashboard" />;
+  return (
+    <DashboardFeatureScreen
+      onAddTrade={() => {
+        router.push("/(tabs)/add-trade");
+      }}
+    />
+  );
 }

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -1,0 +1,164 @@
+import { StyleSheet, View } from "react-native";
+import type { StoreApi } from "zustand/vanilla";
+
+import {
+  AppButton,
+  AppText,
+  EmptyState,
+  MaskedValue,
+  ScreenContainer,
+} from "@/src/components/common";
+import { formatDate, formatINR, formatPercentage } from "@/src/domain/formatters";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import { colors, radii, shadows, spacing } from "@/src/theme";
+import type { AssetClass } from "@/src/types";
+
+import { useDashboard } from "./useDashboard";
+
+type DashboardScreenProps = {
+  onAddTrade?: () => void;
+  store?: StoreApi<PortfolioStoreState>;
+};
+
+const assetClassLabels: Record<AssetClass, string> = {
+  cash: "Cash",
+  crypto: "Crypto",
+  etf: "ETF",
+  stock: "Stock",
+};
+
+function formatSignedINR(value: number) {
+  const amount = formatINR(value);
+
+  return value > 0 ? `+${amount}` : amount;
+}
+
+export function DashboardScreen({
+  onAddTrade,
+  store = getPortfolioStore(),
+}: DashboardScreenProps) {
+  const dashboard = useDashboard({ store });
+  const hasAllocation = dashboard.allocation.length > 0;
+  const dayChangeText = `${formatSignedINR(dashboard.dayChange.absolute)} (${formatPercentage(
+    dashboard.dayChange.percentage,
+  )}) today`;
+
+  return (
+    <ScreenContainer scroll testID="dashboard-screen">
+      <View style={styles.content}>
+        <View style={styles.heroCard}>
+          <AppText color="secondary">Portfolio value</AppText>
+          <MaskedValue
+            masked={dashboard.maskWealthValues}
+            value={formatINR(dashboard.totalValue)}
+            variant="hero"
+            weight="bold"
+          />
+          <AppText
+            color="primary"
+            style={dashboard.dayChange.absolute >= 0 ? styles.profit : styles.loss}
+          >
+            {dayChangeText}
+          </AppText>
+          {onAddTrade && hasAllocation ? (
+            <AppButton title="Add Trade" onPress={onAddTrade} />
+          ) : null}
+        </View>
+
+        {hasAllocation ? (
+          <View style={styles.card}>
+            <AppText variant="title" weight="bold">
+              Allocation
+            </AppText>
+            {dashboard.allocation.map((item) => (
+              <View key={item.assetClass} style={styles.allocationRow}>
+                <View style={styles.allocationLabel}>
+                  <AppText>{assetClassLabels[item.assetClass]}</AppText>
+                  <MaskedValue
+                    color="secondary"
+                    masked={dashboard.maskWealthValues}
+                    value={formatINR(item.value)}
+                  />
+                </View>
+                <AppText weight="bold">{formatPercentage(item.percentage).replace("+", "")}</AppText>
+              </View>
+            ))}
+          </View>
+        ) : (
+          <EmptyState
+            actionLabel={onAddTrade ? "Add Trade" : undefined}
+            message="Add your first trade to build holdings automatically."
+            title="No allocation yet"
+            onAction={onAddTrade}
+          />
+        )}
+
+        <View style={styles.card}>
+          <AppText variant="title" weight="bold">
+            Quote freshness
+          </AppText>
+          <AppText color="secondary">
+            {dashboard.latestQuoteAsOf
+              ? `Quotes updated ${formatDate(dashboard.latestQuoteAsOf)}`
+              : "Quotes will appear after your first priced holding."}
+          </AppText>
+        </View>
+
+        <View style={styles.card}>
+          <AppText variant="title" weight="bold">
+            {dashboard.convictionReadiness.isReady
+              ? "Conviction data ready"
+              : "Conviction data needs more trades"}
+          </AppText>
+          <AppText color="secondary">
+            {dashboard.convictionReadiness.ratedTradeCount} of{" "}
+            {dashboard.convictionReadiness.requiredTradeCount} trades rated. Keep
+            conviction optional, but useful.
+          </AppText>
+        </View>
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  allocationLabel: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  allocationRow: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: spacing.cardInner,
+    justifyContent: "space-between",
+  },
+  card: {
+    ...shadows.none,
+    backgroundColor: colors.surface.card,
+    borderColor: colors.border.subtle,
+    borderRadius: radii.card,
+    borderWidth: 1,
+    gap: spacing.cardInner,
+    padding: spacing.md,
+  },
+  content: {
+    gap: spacing.cardGap,
+    paddingBottom: spacing.lg,
+    paddingTop: spacing.md,
+  },
+  heroCard: {
+    ...shadows.none,
+    backgroundColor: colors.surface.elevated,
+    borderColor: colors.border.subtle,
+    borderRadius: radii.card,
+    borderWidth: 1,
+    gap: spacing.cardInner,
+    padding: spacing.md,
+  },
+  loss: {
+    color: colors.loss,
+  },
+  profit: {
+    color: colors.profit,
+  },
+});

--- a/src/features/dashboard/__tests__/DashboardScreen.test.tsx
+++ b/src/features/dashboard/__tests__/DashboardScreen.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { MASKED_INR_VALUE } from "@/src/components/common";
+import { DashboardScreen } from "@/src/features/dashboard";
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import { createPortfolioStore } from "@/src/store";
+import type { Asset, Trade } from "@/src/types";
+
+const asset: Asset = {
+  assetClass: "stock",
+  currency: "INR",
+  exchange: "NSE",
+  id: "asset-reliance",
+  name: "Reliance Industries",
+  symbol: "RELIANCE",
+  ticker: "RELIANCE.NS",
+};
+
+const buyTrade: Trade = {
+  assetId: asset.id,
+  date: "2026-04-20",
+  id: "trade-buy",
+  pricePerUnit: 100,
+  quantity: 2,
+  totalValue: 200,
+  type: "buy",
+};
+
+describe("DashboardScreen", () => {
+  it("shows the empty dashboard with a zero total and Add Trade action", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const onAddTrade = jest.fn();
+
+    const { getByText } = render(
+      <DashboardScreen store={store} onAddTrade={onAddTrade} />,
+    );
+
+    expect(getByText("₹0.00")).toBeTruthy();
+    expect(getByText("No allocation yet")).toBeTruthy();
+    expect(
+      getByText("Add your first trade to build holdings automatically."),
+    ).toBeTruthy();
+
+    fireEvent.press(getByText("Add Trade"));
+
+    expect(onAddTrade).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows portfolio totals, allocation, quote freshness, and conviction guidance", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset(asset);
+    store.getState().addTrade({ ...buyTrade, conviction: 4 });
+    store.getState().addCashEntry({
+      amount: 50,
+      date: "2026-04-22",
+      id: "cash-1",
+      label: "Broker cash",
+      type: "addition",
+    });
+    store.getState().upsertQuote({
+      asOf: "2026-04-22T10:00:00.000Z",
+      assetId: asset.id,
+      currency: "INR",
+      dayChangePct: 10,
+      price: 150,
+      source: "yahoo",
+    });
+
+    const { getByText, queryByText } = render(<DashboardScreen store={store} />);
+
+    expect(getByText("₹350.00")).toBeTruthy();
+    expect(getByText("+₹27.27 (+10.00%) today")).toBeTruthy();
+    expect(getByText("Stock")).toBeTruthy();
+    expect(getByText("85.71%")).toBeTruthy();
+    expect(getByText("Cash")).toBeTruthy();
+    expect(getByText("14.29%")).toBeTruthy();
+    expect(getByText("Quotes updated 22 Apr 2026")).toBeTruthy();
+    expect(getByText("Conviction data needs more trades")).toBeTruthy();
+    expect(getByText("1 of 5 trades rated. Keep conviction optional, but useful.")).toBeTruthy();
+    expect(queryByText(/LTCG/i)).toBeNull();
+    expect(queryByText(/Minimal Mode/i)).toBeNull();
+  });
+
+  it("masks wealth values when value masking is enabled", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().updatePreferences({ maskWealthValues: true });
+    store.getState().addAsset(asset);
+    store.getState().addTrade(buyTrade);
+    store.getState().upsertQuote({
+      asOf: "2026-04-22T10:00:00.000Z",
+      assetId: asset.id,
+      currency: "INR",
+      price: 150,
+      source: "yahoo",
+    });
+
+    const { getAllByText, queryByText } = render(<DashboardScreen store={store} />);
+
+    expect(getAllByText(MASKED_INR_VALUE).length).toBeGreaterThan(0);
+    expect(queryByText("₹300.00")).toBeNull();
+    expect(getAllByText("100.00%").length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/dashboard/__tests__/useDashboard.test.tsx
+++ b/src/features/dashboard/__tests__/useDashboard.test.tsx
@@ -1,0 +1,112 @@
+import { renderHook } from "@testing-library/react-native";
+
+import { useDashboard } from "@/src/features/dashboard/useDashboard";
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import { createPortfolioStore } from "@/src/store";
+import type { Asset, Trade } from "@/src/types";
+
+const stockAsset: Asset = {
+  assetClass: "stock",
+  currency: "INR",
+  exchange: "NSE",
+  id: "asset-reliance",
+  name: "Reliance Industries",
+  symbol: "RELIANCE",
+  ticker: "RELIANCE.NS",
+};
+
+const etfAsset: Asset = {
+  assetClass: "etf",
+  currency: "INR",
+  exchange: "NSE",
+  id: "asset-niftybees",
+  name: "Nippon India Nifty 50 BeES",
+  symbol: "NIFTYBEES",
+  ticker: "NIFTYBEES.NS",
+};
+
+const buyStock: Trade = {
+  assetId: stockAsset.id,
+  conviction: 4,
+  date: "2026-04-20",
+  id: "trade-stock",
+  pricePerUnit: 100,
+  quantity: 2,
+  totalValue: 200,
+  type: "buy",
+};
+
+const buyEtf: Trade = {
+  assetId: etfAsset.id,
+  date: "2026-04-21",
+  id: "trade-etf",
+  pricePerUnit: 50,
+  quantity: 2,
+  totalValue: 100,
+  type: "buy",
+};
+
+describe("useDashboard", () => {
+  it("derives total, allocation, day change, quote freshness, and conviction readiness", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset(stockAsset);
+    store.getState().addAsset(etfAsset);
+    store.getState().addTrade(buyStock);
+    store.getState().addTrade(buyEtf);
+    store.getState().addCashEntry({
+      amount: 50,
+      date: "2026-04-22",
+      id: "cash-1",
+      label: "Broker cash",
+      type: "addition",
+    });
+    store.getState().upsertQuote({
+      asOf: "2026-04-22T10:00:00.000Z",
+      assetId: stockAsset.id,
+      currency: "INR",
+      dayChangePct: 10,
+      price: 150,
+      source: "yahoo",
+    });
+    store.getState().upsertQuote({
+      asOf: "2026-04-21T10:00:00.000Z",
+      assetId: etfAsset.id,
+      currency: "INR",
+      dayChangePct: -5,
+      price: 100,
+      source: "yahoo",
+    });
+
+    const { result } = renderHook(() => useDashboard({ store }));
+
+    expect(result.current.totalValue).toBe(550);
+    expect(result.current.cashBalance).toBe(50);
+    expect(result.current.dayChange).toEqual({
+      absolute: 16.75,
+      percentage: 3.47,
+    });
+    expect(result.current.latestQuoteAsOf).toBe("2026-04-22T10:00:00.000Z");
+    expect(result.current.allocation).toEqual([
+      {
+        assetClass: "stock",
+        percentage: 54.55,
+        value: 300,
+      },
+      {
+        assetClass: "etf",
+        percentage: 36.36,
+        value: 200,
+      },
+      {
+        assetClass: "cash",
+        percentage: 9.09,
+        value: 50,
+      },
+    ]);
+    expect(result.current.convictionReadiness).toMatchObject({
+      isReady: false,
+      ratedTradeCount: 1,
+      requiredTradeCount: 5,
+    });
+  });
+});

--- a/src/features/dashboard/index.ts
+++ b/src/features/dashboard/index.ts
@@ -1,1 +1,2 @@
-export {};
+export { DashboardScreen } from "./DashboardScreen";
+export { useDashboard } from "./useDashboard";

--- a/src/features/dashboard/useDashboard.ts
+++ b/src/features/dashboard/useDashboard.ts
@@ -1,0 +1,86 @@
+import { useSyncExternalStore } from "react";
+import type { StoreApi } from "zustand/vanilla";
+
+import {
+  calculateAllocation,
+  calculateCashBalance,
+  calculateHoldings,
+  calculatePortfolioDayChange,
+  calculatePortfolioTotal,
+  getConvictionReadiness,
+  type AllocationItem,
+  type ConvictionReadiness,
+  type PortfolioDayChange,
+} from "@/src/domain/calculations";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import type { Holding } from "@/src/types";
+
+type UseDashboardInput = {
+  store?: StoreApi<PortfolioStoreState>;
+};
+
+export type DashboardState = {
+  allocation: AllocationItem[];
+  cashBalance: number;
+  convictionReadiness: ConvictionReadiness;
+  dayChange: PortfolioDayChange;
+  holdings: Holding[];
+  latestQuoteAsOf?: string;
+  maskWealthValues: boolean;
+  totalValue: number;
+};
+
+function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
+  return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+}
+
+function withQuoteMetadata(
+  holdings: Holding[],
+  quoteCache: PortfolioStoreState["quoteCache"],
+) {
+  return holdings.map((holding) => {
+    const quote = quoteCache[holding.asset.id];
+
+    return {
+      ...holding,
+      dayChangePct: quote?.dayChangePct,
+      lastUpdated: quote?.asOf,
+    };
+  });
+}
+
+function getLatestQuoteAsOf(holdings: Holding[]) {
+  return holdings
+    .map((holding) => holding.lastUpdated)
+    .filter((value): value is string => Boolean(value))
+    .sort((left, right) => new Date(right).getTime() - new Date(left).getTime())[0];
+}
+
+export function useDashboard({
+  store = getPortfolioStore(),
+}: UseDashboardInput = {}): DashboardState {
+  const snapshot = usePortfolioSnapshot(store);
+  const holdings = withQuoteMetadata(
+    calculateHoldings({
+      assets: snapshot.assets,
+      quoteCache: snapshot.quoteCache,
+      trades: snapshot.trades,
+    }),
+    snapshot.quoteCache,
+  );
+  const cashBalance = calculateCashBalance(snapshot.cashEntries);
+
+  return {
+    allocation: calculateAllocation({
+      cashBalance,
+      holdings,
+    }),
+    cashBalance,
+    convictionReadiness: getConvictionReadiness(snapshot.trades),
+    dayChange: calculatePortfolioDayChange(holdings),
+    holdings,
+    latestQuoteAsOf: getLatestQuoteAsOf(holdings),
+    maskWealthValues: snapshot.preferences.maskWealthValues,
+    totalValue: calculatePortfolioTotal(holdings, snapshot.cashEntries),
+  };
+}


### PR DESCRIPTION
## Summary
- Add store-backed dashboard derivation for total value, allocation, quote freshness, and conviction readiness.
- Replace the dashboard placeholder with empty and filled MVP states plus Add Trade CTA.
- Add value masking support for dashboard wealth values without masking percentages.

## Validation
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm audit --audit-level=high
- npx expo start --offline --port 8086

Closes #9