### PR TITLE
[V1] Fix Android cold launch Unmatched Route

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,5 @@
+import { Redirect } from "expo-router";
+
+export default function IndexRoute() {
+  return <Redirect href="/(tabs)/dashboard" />;
+}

--- a/src/__tests__/rootRoute.test.ts
+++ b/src/__tests__/rootRoute.test.ts
@@ -1,0 +1,9 @@
+import IndexRoute from "../../app/index";
+
+describe("root route", () => {
+  it("redirects launcher cold starts to the dashboard tab", () => {
+    const redirectElement = IndexRoute() as { props: { href: string } };
+
+    expect(redirectElement.props.href).toBe("/(tabs)/dashboard");
+  });
+});


### PR DESCRIPTION
## Summary
- Add an Expo Router root route that redirects Android launcher cold starts to the dashboard tab.
- Add a regression test for the root route redirect target.

## Verification
- npm run typecheck
- npm test
- npm run doctor
- npm run android:smoke -- --strict
- Local Android release APK built from generated native project and installed on Pixel 8 emulator.
- Cold launch via com.abdulshaikh.cogvest/.MainActivity opened dashboard-screen with Portfolio value and bottom tabs visible; Unmatched Route was not shown.

Closes #52