### PR TITLE
[V1] Add Android PC test harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,28 @@ behavioural investing insights and Minimal Mode.
   build URL recorded, and Play Console internal testing upload ready/manual.
 - Do not auto-submit to Google Play in V1.
 
+## Android PC Test Harness
+- Prefer PC-only Android verification with Android Emulator and `adb`; do not
+  assume a physical phone is required.
+- Use `npm run test:verify` for static checks, Jest, and Expo doctor.
+- Use `npm run android:doctor` to check Node, npm, adb, emulator visibility,
+  Expo CLI, package scripts, and optional Maestro.
+- Use `npm run android:smoke` for emulator/package smoke checks; use
+  `npm run android:smoke -- --strict` only when CogVest should already be
+  installed.
+- Use `npm run start:clear`, then press `a`, for the normal Expo emulator loop.
+- Use `npm run android` for local native dev build/install on the emulator.
+- Do not trigger EAS cloud builds unless the user explicitly asks.
+- Do not put emulator, APK, or Maestro checks in default GitHub PR CI unless
+  explicitly requested.
+- For installed APK checks, remember APK is locally installable with `adb`;
+  AAB is for Play Store distribution and is not directly installable locally.
+- If Codex adb access fails in the sandbox, retry adb/harness commands with
+  elevated sandbox permission before concluding the emulator is unavailable.
+- PC harness docs live in `docs/testing/android-pc-test-harness.md`,
+  `docs/testing/android-emulator-checklist.md`, and
+  `docs/testing/apk-smoke-test-checklist.md`.
+
 ## References
 - Full spec: docs/cogvest-master-spec.md
 - Version roadmap: docs/roadmap/cogvest-version-roadmap.md

--- a/docs/issues/v1-add-stable-testids-for-android-e2e.md
+++ b/docs/issues/v1-add-stable-testids-for-android-e2e.md
@@ -1,0 +1,36 @@
+# [V1] Add stable testIDs for Android E2E testing
+
+GitHub issue: https://github.com/abdul-shaikh-dev/CogVest/issues/50
+
+## Context
+
+The Android PC test harness includes optional Maestro flow drafts. Some
+screen-level testIDs already exist, but robust form entry and settings flows
+need stable control-level testIDs before black-box E2E can avoid brittle text
+matching.
+
+## Scope
+
+Add stable testIDs where needed for Android E2E:
+
+- `dashboard-screen`
+- `holdings-screen`
+- `add-trade-screen`
+- `add-trade-button`
+- `asset-input`
+- `quantity-input`
+- `price-input`
+- `conviction-1`
+- `conviction-2`
+- `conviction-3`
+- `conviction-4`
+- `conviction-5`
+- `save-trade-button`
+- `value-mask-toggle`
+
+## Acceptance Criteria
+
+- Maestro Add Trade flow can target controls by stable IDs.
+- Value masking flow can target the toggle by stable ID.
+- Existing component tests remain green.
+- No behavior or visual design changes are introduced.

--- a/docs/testing/android-emulator-checklist.md
+++ b/docs/testing/android-emulator-checklist.md
@@ -1,0 +1,33 @@
+# Android Emulator Checklist
+
+- [ ] Android Studio installed.
+- [ ] Android SDK installed.
+- [ ] Android Emulator installed.
+- [ ] Pixel 7 or Pixel 8 emulator created.
+- [ ] Android 14 or Android 15 x86_64 image selected.
+- [ ] Emulator boots.
+- [ ] `adb devices` shows the emulator in `device` state.
+- [ ] `npm install` succeeds.
+- [ ] `npm run typecheck` passes.
+- [ ] `npm test` passes.
+- [ ] `npm run doctor` passes.
+- [ ] `npm run android:doctor` prints readable PASS/FAIL/WARNING output.
+- [ ] `npm run android:smoke` prints connected emulator/app-install status.
+- [ ] `npm run start:clear` starts Metro.
+- [ ] Pressing `a` opens CogVest in the emulator.
+- [ ] App launches to Dashboard, not Unmatched Route.
+- [ ] Dashboard tab renders.
+- [ ] Holdings tab renders.
+- [ ] Add Trade tab renders.
+- [ ] Cash tab renders.
+- [ ] Settings opens.
+- [ ] App can be closed and reopened.
+
+## Notes
+
+```text
+Emulator name:
+Android version:
+Result:
+Defects:
+```

