### PR TITLE
[V1] Link EAS project

### DIFF
--- a/app.json
+++ b/app.json
@@ -29,6 +29,13 @@
     "plugins": [
       "expo-router",
       "expo-font"
-    ]
+    ],
+    "extra": {
+      "router": {},
+      "eas": {
+        "projectId": "e831d362-739b-4075-95b7-f5f85a48e610"
+      }
+    },
+    "owner": "abdul_shaikh_dev"
   }
 }

--- a/src/__tests__/androidIdentity.test.ts
+++ b/src/__tests__/androidIdentity.test.ts
@@ -16,6 +16,13 @@ describe("Android app identity", () => {
     expect(Number.isInteger(expo.android.versionCode)).toBe(true);
   });
 
+  it("links the Expo project for EAS builds", () => {
+    expect(expo.owner).toBe("abdul_shaikh_dev");
+    expect(expo.extra.eas.projectId).toBe(
+      "e831d362-739b-4075-95b7-f5f85a48e610",
+    );
+  });
+
   it("configures Android icon and splash assets", () => {
     expect(expo.icon).toBe("./assets/icon.png");
     expect(expo.splash.image).toBe("./assets/splash-icon.png");


### PR DESCRIPTION
## Summary
- Link the app to the Expo/EAS project created for @abdul_shaikh_dev/cogvest.
- Add a regression assertion for the EAS owner/projectId in the Android identity test.

## Validation
- npm run typecheck
- npm test -- --runInBand src/__tests__/androidIdentity.test.ts
- npm test -- --runInBand
- npm run doctor

Refs #16