### PR TITLE
[V1] Build Cash screen

### DIFF
--- a/app/(tabs)/cash.tsx
+++ b/app/(tabs)/cash.tsx
@@ -1,5 +1,5 @@
-import { PlaceholderScreen } from "@/src/components/common/PlaceholderScreen";
+import { CashScreen as CashFeatureScreen } from "@/src/features/cash";
 
 export default function CashScreen() {
-  return <PlaceholderScreen title="Cash" />;
+  return <CashFeatureScreen />;
 }

--- a/src/components/cards/CashEntryRow.tsx
+++ b/src/components/cards/CashEntryRow.tsx
@@ -1,0 +1,67 @@
+import { StyleSheet, View } from "react-native";
+
+import { AppText } from "@/src/components/common";
+import { formatDate, formatINR } from "@/src/domain/formatters";
+import { colors, radii, shadows, spacing } from "@/src/theme";
+import type { CashEntry } from "@/src/types";
+
+type CashEntryRowProps = {
+  entry: CashEntry;
+};
+
+function formatCashAmount(entry: CashEntry) {
+  const amount = formatINR(entry.amount);
+
+  return entry.type === "addition" ? `+${amount}` : `-${amount}`;
+}
+
+export function CashEntryRow({ entry }: CashEntryRowProps) {
+  const isAddition = entry.type === "addition";
+
+  return (
+    <View style={styles.row}>
+      <View style={styles.details}>
+        <AppText weight="bold">{entry.label}</AppText>
+        <AppText color="secondary" variant="caption">
+          {formatDate(entry.date)}
+        </AppText>
+        {entry.notes ? (
+          <AppText color="secondary" variant="caption">
+            {entry.notes}
+          </AppText>
+        ) : null}
+      </View>
+      <AppText
+        style={isAddition ? styles.addition : styles.withdrawal}
+        weight="bold"
+      >
+        {formatCashAmount(entry)}
+      </AppText>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  addition: {
+    color: colors.profit,
+  },
+  details: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  row: {
+    ...shadows.none,
+    alignItems: "center",
+    backgroundColor: colors.surface.card,
+    borderColor: colors.border.subtle,
+    borderRadius: radii.card,
+    borderWidth: 1,
+    flexDirection: "row",
+    gap: spacing.cardInner,
+    justifyContent: "space-between",
+    padding: spacing.md,
+  },
+  withdrawal: {
+    color: colors.loss,
+  },
+});

--- a/src/components/cards/index.ts
+++ b/src/components/cards/index.ts
@@ -1,1 +1,2 @@
+export { CashEntryRow } from "./CashEntryRow";
 export { HoldingCard } from "./HoldingCard";

