### PR TITLE
[V1] Build Settings and value masking

### DIFF
--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,5 +1,5 @@
-import { PlaceholderScreen } from "@/src/components/common/PlaceholderScreen";
+import { SettingsScreen as SettingsFeatureScreen } from "@/src/features/settings";
 
 export default function SettingsScreen() {
-  return <PlaceholderScreen title="Settings" />;
+  return <SettingsFeatureScreen />;
 }

--- a/src/components/cards/CashEntryRow.tsx
+++ b/src/components/cards/CashEntryRow.tsx
@@ -1,12 +1,13 @@
 import { StyleSheet, View } from "react-native";
 
-import { AppText } from "@/src/components/common";
+import { AppText, MaskedValue } from "@/src/components/common";
 import { formatDate, formatINR } from "@/src/domain/formatters";
 import { colors, radii, shadows, spacing } from "@/src/theme";
 import type { CashEntry } from "@/src/types";
 
 type CashEntryRowProps = {
   entry: CashEntry;
+  masked?: boolean;
 };
 
 function formatCashAmount(entry: CashEntry) {
@@ -15,7 +16,7 @@ function formatCashAmount(entry: CashEntry) {
   return entry.type === "addition" ? `+${amount}` : `-${amount}`;
 }
 
-export function CashEntryRow({ entry }: CashEntryRowProps) {
+export function CashEntryRow({ entry, masked = false }: CashEntryRowProps) {
   const isAddition = entry.type === "addition";
 
   return (
@@ -31,12 +32,12 @@ export function CashEntryRow({ entry }: CashEntryRowProps) {
           </AppText>
         ) : null}
       </View>
-      <AppText
+      <MaskedValue
+        masked={masked}
         style={isAddition ? styles.addition : styles.withdrawal}
+        value={formatCashAmount(entry)}
         weight="bold"
-      >
-        {formatCashAmount(entry)}
-      </AppText>
+      />
     </View>
   );
 }

--- a/src/components/cards/HoldingCard.tsx
+++ b/src/components/cards/HoldingCard.tsx
@@ -8,20 +8,20 @@ import { AppText, MaskedValue } from "../common";
 
 type HoldingCardProps = {
   holding: Holding;
+  masked?: boolean;
 };
 
 function formatQuantity(value: number) {
   return Number.isInteger(value) ? value.toString() : value.toFixed(4);
 }
 
-function formatPnL(holding: Holding) {
+function formatPnLAmount(holding: Holding) {
   const amount = formatINR(holding.unrealisedPnL);
-  const percentage = formatPercentage(holding.unrealisedPnLPct);
 
-  return `${holding.unrealisedPnL > 0 ? "+" : ""}${amount} (${percentage})`;
+  return `${holding.unrealisedPnL > 0 ? "+" : ""}${amount}`;
 }
 
-export function HoldingCard({ holding }: HoldingCardProps) {
+export function HoldingCard({ holding, masked = false }: HoldingCardProps) {
   const isProfit = holding.unrealisedPnL >= 0;
 
   return (
@@ -36,16 +36,25 @@ export function HoldingCard({ holding }: HoldingCardProps) {
         <View style={styles.valueBlock}>
           <MaskedValue
             align="right"
+            masked={masked}
             value={formatINR(holding.currentValue)}
             weight="bold"
           />
-          <AppText
-            align="right"
-            color={isProfit ? "primary" : "primary"}
-            style={isProfit ? styles.profit : styles.loss}
-          >
-            {formatPnL(holding)}
-          </AppText>
+          <View style={styles.pnlLine}>
+            <MaskedValue
+              align="right"
+              masked={masked}
+              style={isProfit ? styles.profit : styles.loss}
+              value={formatPnLAmount(holding)}
+            />
+            <AppText
+              align="right"
+              color={isProfit ? "primary" : "primary"}
+              style={isProfit ? styles.profit : styles.loss}
+            >
+              {formatPercentage(holding.unrealisedPnLPct)}
+            </AppText>
+          </View>
         </View>
       </View>
 
@@ -94,6 +103,10 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     flexWrap: "wrap",
     gap: spacing.sm,
+  },
+  pnlLine: {
+    alignItems: "flex-end",
+    gap: spacing.xs,
   },
   profit: {
     color: colors.profit,

--- a/src/features/cash/CashScreen.tsx
+++ b/src/features/cash/CashScreen.tsx
@@ -3,7 +3,13 @@ import { Pressable, StyleSheet, View } from "react-native";
 import type { StoreApi } from "zustand/vanilla";
 
 import { CashEntryRow } from "@/src/components/cards";
-import { AppButton, AppText, EmptyState, ScreenContainer } from "@/src/components/common";
+import {
+  AppButton,
+  AppText,
+  EmptyState,
+  MaskedValue,
+  ScreenContainer,
+} from "@/src/components/common";
 import { FormTextField } from "@/src/components/forms";
 import { formatINR } from "@/src/domain/formatters";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
@@ -54,7 +60,7 @@ function validateCashEntry({
 }
 
 export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
-  const { addEntry, balance, entries } = useCash({ store });
+  const { addEntry, balance, entries, maskWealthValues } = useCash({ store });
   const [type, setType] = useState<CashEntryType>("addition");
   const [amount, setAmount] = useState("");
   const [label, setLabel] = useState("");
@@ -97,9 +103,13 @@ export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
       <View style={styles.content}>
         <View style={styles.heroCard}>
           <AppText color="secondary">Cash balance</AppText>
-          <AppText selectable variant="hero" weight="bold">
-            {formatINR(balance)}
-          </AppText>
+          <MaskedValue
+            masked={maskWealthValues}
+            selectable
+            value={formatINR(balance)}
+            variant="hero"
+            weight="bold"
+          />
         </View>
 
         <View style={styles.segmentedControl}>
@@ -174,7 +184,11 @@ export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
               Cash history
             </AppText>
             {entries.map((entry) => (
-              <CashEntryRow entry={entry} key={entry.id} />
+              <CashEntryRow
+                entry={entry}
+                key={entry.id}
+                masked={maskWealthValues}
+              />
             ))}
           </View>
         )}

--- a/src/features/cash/__tests__/CashScreen.test.tsx
+++ b/src/features/cash/__tests__/CashScreen.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
+import { MASKED_INR_VALUE } from "@/src/components/common";
 import { CashScreen } from "@/src/features/cash";
 import { createMemoryJsonStorage } from "@/src/services/storage";
 import { createPortfolioStore } from "@/src/store";
@@ -52,5 +53,25 @@ describe("CashScreen", () => {
     expect(getByText("Amount must be a valid number.")).toBeTruthy();
     expect(getByText("Label is required.")).toBeTruthy();
     expect(getByText("Date is required.")).toBeTruthy();
+  });
+
+  it("masks cash wealth values when value masking is enabled", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().updatePreferences({ maskWealthValues: true });
+    store.getState().addCashEntry({
+      amount: 1000,
+      date: "2026-04-20",
+      id: "cash-1",
+      label: "Broker cash",
+      type: "addition",
+    });
+
+    const { getAllByText, getByText, queryByText } = render(
+      <CashScreen store={store} />,
+    );
+
+    expect(getAllByText(MASKED_INR_VALUE).length).toBeGreaterThan(0);
+    expect(getByText("Broker cash")).toBeTruthy();
+    expect(queryByText("₹1,000.00")).toBeNull();
   });
 });

--- a/src/features/cash/useCash.ts
+++ b/src/features/cash/useCash.ts
@@ -22,6 +22,7 @@ export type UseCashResult = {
   addEntry: (entry: AddCashEntryInput) => CashEntry;
   balance: number;
   entries: CashEntry[];
+  maskWealthValues: boolean;
 };
 
 function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
@@ -55,5 +56,6 @@ export function useCash({
     addEntry,
     balance: calculateCashBalance(snapshot.cashEntries),
     entries: sortCashEntries(snapshot.cashEntries),
+    maskWealthValues: snapshot.preferences.maskWealthValues,
   };
 }

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -39,9 +39,7 @@ export function DashboardScreen({
 }: DashboardScreenProps) {
   const dashboard = useDashboard({ store });
   const hasAllocation = dashboard.allocation.length > 0;
-  const dayChangeText = `${formatSignedINR(dashboard.dayChange.absolute)} (${formatPercentage(
-    dashboard.dayChange.percentage,
-  )}) today`;
+  const dayChangeAmount = formatSignedINR(dashboard.dayChange.absolute);
 
   return (
     <ScreenContainer scroll testID="dashboard-screen">
@@ -54,12 +52,19 @@ export function DashboardScreen({
             variant="hero"
             weight="bold"
           />
-          <AppText
-            color="primary"
-            style={dashboard.dayChange.absolute >= 0 ? styles.profit : styles.loss}
-          >
-            {dayChangeText}
-          </AppText>
+          <View style={styles.dayChangeLine}>
+            <MaskedValue
+              masked={dashboard.maskWealthValues}
+              style={dashboard.dayChange.absolute >= 0 ? styles.profit : styles.loss}
+              value={dayChangeAmount}
+            />
+            <AppText
+              color="primary"
+              style={dashboard.dayChange.absolute >= 0 ? styles.profit : styles.loss}
+            >
+              ({formatPercentage(dashboard.dayChange.percentage)}) today
+            </AppText>
+          </View>
           {onAddTrade && hasAllocation ? (
             <AppButton title="Add Trade" onPress={onAddTrade} />
           ) : null}
@@ -145,6 +150,11 @@ const styles = StyleSheet.create({
     gap: spacing.cardGap,
     paddingBottom: spacing.lg,
     paddingTop: spacing.md,
+  },
+  dayChangeLine: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
   },
   heroCard: {
     ...shadows.none,

--- a/src/features/dashboard/__tests__/DashboardScreen.test.tsx
+++ b/src/features/dashboard/__tests__/DashboardScreen.test.tsx
@@ -31,11 +31,11 @@ describe("DashboardScreen", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     const onAddTrade = jest.fn();
 
-    const { getByText } = render(
+    const { getAllByText, getByText } = render(
       <DashboardScreen store={store} onAddTrade={onAddTrade} />,
     );
 
-    expect(getByText("₹0.00")).toBeTruthy();
+    expect(getAllByText("₹0.00").length).toBeGreaterThan(0);
     expect(getByText("No allocation yet")).toBeTruthy();
     expect(
       getByText("Add your first trade to build holdings automatically."),
@@ -69,7 +69,8 @@ describe("DashboardScreen", () => {
     const { getByText, queryByText } = render(<DashboardScreen store={store} />);
 
     expect(getByText("₹350.00")).toBeTruthy();
-    expect(getByText("+₹27.27 (+10.00%) today")).toBeTruthy();
+    expect(getByText("+₹27.27")).toBeTruthy();
+    expect(getByText("(+10.00%) today")).toBeTruthy();
     expect(getByText("Stock")).toBeTruthy();
     expect(getByText("85.71%")).toBeTruthy();
     expect(getByText("Cash")).toBeTruthy();
@@ -98,6 +99,7 @@ describe("DashboardScreen", () => {
 
     expect(getAllByText(MASKED_INR_VALUE).length).toBeGreaterThan(0);
     expect(queryByText("₹300.00")).toBeNull();
+    expect(queryByText("+₹100.00")).toBeNull();
     expect(getAllByText("100.00%").length).toBeGreaterThan(0);
   });
 });

--- a/src/features/holdings/HoldingsScreen.tsx
+++ b/src/features/holdings/HoldingsScreen.tsx
@@ -24,7 +24,7 @@ export function HoldingsScreen({
   refreshQuotes,
   store = getPortfolioStore(),
 }: HoldingsScreenProps) {
-  const { failures, holdings, isRefreshing, refresh } = useHoldings({
+  const { failures, holdings, isRefreshing, maskWealthValues, refresh } = useHoldings({
     refreshQuotes,
     store,
   });
@@ -77,7 +77,11 @@ export function HoldingsScreen({
             testID="holdings-list"
           >
             {holdings.map((holding) => (
-              <HoldingCard key={holding.asset.id} holding={holding} />
+              <HoldingCard
+                key={holding.asset.id}
+                holding={holding}
+                masked={maskWealthValues}
+              />
             ))}
           </View>
         )}

--- a/src/features/holdings/__tests__/HoldingsScreen.test.tsx
+++ b/src/features/holdings/__tests__/HoldingsScreen.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
+import { MASKED_INR_VALUE } from "@/src/components/common";
 import { HoldingsScreen } from "@/src/features/holdings";
 import type { QuoteRefreshResult, RefreshQuotesInput } from "@/src/services/quotes";
 import { createMemoryJsonStorage } from "@/src/services/storage";
@@ -64,7 +65,8 @@ describe("HoldingsScreen", () => {
     expect(getByText("Qty 2")).toBeTruthy();
     expect(getByText("Avg ₹100.00")).toBeTruthy();
     expect(getByText("₹250.00")).toBeTruthy();
-    expect(getByText("+₹50.00 (+25.00%)")).toBeTruthy();
+    expect(getByText("+₹50.00")).toBeTruthy();
+    expect(getByText("+25.00%")).toBeTruthy();
     expect(getByText("Updated 20 Apr 2026")).toBeTruthy();
     expect(queryByText(/LTCG/i)).toBeNull();
   });
@@ -105,5 +107,28 @@ describe("HoldingsScreen", () => {
       expect(getByText("₹300.00")).toBeTruthy();
       expect(getByText("Updated 21 Apr 2026")).toBeTruthy();
     });
+  });
+
+  it("masks wealth values without hiding quantities or percentages", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().updatePreferences({ maskWealthValues: true });
+    store.getState().addAsset(asset);
+    store.getState().addTrade(buyTrade);
+    store.getState().upsertQuote({
+      asOf: "2026-04-20T10:00:00.000Z",
+      assetId: asset.id,
+      currency: "INR",
+      price: 125,
+      source: "yahoo",
+    });
+
+    const { getAllByText, getByText, queryByText } = render(
+      <HoldingsScreen store={store} />,
+    );
+
+    expect(getAllByText(MASKED_INR_VALUE).length).toBeGreaterThan(0);
+    expect(getByText("Qty 2")).toBeTruthy();
+    expect(getByText("+25.00%")).toBeTruthy();
+    expect(queryByText("₹250.00")).toBeNull();
   });
 });

--- a/src/features/holdings/useHoldings.ts
+++ b/src/features/holdings/useHoldings.ts
@@ -24,6 +24,7 @@ export type UseHoldingsResult = {
   failures: QuoteRefreshFailure[];
   holdings: Holding[];
   isRefreshing: boolean;
+  maskWealthValues: boolean;
   refresh: () => Promise<QuoteRefreshResult>;
 };
 
@@ -97,6 +98,7 @@ export function useHoldings({
     failures,
     holdings,
     isRefreshing,
+    maskWealthValues: snapshot.preferences.maskWealthValues,
     refresh,
   };
 }

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -1,0 +1,157 @@
+import * as Haptics from "expo-haptics";
+import { Pressable, StyleSheet, View } from "react-native";
+import type { StoreApi } from "zustand/vanilla";
+
+import { AppText, ScreenContainer } from "@/src/components/common";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import { colors, interaction, radii, shadows, spacing } from "@/src/theme";
+
+import { useSettings } from "./useSettings";
+
+type SettingsScreenProps = {
+  store?: StoreApi<PortfolioStoreState>;
+};
+
+export function SettingsScreen({
+  store = getPortfolioStore(),
+}: SettingsScreenProps) {
+  const { maskWealthValues, toggleMaskWealthValues } = useSettings({ store });
+
+  async function handleToggleMasking() {
+    toggleMaskWealthValues();
+    await Haptics.selectionAsync();
+  }
+
+  return (
+    <ScreenContainer scroll testID="settings-screen">
+      <View style={styles.content}>
+        <View style={styles.header}>
+          <AppText color="secondary">Privacy and app controls</AppText>
+          <AppText variant="hero" weight="bold">
+            Settings
+          </AppText>
+        </View>
+
+        <Pressable
+          accessibilityLabel="Toggle value masking"
+          accessibilityRole="switch"
+          accessibilityState={{ checked: maskWealthValues }}
+          onPress={() => {
+            void handleToggleMasking();
+          }}
+          style={({ pressed }) => [
+            styles.card,
+            styles.toggleRow,
+            pressed && styles.pressed,
+          ]}
+        >
+          <View style={styles.toggleCopy}>
+            <AppText variant="title" weight="bold">
+              Value masking
+            </AppText>
+            <AppText color="secondary">
+              Hide INR wealth values in shared or public spaces.
+            </AppText>
+            <AppText color="secondary" variant="caption">
+              Quantities, percentages, and per-unit prices stay visible.
+            </AppText>
+          </View>
+          <View style={[styles.switchTrack, maskWealthValues && styles.switchOn]}>
+            <View
+              style={[
+                styles.switchThumb,
+                maskWealthValues && styles.switchThumbOn,
+              ]}
+            />
+          </View>
+        </Pressable>
+
+        <View style={styles.card}>
+          <AppText weight="bold">
+            {maskWealthValues ? "Values masked" : "Values visible"}
+          </AppText>
+          <AppText color="secondary">
+            This preference is stored locally on this device.
+          </AppText>
+        </View>
+
+        <View style={styles.card}>
+          <AppText variant="title" weight="bold">
+            Local-first privacy
+          </AppText>
+          <AppText color="secondary">
+            CogVest keeps portfolio data on-device. No backend, auth, analytics,
+            or cloud sync is enabled in V1.
+          </AppText>
+        </View>
+
+        <View style={styles.card}>
+          <AppText variant="title" weight="bold">
+            Quote refresh
+          </AppText>
+          <AppText color="secondary">
+            Dashboard and Holdings refresh current quotes on demand. Manual
+            prices remain available when quote APIs fail.
+          </AppText>
+        </View>
+
+        <View style={styles.card}>
+          <AppText color="secondary">App version 1.0.0</AppText>
+        </View>
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    ...shadows.none,
+    backgroundColor: colors.surface.card,
+    borderColor: colors.border.subtle,
+    borderRadius: radii.card,
+    borderWidth: 1,
+    gap: spacing.cardInner,
+    padding: spacing.md,
+  },
+  content: {
+    gap: spacing.cardGap,
+    paddingBottom: spacing.lg,
+    paddingTop: spacing.md,
+  },
+  header: {
+    gap: spacing.xs,
+  },
+  pressed: {
+    opacity: interaction.pressedOpacity,
+  },
+  switchOn: {
+    backgroundColor: colors.primary,
+  },
+  switchThumb: {
+    backgroundColor: colors.text.primary,
+    borderRadius: 10,
+    height: 20,
+    width: 20,
+  },
+  switchThumbOn: {
+    alignSelf: "flex-end",
+  },
+  switchTrack: {
+    backgroundColor: colors.surface.elevated,
+    borderColor: colors.border.subtle,
+    borderRadius: radii.pill,
+    borderWidth: 1,
+    justifyContent: "center",
+    padding: 3,
+    width: 48,
+  },
+  toggleCopy: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  toggleRow: {
+    alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+});

--- a/src/features/settings/__tests__/SettingsScreen.test.tsx
+++ b/src/features/settings/__tests__/SettingsScreen.test.tsx
@@ -1,0 +1,33 @@
+import * as Haptics from "expo-haptics";
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { SettingsScreen } from "@/src/features/settings";
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import { createPortfolioStore } from "@/src/store";
+
+jest.mock("expo-haptics", () => ({
+  selectionAsync: jest.fn(),
+}));
+
+describe("SettingsScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows privacy settings and toggles value masking", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const { getByLabelText, getByText } = render(<SettingsScreen store={store} />);
+
+    expect(getByText("Settings")).toBeTruthy();
+    expect(getByText("Value masking")).toBeTruthy();
+    expect(getByText("Values visible")).toBeTruthy();
+    expect(getByText("Local-first privacy")).toBeTruthy();
+    expect(getByText("App version 1.0.0")).toBeTruthy();
+
+    fireEvent.press(getByLabelText("Toggle value masking"));
+
+    expect(store.getState().preferences.maskWealthValues).toBe(true);
+    expect(getByText("Values masked")).toBeTruthy();
+    expect(Haptics.selectionAsync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/settings/__tests__/useSettings.test.tsx
+++ b/src/features/settings/__tests__/useSettings.test.tsx
@@ -1,0 +1,25 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import { useSettings } from "@/src/features/settings/useSettings";
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import { createPortfolioStore } from "@/src/store";
+
+describe("useSettings", () => {
+  it("toggles and persists the global value masking preference", () => {
+    const storage = createMemoryJsonStorage();
+    const firstStore = createPortfolioStore({ storage });
+    const { result } = renderHook(() => useSettings({ store: firstStore }));
+
+    expect(result.current.maskWealthValues).toBe(false);
+
+    act(() => {
+      result.current.toggleMaskWealthValues();
+    });
+
+    expect(result.current.maskWealthValues).toBe(true);
+
+    const secondStore = createPortfolioStore({ storage });
+
+    expect(secondStore.getState().preferences.maskWealthValues).toBe(true);
+  });
+});

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -1,1 +1,2 @@
-export {};
+export { SettingsScreen } from "./SettingsScreen";
+export { useSettings } from "./useSettings";

--- a/src/features/settings/useSettings.ts
+++ b/src/features/settings/useSettings.ts
@@ -1,0 +1,34 @@
+import { useSyncExternalStore } from "react";
+import type { StoreApi } from "zustand/vanilla";
+
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+
+type UseSettingsInput = {
+  store?: StoreApi<PortfolioStoreState>;
+};
+
+export type UseSettingsResult = {
+  maskWealthValues: boolean;
+  toggleMaskWealthValues: () => void;
+};
+
+function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
+  return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+}
+
+export function useSettings({
+  store = getPortfolioStore(),
+}: UseSettingsInput = {}): UseSettingsResult {
+  const snapshot = usePortfolioSnapshot(store);
+
+  function toggleMaskWealthValues() {
+    store.getState().updatePreferences({
+      maskWealthValues: !store.getState().preferences.maskWealthValues,
+    });
+  }
+
+  return {
+    maskWealthValues: snapshot.preferences.maskWealthValues,
+    toggleMaskWealthValues,
+  };
+}


### PR DESCRIPTION
## Summary
- Add a Settings screen with persisted value masking and local-first privacy copy.
- Apply global masking to Dashboard, Holdings, and Cash INR wealth values.
- Keep quantities, percentages, and market price per unit visible while masking wealth amounts.

## Validation
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm audit --audit-level=high
- npx expo start --offline --port 8086

Closes #11