### PR TITLE
[V1] Configure Android app identity and icons

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,6 +18,7 @@
     },
     "android": {
       "package": "com.abdulshaikh.cogvest",
+      "versionCode": 1,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#1C1B1F"

--- a/src/__tests__/androidIdentity.test.ts
+++ b/src/__tests__/androidIdentity.test.ts
@@ -1,0 +1,28 @@
+import appConfig from "../../app.json";
+
+describe("Android app identity", () => {
+  const expo = appConfig.expo;
+
+  it("configures the public app identity", () => {
+    expect(expo.name).toBe("CogVest");
+    expect(expo.slug).toBe("cogvest");
+    expect(expo.scheme).toBe("cogvest");
+    expect(expo.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("configures Android build identity", () => {
+    expect(expo.android.package).toBe("com.abdulshaikh.cogvest");
+    expect(expo.android.versionCode).toBeGreaterThanOrEqual(1);
+    expect(Number.isInteger(expo.android.versionCode)).toBe(true);
+  });
+
+  it("configures Android icon and splash assets", () => {
+    expect(expo.icon).toBe("./assets/icon.png");
+    expect(expo.splash.image).toBe("./assets/splash-icon.png");
+    expect(expo.splash.backgroundColor).toBe("#1C1B1F");
+    expect(expo.android.adaptiveIcon.foregroundImage).toBe(
+      "./assets/adaptive-icon.png",
+    );
+    expect(expo.android.adaptiveIcon.backgroundColor).toBe("#1C1B1F");
+  });
+});


### PR DESCRIPTION
## Summary
- Add Android versionCode to complete Expo Android build identity.
- Add a Jest regression test for app name, slug, scheme, Android package/versionCode, and icon/splash config.

## Validation
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm audit --audit-level=high
- npx expo start --offline --port 8086

Closes #12