--- a/src/features/cash/CashScreen.tsx
+++ b/src/features/cash/CashScreen.tsx
@@ -1,0 +1,231 @@
+import { useState } from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import type { StoreApi } from "zustand/vanilla";
+
+import { CashEntryRow } from "@/src/components/cards";
+import { AppButton, AppText, EmptyState, ScreenContainer } from "@/src/components/common";
+import { FormTextField } from "@/src/components/forms";
+import { formatINR } from "@/src/domain/formatters";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import { colors, interaction, radii, spacing } from "@/src/theme";
+import type { CashEntryType } from "@/src/types";
+
+import { useCash } from "./useCash";
+
+type CashScreenProps = {
+  store?: StoreApi<PortfolioStoreState>;
+};
+
+type FieldErrors = Partial<Record<"amount" | "date" | "label", string>>;
+
+function validateCashEntry({
+  amount,
+  date,
+  label,
+}: {
+  amount: string;
+  date: string;
+  label: string;
+}) {
+  const errors: FieldErrors = {};
+  const trimmedAmount = amount.trim();
+  const parsedAmount = trimmedAmount.length > 0 ? Number(trimmedAmount) : Number.NaN;
+
+  if (!Number.isFinite(parsedAmount)) {
+    errors.amount = "Amount must be a valid number.";
+  } else if (parsedAmount <= 0) {
+    errors.amount = "Amount must be greater than zero.";
+  }
+
+  if (label.trim().length === 0) {
+    errors.label = "Label is required.";
+  }
+
+  if (date.trim().length === 0) {
+    errors.date = "Date is required.";
+  } else if (Number.isNaN(new Date(date).getTime())) {
+    errors.date = "Date must be valid.";
+  }
+
+  return {
+    errors,
+    parsedAmount,
+  };
+}
+
+export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
+  const { addEntry, balance, entries } = useCash({ store });
+  const [type, setType] = useState<CashEntryType>("addition");
+  const [amount, setAmount] = useState("");
+  const [label, setLabel] = useState("");
+  const [date, setDate] = useState("");
+  const [notes, setNotes] = useState("");
+  const [errors, setErrors] = useState<FieldErrors>({});
+
+  function resetForm() {
+    setAmount("");
+    setLabel("");
+    setDate("");
+    setNotes("");
+    setErrors({});
+  }
+
+  function submit() {
+    const result = validateCashEntry({
+      amount,
+      date,
+      label,
+    });
+
+    if (Object.keys(result.errors).length > 0) {
+      setErrors(result.errors);
+      return;
+    }
+
+    addEntry({
+      amount: result.parsedAmount,
+      date: date.trim(),
+      label: label.trim(),
+      notes,
+      type,
+    });
+    resetForm();
+  }
+
+  return (
+    <ScreenContainer scroll testID="cash-screen">
+      <View style={styles.content}>
+        <View style={styles.heroCard}>
+          <AppText color="secondary">Cash balance</AppText>
+          <AppText selectable variant="hero" weight="bold">
+            {formatINR(balance)}
+          </AppText>
+        </View>
+
+        <View style={styles.segmentedControl}>
+          {(["addition", "withdrawal"] as const).map((entryType) => (
+            <Pressable
+              accessibilityRole="button"
+              key={entryType}
+              onPress={() => {
+                setType(entryType);
+                setErrors({});
+              }}
+              style={({ pressed }) => [
+                styles.segment,
+                type === entryType && styles.segmentActive,
+                pressed && styles.pressed,
+              ]}
+            >
+              <AppText
+                color={type === entryType ? "inverse" : "secondary"}
+                weight="bold"
+              >
+                {entryType === "addition" ? "Add Cash" : "Withdraw"}
+              </AppText>
+            </Pressable>
+          ))}
+        </View>
+
+        <View style={styles.card}>
+          <AppText variant="body" weight="bold">
+            Cash entry
+          </AppText>
+          <FormTextField
+            error={errors.amount}
+            keyboardType="decimal-pad"
+            label="Amount"
+            onChangeText={setAmount}
+            placeholder="1000"
+            value={amount}
+          />
+          <FormTextField
+            error={errors.label}
+            label="Label"
+            onChangeText={setLabel}
+            placeholder={type === "addition" ? "Broker cash" : "Withdrawal"}
+            value={label}
+          />
+          <FormTextField
+            error={errors.date}
+            label="Date"
+            onChangeText={setDate}
+            placeholder="YYYY-MM-DD"
+            value={date}
+          />
+          <FormTextField
+            label="Notes"
+            multiline
+            onChangeText={setNotes}
+            placeholder="Optional note"
+            value={notes}
+          />
+          <AppButton title="Save Cash Entry" onPress={submit} />
+        </View>
+
+        {entries.length === 0 ? (
+          <EmptyState
+            message="Add available broker or bank cash to include it in portfolio value."
+            title="No cash entries yet"
+          />
+        ) : (
+          <View style={styles.history}>
+            <AppText variant="title" weight="bold">
+              Cash history
+            </AppText>
+            {entries.map((entry) => (
+              <CashEntryRow entry={entry} key={entry.id} />
+            ))}
+          </View>
+        )}
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.surface.card,
+    borderColor: colors.border.subtle,
+    borderRadius: radii.card,
+    borderWidth: 1,
+    gap: spacing.cardInner,
+    padding: spacing.md,
+  },
+  content: {
+    gap: spacing.cardGap,
+    paddingBottom: spacing.lg,
+    paddingTop: spacing.md,
+  },
+  heroCard: {
+    backgroundColor: colors.surface.elevated,
+    borderColor: colors.border.subtle,
+    borderRadius: radii.card,
+    borderWidth: 1,
+    gap: spacing.cardInner,
+    padding: spacing.md,
+  },
+  history: {
+    gap: spacing.cardGap,
+  },
+  pressed: {
+    opacity: interaction.pressedOpacity,
+  },
+  segment: {
+    alignItems: "center",
+    borderRadius: radii.pill,
+    flex: 1,
+    paddingVertical: spacing.cardInner,
+  },
+  segmentActive: {
+    backgroundColor: colors.primary,
+  },
+  segmentedControl: {
+    backgroundColor: colors.surface.card,
+    borderColor: colors.border.subtle,
+    borderRadius: radii.pill,
+    borderWidth: 1,
+    flexDirection: "row",
+    padding: spacing.xs,
+  },
+});