--- a/docs/testing/android-pc-test-harness.md
+++ b/docs/testing/android-pc-test-harness.md
@@ -1,0 +1,236 @@
+# Android PC Test Harness
+
+## Purpose
+
+This harness verifies CogVest Android behavior from a PC without requiring a
+physical Android phone. It covers static checks, Jest/React Native Testing
+Library tests, Expo health checks, Android Emulator smoke checks, optional APK
+install smoke tests, and optional Maestro E2E flows.
+
+Default GitHub PR CI remains lightweight. Emulator, APK, and Maestro checks are
+manual PC-only verification steps.
+
+## Required Tools
+
+- Android Studio
+- Android SDK
+- Android Emulator
+- Android SDK Platform Tools (`adb`)
+- Node.js and npm
+- Expo CLI through `npx expo`
+- Optional: Maestro
+
+## Create an Emulator
+
+1. Open Android Studio.
+2. Open Device Manager.
+3. Select Create Virtual Device.
+4. Choose Pixel 7 or Pixel 8.
+5. Choose an Android 14 or Android 15 x86_64 system image.
+6. Finish setup and start the emulator.
+
+## Verify adb
+
+Run:
+
+```powershell
+adb devices
+```
+
+Expected ready emulator output includes a row like:
+
+```text
+emulator-5554    device
+```
+
+If `adb` is not found on Windows, add this folder to `PATH`:
+
+```text
+C:\Users\<username>\AppData\Local\Android\Sdk\platform-tools
+```
+
+## Normal Checks
+
+Run:
+
+```powershell
+npm run test:verify
+```
+
+This runs:
+
+```powershell
+npm run typecheck
+npm test
+npm run doctor
+```
+
+## Android Harness Checks
+
+Run:
+
+```powershell
+npm run android:doctor
+npm run android:smoke
+```
+
+`android:doctor` checks Node, npm, adb, connected emulators, Expo CLI through
+`npx`, required package scripts, and optional Maestro availability.
+
+`android:smoke` checks adb, lists connected devices, and warns if the CogVest
+Android package is not installed.
+
+Strict installed-app smoke mode:
+
+```powershell
+npm run android:smoke -- --strict
+```
+
+## Start Expo on Android Emulator
+
+Run:
+
+```powershell
+npm run start:clear
+```
+
+When Metro starts, press:
+
+```text
+a
+```
+
+Expo should open CogVest on the running Android Emulator.
+
+## Local Native Build
+
+Run:
+
+```powershell
+npm run android
+```
+
+Use this when a local native build is needed. For normal JavaScript and
+TypeScript iteration, start Metro and press `a`.
+
+## Install a Preview APK
+
+APK files can be installed locally on an emulator:
+
+```powershell
+adb install -r path/to/app.apk
+```
+
+Uninstall CogVest:
+
+```powershell
+adb uninstall com.abdulshaikh.cogvest
+```
+
+APK versus AAB:
+
+- APK is installable locally on an emulator.
+- AAB is for Play Store distribution and is not directly installable for local emulator testing.
+
+Do not trigger EAS cloud builds from this harness unless explicitly approved.
+
+## Optional Maestro E2E
+
+The `e2e/` folder contains optional Maestro flow drafts. If Maestro is not
+installed, the harness should not fail.
+
+Check Maestro:
+
+```powershell
+maestro --version
+```
+
+Run a flow after CogVest is installed on the emulator:
+
+```powershell
+maestro test e2e/smoke-launch.yaml
+```
+
+## Recommended Future testIDs
+
+Several screen-level testIDs already exist, but robust form E2E flows need more
+stable controls. Recommended follow-up testIDs:
+
+- `dashboard-screen`
+- `holdings-screen`
+- `add-trade-screen`
+- `add-trade-button`
+- `asset-input`
+- `quantity-input`
+- `price-input`
+- `conviction-1`
+- `conviction-2`
+- `conviction-3`
+- `conviction-4`
+- `conviction-5`
+- `save-trade-button`
+- `value-mask-toggle`
+
+## Troubleshooting
+
+### adb not found
+
+Install Android SDK Platform Tools and add this folder to `PATH`:
+
+```text
+C:\Users\<username>\AppData\Local\Android\Sdk\platform-tools
+```
+
+Close and reopen PowerShell, then run `adb devices`.
+
+### No emulator detected
+
+Start an emulator from Android Studio Device Manager, then run:
+
+```powershell
+adb devices
+```
+
+### Emulator offline
+
+Cold boot the emulator from Device Manager. If it remains offline, restart the
+adb server:
+
+```powershell
+adb kill-server
+adb start-server
+adb devices
+```
+
+### Metro cache issues
+
+Run:
+
+```powershell
+npm run start:clear
+```
+
+### Expo Router unmatched route
+
+Confirm the app starts through Expo Router and lands on the dashboard tab. If an
+Unmatched Route screen appears, capture the route shown on screen and the Metro
+logs before changing app code.
+
+### App opens blank screen
+
+Check Metro logs and Android logs:
+
+```powershell
+adb logcat
+```
+
+Restart Metro with `npm run start:clear`.
+
+### Port 8081 already in use
+
+Stop the old Metro process or use a different terminal. On Windows, inspect
+processes with:
+
+```powershell
+netstat -ano | findstr :8081
+```

