### PR TITLE
[V1] Add Android production build workflow draft

### DIFF
--- a/docs/release/android-release-process.md
+++ b/docs/release/android-release-process.md
@@ -52,6 +52,7 @@ V1 release-candidate requires:
 - production AAB builds successfully
 - EAS build URL is recorded
 - Play Console internal testing upload is ready/manual
+- Google Play auto-submit remains disabled
 
 ## Android Identity
 

--- a/docs/release/github-actions-drafts.md
+++ b/docs/release/github-actions-drafts.md
@@ -70,10 +70,16 @@ Notes:
 
 ## Android Production Build
 
-Path: `.github/workflows/android-production.yml`
+Purpose: build a production Android App Bundle for the V1 release-candidate
+gate. This is not part of the V1 dev-complete gate.
+
+Required GitHub secret:
+- `EXPO_TOKEN`
+
+Draft workflow file: `.github/workflows/android-production.yml`
 
 ```yaml
-name: Android Production Build
+name: Android Production AAB
 
 on:
   workflow_dispatch:
@@ -82,19 +88,48 @@ on:
       - "v*.*.*"
 
 jobs:
-  production:
+  production-aab:
+    name: Build Android production AAB
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-      - run: npm ci
-      - run: npm run typecheck
-      - run: npm test
-      - run: npx expo doctor
-      - run: npx eas-cli build --platform android --profile production --non-interactive
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test -- --runInBand
+
+      - name: Expo doctor
+        run: npm run doctor
+
+      - name: Build production AAB
+        run: eas build --platform android --profile production --non-interactive
 ```
+
+Notes:
+- This workflow is manual through `workflow_dispatch` or tag-triggered for
+  `v*.*.*` release tags.
+- It depends on the root `eas.json` production profile, which outputs AAB.
+- V1 does not auto-submit to Google Play.
+- Google Play upload remains manual through Play Console internal testing.
+- Record the EAS build URL in `docs/release/v1-release-checklist.md` during
+  release-candidate verification.


### PR DESCRIPTION
## Summary
- Update the Android production workflow draft for V1 release-candidate use.
- Document manual/tag triggers, required EXPO_TOKEN, repo checks, Expo doctor, and production AAB build.
- Keep Google Play upload manual and explicitly avoid V1 auto-submit.
- Confirm no active production workflow file was added under .github/workflows.

## Validation
- Select-String review for EXPO_TOKEN, workflow_dispatch, v*.*.* tag trigger, production EAS build, AAB, and manual/no auto-submit notes
- Verified .github/workflows still only contains active ci.yml
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm audit --audit-level=high
- npx expo start --offline --port 8086

Closes #15