### PR TITLE
[V1] Add stable Android E2E testIDs

### DIFF
--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -7,6 +7,7 @@ import { AppText } from "./AppText";
 
 type EmptyStateProps = {
   actionLabel?: string;
+  actionTestID?: string;
   message: string;
   onAction?: () => void;
   title: string;
@@ -14,6 +15,7 @@ type EmptyStateProps = {
 
 export function EmptyState({
   actionLabel,
+  actionTestID,
   message,
   onAction,
   title,
@@ -27,7 +29,7 @@ export function EmptyState({
         {message}
       </AppText>
       {actionLabel && onAction ? (
-        <AppButton title={actionLabel} onPress={onAction} />
+        <AppButton title={actionLabel} testID={actionTestID} onPress={onAction} />
       ) : null}
     </View>
   );

--- a/src/components/forms/FormTextField.tsx
+++ b/src/components/forms/FormTextField.tsx
@@ -11,6 +11,7 @@ type FormTextFieldProps = {
   multiline?: boolean;
   onChangeText: (value: string) => void;
   placeholder?: string;
+  testID?: string;
   value: string;
 };
 
@@ -21,6 +22,7 @@ export function FormTextField({
   multiline = false,
   onChangeText,
   placeholder,
+  testID,
   value,
 }: FormTextFieldProps) {
   return (
@@ -36,6 +38,7 @@ export function FormTextField({
         placeholder={placeholder}
         placeholderTextColor={colors.text.muted}
         style={[styles.input, multiline && styles.multiline, error && styles.invalid]}
+        testID={testID}
         value={value}
       />
       {error ? (

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -66,7 +66,11 @@ export function DashboardScreen({
             </AppText>
           </View>
           {onAddTrade && hasAllocation ? (
-            <AppButton title="Add Trade" onPress={onAddTrade} />
+            <AppButton
+              title="Add Trade"
+              testID="add-trade-button"
+              onPress={onAddTrade}
+            />
           ) : null}
         </View>
 
@@ -92,6 +96,7 @@ export function DashboardScreen({
         ) : (
           <EmptyState
             actionLabel={onAddTrade ? "Add Trade" : undefined}
+            actionTestID="add-trade-button"
             message="Add your first trade to build holdings automatically."
             title="No allocation yet"
             onAction={onAddTrade}

--- a/src/features/dashboard/__tests__/DashboardScreen.test.tsx
+++ b/src/features/dashboard/__tests__/DashboardScreen.test.tsx
@@ -31,10 +31,12 @@ describe("DashboardScreen", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     const onAddTrade = jest.fn();
 
-    const { getAllByText, getByText } = render(
+    const { getAllByText, getByTestId, getByText } = render(
       <DashboardScreen store={store} onAddTrade={onAddTrade} />,
     );
 
+    expect(getByTestId("dashboard-screen")).toBeTruthy();
+    expect(getByTestId("add-trade-button")).toBeTruthy();
     expect(getAllByText("₹0.00").length).toBeGreaterThan(0);
     expect(getByText("No allocation yet")).toBeTruthy();
     expect(

--- a/src/features/holdings/HoldingsScreen.tsx
+++ b/src/features/holdings/HoldingsScreen.tsx
@@ -67,6 +67,7 @@ export function HoldingsScreen({
         {holdings.length === 0 ? (
           <EmptyState
             actionLabel={onAddTrade ? "Add Trade" : undefined}
+            actionTestID="add-trade-button"
             message="Holdings are created automatically from your trades."
             title="No holdings yet"
             onAction={onAddTrade}

--- a/src/features/holdings/__tests__/HoldingsScreen.test.tsx
+++ b/src/features/holdings/__tests__/HoldingsScreen.test.tsx
@@ -32,10 +32,12 @@ describe("HoldingsScreen", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     const onAddTrade = jest.fn();
 
-    const { getByText } = render(
+    const { getByTestId, getByText } = render(
       <HoldingsScreen store={store} onAddTrade={onAddTrade} />,
     );
 
+    expect(getByTestId("holdings-screen")).toBeTruthy();
+    expect(getByTestId("add-trade-button")).toBeTruthy();
     expect(getByText("No holdings yet")).toBeTruthy();
     expect(
       getByText("Holdings are created automatically from your trades."),

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -44,6 +44,7 @@ export function SettingsScreen({
             styles.toggleRow,
             pressed && styles.pressed,
           ]}
+          testID="value-mask-toggle"
         >
           <View style={styles.toggleCopy}>
             <AppText variant="title" weight="bold">

--- a/src/features/settings/__tests__/SettingsScreen.test.tsx
+++ b/src/features/settings/__tests__/SettingsScreen.test.tsx
@@ -16,8 +16,11 @@ describe("SettingsScreen", () => {
 
   it("shows privacy settings and toggles value masking", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
-    const { getByLabelText, getByText } = render(<SettingsScreen store={store} />);
+    const { getByLabelText, getByTestId, getByText } = render(
+      <SettingsScreen store={store} />,
+    );
 
+    expect(getByTestId("value-mask-toggle")).toBeTruthy();
     expect(getByText("Settings")).toBeTruthy();
     expect(getByText("Value masking")).toBeTruthy();
     expect(getByText("Values visible")).toBeTruthy();

--- a/src/features/trades/__tests__/AddTradeForm.test.tsx
+++ b/src/features/trades/__tests__/AddTradeForm.test.tsx
@@ -40,7 +40,20 @@ describe("AddTradeForm", () => {
 
   it("creates a manual asset and persists a reviewed buy trade", async () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
-    const { getByLabelText, getByText } = render(<AddTradeForm store={store} />);
+    const { getByLabelText, getByTestId, getByText } = render(
+      <AddTradeForm store={store} />,
+    );
+
+    expect(getByTestId("add-trade-screen")).toBeTruthy();
+    expect(getByTestId("asset-input")).toBeTruthy();
+    expect(getByTestId("quantity-input")).toBeTruthy();
+    expect(getByTestId("price-input")).toBeTruthy();
+    expect(getByTestId("conviction-1")).toBeTruthy();
+    expect(getByTestId("conviction-2")).toBeTruthy();
+    expect(getByTestId("conviction-3")).toBeTruthy();
+    expect(getByTestId("conviction-4")).toBeTruthy();
+    expect(getByTestId("conviction-5")).toBeTruthy();
+    expect(getByTestId("save-trade-button")).toBeTruthy();
 
     fireEvent.changeText(getByLabelText("Asset name"), "Reliance Industries");
     fireEvent.changeText(getByLabelText("Symbol"), "RELIANCE");
@@ -49,7 +62,7 @@ describe("AddTradeForm", () => {
     fireEvent.changeText(getByLabelText("Price per unit"), "100");
     fireEvent.changeText(getByLabelText("Fees"), "5");
     fireEvent.changeText(getByLabelText("Trade date"), "2026-04-20");
-    fireEvent.changeText(getByLabelText("Conviction"), "4");
+    fireEvent.press(getByTestId("conviction-4"));
     fireEvent.changeText(getByLabelText("Note"), "Core portfolio add");
 
     fireEvent.press(getByText("Review Trade"));

--- a/src/features/trades/add-trade-form.tsx
+++ b/src/features/trades/add-trade-form.tsx
@@ -18,6 +18,7 @@ type AddTradeFormProps = {
 type FieldErrors = Partial<Record<string, string>>;
 
 const manualAssetId = "__manual_asset__";
+const convictionScores: ConvictionScore[] = [1, 2, 3, 4, 5];
 
 function todayInputValue() {
   return new Date().toISOString().slice(0, 10);
@@ -255,6 +256,7 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
             resetReview();
           }}
           placeholder="Reliance Industries"
+          testID="asset-input"
           value={assetName}
         />
         <View style={styles.row}>
@@ -302,6 +304,7 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
                 resetReview();
               }}
               placeholder="2"
+              testID="quantity-input"
               value={quantity}
             />
           </View>
@@ -315,6 +318,7 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
                 resetReview();
               }}
               placeholder="100"
+              testID="price-input"
               value={pricePerUnit}
             />
           </View>
@@ -346,17 +350,48 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
             />
           </View>
         </View>
-        <FormTextField
-          error={errors.conviction}
-          keyboardType="number-pad"
-          label="Conviction"
-          onChangeText={(value) => {
-            setConviction(value);
-            resetReview();
-          }}
-          placeholder="Optional 1-5"
-          value={conviction}
-        />
+        <View style={styles.convictionGroup}>
+          <AppText color="secondary" variant="caption" weight="medium">
+            Conviction
+          </AppText>
+          <View style={styles.convictionRow}>
+            {convictionScores.map((score) => {
+              const scoreValue = score.toString();
+              const isSelected = conviction === scoreValue;
+
+              return (
+                <Pressable
+                  accessibilityLabel={`Conviction ${score}`}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: isSelected }}
+                  key={score}
+                  onPress={() => {
+                    setConviction(isSelected ? "" : scoreValue);
+                    resetReview();
+                  }}
+                  style={({ pressed }) => [
+                    styles.convictionChip,
+                    isSelected && styles.convictionChipActive,
+                    pressed && styles.pressed,
+                  ]}
+                  testID={`conviction-${score}`}
+                >
+                  <AppText
+                    color={isSelected ? "inverse" : "secondary"}
+                    weight="bold"
+                  >
+                    {score}
+                  </AppText>
+                </Pressable>
+              );
+            })}
+          </View>
+          {errors.conviction ? (
+            <AppText selectable style={styles.errorText} variant="caption">
+              {errors.conviction}
+            </AppText>
+          ) : null}
+        </View>
         <FormTextField
           label="Note"
           multiline
@@ -394,6 +429,7 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
         <AppButton title="Review Trade" onPress={handleReview} />
         <AppButton
           disabled={!reviewTrade}
+          testID="save-trade-button"
           title="Confirm Trade"
           onPress={handleConfirm}
           variant="secondary"
@@ -432,6 +468,30 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     gap: spacing.cardInner,
     padding: spacing.cardInner,
+  },
+  convictionChip: {
+    alignItems: "center",
+    backgroundColor: colors.surface.elevated,
+    borderColor: colors.border.subtle,
+    borderRadius: radii.pill,
+    borderWidth: 1,
+    flex: 1,
+    justifyContent: "center",
+    minHeight: 44,
+  },
+  convictionChipActive: {
+    backgroundColor: colors.primary,
+    borderColor: colors.primary,
+  },
+  convictionGroup: {
+    gap: spacing.xs,
+  },
+  convictionRow: {
+    flexDirection: "row",
+    gap: spacing.xs,
+  },
+  errorText: {
+    color: colors.loss,
   },
   flex: {
     flex: 1,


### PR DESCRIPTION
## Summary
- Add stable testIDs for Dashboard, Holdings, Add Trade, Settings value masking, and Add Trade form controls.
- Add reusable testID pass-throughs for form fields and empty-state actions.
- Replace free-text conviction entry with optional 1-5 conviction chips so Android E2E can target each score deterministically.
- Expand component tests to assert the E2E IDs exist.

## Verification
- npm test -- src/features/trades/__tests__/AddTradeForm.test.tsx src/features/settings/__tests__/SettingsScreen.test.tsx src/features/dashboard/__tests__/DashboardScreen.test.tsx src/features/holdings/__tests__/HoldingsScreen.test.tsx
- npm run typecheck
- npm test
- npm run doctor
- npm run android:smoke -- --strict

Closes #50