### PR TITLE
[V1] Add Android preview build workflow draft

### DIFF
--- a/docs/release/android-release-process.md
+++ b/docs/release/android-release-process.md
@@ -108,6 +108,9 @@ Do not commit secrets.
 GitHub Actions secrets:
 - `EXPO_TOKEN`
 
+Draft GitHub Actions workflows are documented in
+`docs/release/github-actions-drafts.md`.
+
 Future Play submission secrets:
 - Google Play service account JSON, only if EAS Submit is configured.
 

--- a/docs/release/github-actions-drafts.md
+++ b/docs/release/github-actions-drafts.md
@@ -1,36 +1,72 @@
 # GitHub Actions Drafts
 
-These workflows are drafts. Do not trigger EAS cloud builds unless explicitly approved.
+These workflows are release drafts only. Do not enable cloud EAS builds on pull
+requests or pushes until the release process is approved.
 
-## Android Preview Build
+## Android Preview APK
 
-Path: `.github/workflows/android-preview.yml`
+Purpose: manually trigger a V1 preview APK build for installation testing on a
+real Android device.
+
+Required GitHub secret:
+- `EXPO_TOKEN`
+
+Draft workflow file: `.github/workflows/android-preview.yml`
 
 ```yaml
-name: Android Preview Build
+name: Android Preview APK
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main]
+
+concurrency:
+  group: android-preview-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  preview:
+  preview-apk:
+    name: Build Android preview APK
     runs-on: ubuntu-latest
+    timeout-minutes: 45
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-      - run: npm ci
-      - run: npm run typecheck
-      - run: npm test
-      - run: npx expo doctor
-      - run: npx eas-cli build --platform android --profile preview --non-interactive
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test -- --runInBand
+
+      - name: Expo doctor
+        run: npm run doctor
+
+      - name: Build preview APK
+        run: eas build --platform android --profile preview --non-interactive
 ```
+
+Notes:
+- This workflow is manual only through `workflow_dispatch`.
+- It does not use an emulator.
+- It depends on the root `eas.json` preview profile, which outputs APK.
+- Record the EAS build URL in `docs/release/v1-release-checklist.md` during
+  release verification.
 
 ## Android Production Build
 
@@ -62,7 +98,3 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 ```
-
-## Boundary
-
-Default PR checks should not require an Android emulator. Device testing is release-gate/manual.


### PR DESCRIPTION
## Summary
- Update the Android preview APK GitHub Actions draft to be manual-only and not PR-triggered.
- Include install, typecheck, Jest, Expo doctor, and EAS preview APK build steps.
- Document the required EXPO_TOKEN secret and confirm the workflow does not require an emulator.
- Link the draft workflow document from the Android release process.

## Validation
- Select-String review for EXPO_TOKEN, workflow_dispatch, preview EAS build, checks, and no emulator requirement
- Verified .github/workflows still only contains active ci.yml
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm audit --audit-level=high
- npx expo start --offline --port 8086

Closes #14