--- a/src/features/cash/__tests__/CashScreen.test.tsx
+++ b/src/features/cash/__tests__/CashScreen.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+
+import { CashScreen } from "@/src/features/cash";
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import { createPortfolioStore } from "@/src/store";
+
+describe("CashScreen", () => {
+  it("shows an empty cash state with zero balance", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+
+    const { getByText } = render(<CashScreen store={store} />);
+
+    expect(getByText("₹0.00")).toBeTruthy();
+    expect(getByText("No cash entries yet")).toBeTruthy();
+    expect(getByText("Add available broker or bank cash to include it in portfolio value.")).toBeTruthy();
+  });
+
+  it("adds and withdraws cash and shows history rows", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const { getByLabelText, getByText } = render(<CashScreen store={store} />);
+
+    fireEvent.changeText(getByLabelText("Amount"), "1000");
+    fireEvent.changeText(getByLabelText("Label"), "Broker cash");
+    fireEvent.changeText(getByLabelText("Date"), "2026-04-20");
+    fireEvent.press(getByText("Save Cash Entry"));
+
+    await waitFor(() => {
+      expect(getByText("₹1,000.00")).toBeTruthy();
+      expect(getByText("Broker cash")).toBeTruthy();
+      expect(getByText("+₹1,000.00")).toBeTruthy();
+    });
+
+    fireEvent.press(getByText("Withdraw"));
+    fireEvent.changeText(getByLabelText("Amount"), "250");
+    fireEvent.changeText(getByLabelText("Label"), "Emergency withdrawal");
+    fireEvent.changeText(getByLabelText("Date"), "2026-04-21");
+    fireEvent.press(getByText("Save Cash Entry"));
+
+    await waitFor(() => {
+      expect(getByText("₹750.00")).toBeTruthy();
+      expect(getByText("Emergency withdrawal")).toBeTruthy();
+      expect(getByText("-₹250.00")).toBeTruthy();
+    });
+  });
+
+  it("shows validation errors for invalid cash entries", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const { getByText } = render(<CashScreen store={store} />);
+
+    fireEvent.press(getByText("Save Cash Entry"));
+
+    expect(getByText("Amount must be a valid number.")).toBeTruthy();
+    expect(getByText("Label is required.")).toBeTruthy();
+    expect(getByText("Date is required.")).toBeTruthy();
+  });
+});