--- a/docs/testing/apk-smoke-test-checklist.md
+++ b/docs/testing/apk-smoke-test-checklist.md
@@ -1,0 +1,28 @@
+# APK Smoke Test Checklist
+
+- [ ] Download APK from EAS/Expo.
+- [ ] Start Android Emulator.
+- [ ] Confirm emulator is ready with `adb devices`.
+- [ ] Install APK with `adb install -r path/to/app.apk`.
+- [ ] Open CogVest from launcher.
+- [ ] Verify no Unmatched Route screen appears.
+- [ ] Verify Dashboard loads.
+- [ ] Verify bottom tabs render.
+- [ ] Verify Settings opens.
+- [ ] Verify app survives close/reopen.
+- [ ] Run `npm run android:smoke -- --strict`.
+- [ ] Record APK build URL.
+- [ ] Record emulator/device name.
+- [ ] Record Android version.
+- [ ] Record result.
+
+## Evidence
+
+```text
+APK build URL:
+Emulator/device name:
+Android version:
+Install command:
+Result:
+Defects:
+```

--- a/e2e/add-trade.yaml
+++ b/e2e/add-trade.yaml
@@ -1,0 +1,7 @@
+appId: com.abdulshaikh.cogvest
+---
+- launchApp
+- tapOn: "Add Trade"
+- assertVisible: "Add Trade"
+- assertVisible: "Log a buy or sell"
+# Full form entry is intentionally deferred until stable form testIDs exist.

--- a/e2e/holdings.yaml
+++ b/e2e/holdings.yaml
@@ -1,0 +1,6 @@
+appId: com.abdulshaikh.cogvest
+---
+- launchApp
+- tapOn: "Holdings"
+- assertVisible: "Holdings"
+- assertVisible: "Add Trade"

--- a/e2e/smoke-launch.yaml
+++ b/e2e/smoke-launch.yaml
@@ -1,0 +1,6 @@
+appId: com.abdulshaikh.cogvest
+---
+- launchApp
+- assertVisible: "Dashboard"
+- assertVisible: "Holdings"
+- assertVisible: "Add Trade"

--- a/e2e/value-masking.yaml
+++ b/e2e/value-masking.yaml
@@ -1,0 +1,7 @@
+appId: com.abdulshaikh.cogvest
+---
+- launchApp
+- tapOn: "Settings"
+- assertVisible: "Value masking"
+- tapOn: "Value masking"
+- assertVisible: "Values masked"

--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
+    "start:clear": "expo start --clear",
     "android": "expo run:android",
     "doctor": "expo-doctor",
