### PR TITLE
[V1] Configure EAS build profiles

### DIFF
--- a/docs/release/android-release-process.md
+++ b/docs/release/android-release-process.md
@@ -70,7 +70,7 @@ Before production build:
 
 ## EAS Profiles
 
-Recommended `eas.json`:
+Configured in root `eas.json`:
 
 ```json
 {

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,26 @@
+{
+  "cli": {
+    "version": ">= 13.0.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "distribution": "store",
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
+  }
+}

--- a/src/__tests__/easConfig.test.ts
+++ b/src/__tests__/easConfig.test.ts
@@ -1,0 +1,33 @@
+declare const require: (id: string) => {
+  cli: {
+    version: string;
+  };
+  build: Record<string, unknown>;
+};
+
+const easConfig = require("../../eas.json");
+
+describe("EAS build profiles", () => {
+  it("defines Android development, preview, and production profiles", () => {
+    expect(easConfig.cli.version).toBe(">= 13.0.0");
+    expect(easConfig.build.development).toMatchObject({
+      developmentClient: true,
+      distribution: "internal",
+      android: {
+        buildType: "apk",
+      },
+    });
+    expect(easConfig.build.preview).toMatchObject({
+      distribution: "internal",
+      android: {
+        buildType: "apk",
+      },
+    });
+    expect(easConfig.build.production).toMatchObject({
+      distribution: "store",
+      android: {
+        buildType: "app-bundle",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add root eas.json with Android development, preview, and production build profiles.
- Configure preview builds as APK and production builds as AAB.
- Add a Jest regression test for the EAS profile shape and align the Android release docs with the committed config.

## Validation
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm audit --audit-level=high
- npx expo start --offline --port 8086
- npx eas-cli config --platform android --profile preview (blocked by missing Expo account/EXPO_TOKEN after invoking EAS CLI)

Closes #13