### PR TITLE
[V1] Record preview APK verification blockers

### DIFF
--- a/.github/workflows/android-preview.yml
+++ b/.github/workflows/android-preview.yml
@@ -1,0 +1,45 @@
+name: Android Preview APK
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: android-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview-apk:
+    name: Build Android preview APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test -- --runInBand
+
+      - name: Expo doctor
+        run: npm run doctor
+
+      - name: Build preview APK
+        run: eas build --platform android --profile preview --non-interactive

--- a/docs/release/v1-release-checklist.md
+++ b/docs/release/v1-release-checklist.md
@@ -32,7 +32,8 @@
 Preview APK:
 
 ```text
-Record preview EAS build URL during release verification.
+Pending. The 2026-05-01 verification run could not start an EAS preview build
+because this environment has no Expo login or EXPO_TOKEN.
 ```
 
 Production AAB:
@@ -44,3 +45,23 @@ Record production EAS build URL during release-candidate verification.
 ## Manual QA Notes
 
 Record device model, Android version, and any issues found during preview APK testing.
+
+## Verification Runs
+
+### 2026-05-01 - Local Gate Check
+
+- `npm run typecheck`: passed.
+- `npm test -- --runInBand`: passed, 24 suites and 77 tests.
+- `npm run doctor`: passed, 17/17 Expo doctor checks.
+- `npm audit --audit-level=high`: passed; remaining findings are moderate Expo transitive dependencies where the force fix would downgrade Expo.
+- `npx expo start --offline --port 8086`: passed; Metro started and waited on `http://localhost:8086`.
+- `npx eas-cli build --platform android --profile preview --non-interactive`: blocked before build start because no Expo account login or `EXPO_TOKEN` is available.
+- `adb devices`: blocked because `adb` is not installed or not on `PATH` in this environment.
+
+Pending before issue #16 can be closed:
+
+- Set `EXPO_TOKEN` or run `eas login` in an approved environment.
+- Run `eas build --platform android --profile preview --non-interactive`.
+- Record the preview EAS build URL above.
+- Install the generated APK on a real Android device.
+- Record device model, Android version, pass/fail status for core flows, and any defects.


### PR DESCRIPTION
## Summary
- Record the 2026-05-01 V1 local gate verification results in the release checklist.
- Document that preview APK build is blocked by missing Expo login/EXPO_TOKEN in this environment.
- Document that real-device install is blocked because adb is unavailable and no physical Android device verification was possible here.
- Leave the issue open until a preview APK build URL and real-device QA notes are recorded.

## Validation
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm audit --audit-level=high
- npx expo start --offline --port 8086
- npx eas-cli build --platform android --profile preview --non-interactive (blocked before build start by missing Expo account/EXPO_TOKEN)
- adb devices (blocked because adb is not installed or not on PATH)

Refs #16