-    "test": "jest",
-    "typecheck": "tsc --noEmit"
+    "test": "jest --runInBand",
+    "typecheck": "tsc --noEmit",
+    "android:doctor": "node scripts/android-doctor.mjs",
+    "android:smoke": "node scripts/android-smoke-check.mjs",
+    "test:verify": "npm run typecheck && npm test && npm run doctor"
   },
   "jest": {
     "preset": "jest-expo",

--- a/scripts/android-doctor.mjs
+++ b/scripts/android-doctor.mjs
@@ -1,0 +1,156 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { homedir } from "node:os";
+
+const requiredScripts = [
+  "typecheck",
+  "test",
+  "doctor",
+  "start",
+  "start:clear",
+  "android",
+  "android:doctor",
+  "android:smoke",
+  "test:verify",
+];
+
+function run(command, args = []) {
+  return spawnSync(command, args, {
+    encoding: "utf8",
+  });
+}
+
+function pass(message) {
+  console.log(`PASS ${message}`);
+}
+
+function fail(message) {
+  console.log(`FAIL ${message}`);
+}
+
+function warning(message) {
+  console.log(`WARNING ${message}`);
+}
+
+function candidateNames(command) {
+  if (process.platform !== "win32") {
+    return [command];
+  }
+
+  if (/\.(exe|cmd|bat)$/i.test(command)) {
+    return [command];
+  }
+
+  return [`${command}.exe`, `${command}.cmd`, `${command}.bat`, command];
+}
+
+function findExecutable(command) {
+  if (command.includes("\\") || command.includes("/")) {
+    return existsSync(command) ? command : null;
+  }
+
+  const pathValue = process.env.PATH ?? "";
+  for (const directory of pathValue.split(process.platform === "win32" ? ";" : ":")) {
+    for (const candidate of candidateNames(command)) {
+      const fullPath = join(directory, candidate);
+      if (existsSync(fullPath)) {
+        return fullPath;
+      }
+    }
+  }
+
+  return null;
+}
+
+function parseAdbDevices(output) {
+  return output
+    .split(/\r?\n/)
+    .slice(1)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [id, state] = line.split(/\s+/);
+      return { id, state };
+    });
+}
+
+function checkExecutable(name, label = name) {
+  const executable = findExecutable(name);
+  if (executable) {
+    pass(`${label} found`);
+    return executable;
+  }
+
+  fail(`${label} not found`);
+  return null;
+}
+
+const nodeOk = existsSync(process.execPath);
+if (nodeOk) {
+  pass(`node found: ${process.version}`);
+} else {
+  fail("node not found");
+}
+
+const npmPath = checkExecutable("npm");
+const npxPath = checkExecutable("npx");
+const adbPath = checkExecutable("adb");
+
+if (!adbPath) {
+  const sdkPath = join(homedir(), "AppData", "Local", "Android", "Sdk", "platform-tools");
+  warning(`adb was not found. On Windows, check this SDK path: ${sdkPath}`);
+}
+
+if (adbPath) {
+  const devicesResult = run(adbPath, ["devices"]);
+  if (devicesResult.status !== 0) {
+    warning("adb devices could not run in this shell");
+    const details = `${devicesResult.stderr || devicesResult.stdout}`.trim();
+    if (details) {
+      warning(details);
+    }
+  } else {
+    const devices = parseAdbDevices(devicesResult.stdout);
+    const ready = devices.filter((device) => device.state === "device");
+    if (ready.length > 0) {
+      ready.forEach((device) => pass(`emulator detected: ${device.id}`));
+    } else if (devices.length > 0) {
+      warning(`adb found devices, but none are ready: ${devices.map((device) => `${device.id}:${device.state}`).join(", ")}`);
+    } else {
+      warning("adb devices returned no connected emulators/devices");
+    }
+  }
+}
+
+if (npxPath && existsSync(join("node_modules", ".bin", process.platform === "win32" ? "expo.cmd" : "expo"))) {
+  pass("Expo CLI can be invoked through npx");
+} else {
+  fail("Expo CLI could not be invoked through npx");
+}
+
+if (existsSync("package.json")) {
+  const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+  const scripts = packageJson.scripts ?? {};
+  for (const scriptName of requiredScripts) {
+    if (scripts[scriptName]) {
+      pass(`package script: ${scriptName}`);
+    } else {
+      fail(`package script missing: ${scriptName}`);
+    }
+  }
+} else {
+  fail("package.json not found");
+}
+
+if (findExecutable("maestro")) {
+  pass("Maestro found");
+} else {
+  warning("Maestro not found");
+}
+
+if (!nodeOk || !npmPath) {
+  warning("Node/npm must be fixed before Expo Android testing can run.");
+}
+
+console.log("DONE Android PC test harness check complete");