--- a/src/features/cash/__tests__/useCash.test.tsx
+++ b/src/features/cash/__tests__/useCash.test.tsx
@@ -1,0 +1,80 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import { useCash } from "@/src/features/cash/useCash";
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import { createPortfolioStore } from "@/src/store";
+
+describe("useCash", () => {
+  it("derives cash balance from additions minus withdrawals and sorts history newest first", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addCashEntry({
+      amount: 1000,
+      date: "2026-04-20",
+      id: "cash-add",
+      label: "Broker cash",
+      type: "addition",
+    });
+    store.getState().addCashEntry({
+      amount: 250,
+      date: "2026-04-22",
+      id: "cash-withdraw",
+      label: "Withdrawal",
+      type: "withdrawal",
+    });
+
+    const { result } = renderHook(() => useCash({ store }));
+
+    expect(result.current.balance).toBe(750);
+    expect(result.current.entries.map((entry) => entry.id)).toEqual([
+      "cash-withdraw",
+      "cash-add",
+    ]);
+  });
+
+  it("adds and withdraws cash through the store-backed action", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const { result } = renderHook(() => useCash({ store }));
+
+    act(() => {
+      result.current.addEntry({
+        amount: 1000,
+        date: "2026-04-20",
+        label: "Broker cash",
+        type: "addition",
+      });
+      result.current.addEntry({
+        amount: 300,
+        date: "2026-04-21",
+        label: "Withdrawal",
+        type: "withdrawal",
+      });
+    });
+
+    expect(result.current.balance).toBe(700);
+    expect(store.getState().cashEntries).toHaveLength(2);
+  });
+
+  it("persists cash entries in the portfolio snapshot storage", () => {
+    const storage = createMemoryJsonStorage();
+    const firstStore = createPortfolioStore({ storage });
+    const { result } = renderHook(() => useCash({ store: firstStore }));
+
+    act(() => {
+      result.current.addEntry({
+        amount: 500,
+        date: "2026-04-20",
+        label: "Opening cash",
+        type: "addition",
+      });
+    });
+
+    const secondStore = createPortfolioStore({ storage });
+
+    expect(secondStore.getState().cashEntries).toHaveLength(1);
+    expect(secondStore.getState().cashEntries[0]).toMatchObject({
+      amount: 500,
+      label: "Opening cash",
+      type: "addition",
+    });
+  });
+});

--- a/src/features/cash/index.ts
+++ b/src/features/cash/index.ts
@@ -1,1 +1,2 @@
-export {};
+export { CashScreen } from "./CashScreen";
+export { useCash } from "./useCash";

--- a/src/features/cash/useCash.ts
+++ b/src/features/cash/useCash.ts
@@ -1,0 +1,59 @@
+import { useSyncExternalStore } from "react";
+import type { StoreApi } from "zustand/vanilla";
+
+import { calculateCashBalance } from "@/src/domain/calculations";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import type { CashEntry, CashEntryType } from "@/src/types";
+import { createId } from "@/src/utils";
+
+type UseCashInput = {
+  store?: StoreApi<PortfolioStoreState>;
+};
+
+type AddCashEntryInput = {
+  amount: number;
+  date: string;
+  label: string;
+  notes?: string;
+  type: CashEntryType;
+};
+
+export type UseCashResult = {
+  addEntry: (entry: AddCashEntryInput) => CashEntry;
+  balance: number;
+  entries: CashEntry[];
+};
+
+function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
+  return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+}
+
+function sortCashEntries(entries: CashEntry[]) {
+  return [...entries].sort(
+    (left, right) => new Date(right.date).getTime() - new Date(left.date).getTime(),
+  );
+}
+
+export function useCash({
+  store = getPortfolioStore(),
+}: UseCashInput = {}): UseCashResult {
+  const snapshot = usePortfolioSnapshot(store);
+
+  function addEntry(input: AddCashEntryInput) {
+    const entry: CashEntry = {
+      ...input,
+      id: createId("cash"),
+      notes: input.notes?.trim() || undefined,
+    };
+
+    store.getState().addCashEntry(entry);
+
+    return entry;
+  }
+
+  return {
+    addEntry,
+    balance: calculateCashBalance(snapshot.cashEntries),
+    entries: sortCashEntries(snapshot.cashEntries),
+  };
+}


### PR DESCRIPTION
## Summary
- Add store-backed cash balance derivation and persisted add/withdraw cash action.
- Replace the Cash placeholder with Add Cash, Withdraw, validation, empty state, and history rows.
- Add CashEntryRow card and tests for balance, history sorting, UI entry creation, and persistence.

## Validation
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm audit --audit-level=high
- npx expo start --offline --port 8086

Closes #10