--- a/scripts/android-doctor.mjs
+++ b/scripts/android-doctor.mjs
@@ -106,7 +106,7 @@ if (adbPath) {
   const devicesResult = run(adbPath, ["devices"]);
   if (devicesResult.status !== 0) {
     warning("adb devices could not run in this shell");
-    const details = `${devicesResult.stderr || devicesResult.stdout}`.trim();
+    const details = `${devicesResult.stderr ?? devicesResult.stdout ?? devicesResult.error?.message ?? ""}`.trim();
     if (details) {
       warning(details);
     }

--- a/scripts/android-smoke-check.mjs
+++ b/scripts/android-smoke-check.mjs
@@ -75,10 +75,14 @@ pass("adb found");
 
 const devicesResult = run(adbPath, ["devices"]);
 if (devicesResult.status !== 0) {
+  const details = `${devicesResult.stderr ?? devicesResult.stdout ?? devicesResult.error?.message ?? ""}`.trim();
   if (strict) {
     fail("adb devices could not run in this shell");
   } else {
     warning("adb devices could not run in this shell");
+  }
+  if (details) {
+    warning(details);
   }
   console.log("DONE Android smoke check complete");
   process.exit(strict ? 1 : 0);

--- a/scripts/android-smoke-check.mjs
+++ b/scripts/android-smoke-check.mjs
@@ -1,0 +1,133 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const packageName = "com.abdulshaikh.cogvest";
+const strict = process.argv.includes("--strict");
+let hardFailure = false;
+
+function run(command, args = []) {
+  return spawnSync(command, args, {
+    encoding: "utf8",
+  });
+}
+
+function candidateNames(command) {
+  if (process.platform !== "win32") {
+    return [command];
+  }
+
+  return [`${command}.exe`, `${command}.cmd`, `${command}.bat`, command];
+}
+
+function findExecutable(command) {
+  const pathValue = process.env.PATH ?? "";
+  for (const directory of pathValue.split(process.platform === "win32" ? ";" : ":")) {
+    for (const candidate of candidateNames(command)) {
+      const fullPath = join(directory, candidate);
+      if (existsSync(fullPath)) {
+        return fullPath;
+      }
+    }
+  }
+
+  return null;
+}
+
+function pass(message) {
+  console.log(`PASS ${message}`);
+}
+
+function fail(message) {
+  console.log(`FAIL ${message}`);
+  hardFailure = true;
+}
+
+function warning(message) {
+  console.log(`WARNING ${message}`);
+}
+
+function parseAdbDevices(output) {
+  return output
+    .split(/\r?\n/)
+    .slice(1)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [id, state] = line.split(/\s+/);
+      return { id, state };
+    });
+}
+
+const adbPath = findExecutable("adb");
+if (!adbPath) {
+  const message = "adb not found. Install Android SDK Platform Tools and add platform-tools to PATH.";
+  if (strict) {
+    fail(message);
+  } else {
+    warning(message);
+  }
+  console.log("DONE Android smoke check complete");
+  process.exit(strict ? 1 : 0);
+}
+
+pass("adb found");
+
+const devicesResult = run(adbPath, ["devices"]);
+if (devicesResult.status !== 0) {
+  if (strict) {
+    fail("adb devices could not run in this shell");
+  } else {
+    warning("adb devices could not run in this shell");
+  }
+  console.log("DONE Android smoke check complete");
+  process.exit(strict ? 1 : 0);
+}
+
+console.log(devicesResult.stdout.trim());
+
+const devices = parseAdbDevices(devicesResult.stdout);
+const readyDevices = devices.filter((device) => device.state === "device");
+
+if (readyDevices.length === 0) {
+  const message = "no emulator/device in device state";
+  if (strict) {
+    fail(message);
+  } else {
+    warning(message);
+  }
+  console.log("DONE Android smoke check complete");
+  process.exit(strict && hardFailure ? 1 : 0);
+}
+
+readyDevices.forEach((device) => pass(`connected device: ${device.id}`));
+
+const firstDevice = readyDevices[0].id;
+const packageResult = run(adbPath, [
+  "-s",
+  firstDevice,
+  "shell",
+  "pm",
+  "list",
+  "packages",
+  packageName,
+]);
+
+if (packageResult.status !== 0) {
+  if (strict) {
+    fail(`could not query package ${packageName}`);
+  } else {
+    warning(`could not query package ${packageName}`);
+  }
+} else if (packageResult.stdout.includes(`package:${packageName}`)) {
+  pass(`app package found: ${packageName}`);
+} else if (strict) {
+  fail(`app package not installed: ${packageName}`);
+  console.log("Install an APK with: adb install -r path/to/app.apk");
+} else {
+  warning(`app package not installed: ${packageName}`);
+  console.log("Install an APK with: adb install -r path/to/app.apk");
+}
+
+console.log("DONE Android smoke check complete");
+process.exit(strict && hardFailure ? 1 : 0);


### PR DESCRIPTION
## Summary
- Add PC-only Android testing docs, emulator/APK checklists, and optional Maestro flows.
- Add android:doctor and android:smoke scripts with readable PASS/FAIL/WARNING output.
- Add test:verify plus start:clear scripts and make npm test run in-band for reliable Windows verification.
- Add a follow-up issue draft for stable Android E2E testIDs and created issue #50.

## Validation
- npm run typecheck
- npm test
- npm run doctor
- npm run test:verify
- npm run android:doctor
- npm run android:smoke

## Environment Notes
- adb/emulator not detected in this shell; android:doctor and android:smoke report this without crashing.
- Maestro not detected; optional flows are present but not required.
- No EAS build was triggered.

Closes #49