### PR TITLE
[V1] Build PC-based verification suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,9 @@ behavioural investing insights and Minimal Mode.
 - Use docs/design/v1-ui-mockup-plan.md and the Figma file for V1 UI work.
 
 ## Release Gates
-- V1 dev-complete requires typecheck, tests, Expo doctor, app launch, core
-  manual flows, preview APK build, and preview APK install on a real Android
-  device.
+- V1 dev-complete requires `npm run test:v1:pc`, Android Emulator app launch,
+  local APK build/install on emulator, and passing or logged defects for the
+  PC-based V1 core-flow matrix.
 - V1 release-candidate additionally requires production AAB build success, EAS
   build URL recorded, and Play Console internal testing upload ready/manual.
 - Do not auto-submit to Google Play in V1.
@@ -72,6 +72,8 @@ behavioural investing insights and Minimal Mode.
 - Prefer PC-only Android verification with Android Emulator and `adb`; do not
   assume a physical phone is required.
 - Use `npm run test:verify` for static checks, Jest, and Expo doctor.
+- Use `npm run test:v1:pc` for the V1 PC verification gate. It extends
+  `test:verify` with Android doctor and strict installed-app smoke checks.
 - Use `npm run android:doctor` to check Node, npm, adb, emulator visibility,
   Expo CLI, package scripts, and optional Maestro.
 - Use `npm run android:smoke` for emulator/package smoke checks; use
@@ -89,6 +91,8 @@ behavioural investing insights and Minimal Mode.
 - PC harness docs live in `docs/testing/android-pc-test-harness.md`,
   `docs/testing/android-emulator-checklist.md`, and
   `docs/testing/apk-smoke-test-checklist.md`.
+- V1 core-flow coverage lives in `docs/testing/v1-core-flow-test-matrix.md`
+  and `docs/testing/v1-pc-verification-checklist.md`.
 
 ## References
 - Full spec: docs/cogvest-master-spec.md
@@ -97,6 +101,7 @@ behavioural investing insights and Minimal Mode.
 - V1 prompts: docs/roadmap/v1-codex-prompts.md
 - V1 issue drafts: docs/issues/v1-issue-drafts.md
 - V1 testing plan: docs/testing/v1-testing-plan.md
+- V1 PC verification matrix: docs/testing/v1-core-flow-test-matrix.md
 - Android release process: docs/release/android-release-process.md
 - Mockups: docs/cogvest_standard_mode.png, docs/cogvest_minimal_mode.png
 - Figma roadmap mockups: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d

--- a/docs/release/android-release-process.md
+++ b/docs/release/android-release-process.md
@@ -15,7 +15,9 @@ eas build --platform android --profile development
 
 ### Preview Build
 
-Purpose: installable APK for manual testing on real Android devices.
+Purpose: optional installable APK for internal distribution. For local
+developer verification, prefer a PC-built APK installed on Android Emulator so
+EAS cloud compute is not consumed.
 
 Command:
 
@@ -40,13 +42,12 @@ Output: AAB.
 ## V1 Gate Split
 
 V1 dev-complete requires:
-- `npm run typecheck`
-- `npm test`
-- `npx expo doctor`
-- app starts with `npx expo start`
-- core manual flows pass
-- preview APK builds
-- preview APK installs on a real Android device
+- `npm run test:v1:pc`
+- app starts on Android Emulator
+- local APK builds on the developer PC
+- local APK installs on Android Emulator
+- core V1 flows pass through `docs/testing/v1-core-flow-test-matrix.md`
+- defects are logged with `docs/testing/v1-defect-report-template.md`
 
 V1 release-candidate requires:
 - production AAB builds successfully

--- a/docs/release/github-actions-drafts.md
+++ b/docs/release/github-actions-drafts.md
@@ -5,8 +5,8 @@ requests or pushes until the release process is approved.
 
 ## Android Preview APK
 
-Purpose: manually trigger a V1 preview APK build for installation testing on a
-real Android device.
+Purpose: manually trigger an optional V1 preview APK build for internal
+distribution. This is not required for the local PC/emulator developer gate.
 
 Required GitHub secret:
 - `EXPO_TOKEN`
@@ -65,8 +65,8 @@ Notes:
 - This workflow is manual only through `workflow_dispatch`.
 - It does not use an emulator.
 - It depends on the root `eas.json` preview profile, which outputs APK.
-- Record the EAS build URL in `docs/release/v1-release-checklist.md` during
-  release verification.
+- Record the EAS build URL in `docs/release/v1-release-checklist.md` only if
+  an EAS preview build is explicitly requested for release verification.
 
 ## Android Production Build
 

--- a/docs/release/v1-release-checklist.md
+++ b/docs/release/v1-release-checklist.md
@@ -3,18 +3,12 @@
 ## Dev-Complete Gate
 
 - [ ] `npm install` succeeds.
-- [ ] `npm run typecheck` passes.
-- [ ] `npm test` passes.
-- [ ] `npx expo doctor` passes.
-- [ ] App starts with `npx expo start`.
-- [ ] Add Trade works manually.
-- [ ] Holdings update after trade.
-- [ ] Dashboard total updates after holdings/cash changes.
-- [ ] Cash entry updates cash total.
-- [ ] Value masking works.
-- [ ] App data persists after restart.
-- [ ] Preview APK builds successfully.
-- [ ] Preview APK installs on real Android device.
+- [ ] `npm run test:v1:pc` passes.
+- [ ] App starts on Android Emulator.
+- [ ] Local APK builds successfully on the developer PC.
+- [ ] Local APK installs on Android Emulator.
+- [ ] Core V1 flows pass through `docs/testing/v1-core-flow-test-matrix.md`.
+- [ ] Defects are logged with `docs/testing/v1-defect-report-template.md`.
 - [ ] No backend/auth/cloud was added.
 - [ ] Secrets are not committed.
 
@@ -29,11 +23,10 @@
 
 ## Build URL Log
 
-Preview APK:
+Local APK:
 
 ```text
-Pending. The 2026-05-01 verification run could not start an EAS preview build
-because this environment has no Expo login or EXPO_TOKEN.
+Record local APK path or EAS preview build URL if one is explicitly requested.
 ```
 
 Production AAB:
@@ -44,7 +37,8 @@ Record production EAS build URL during release-candidate verification.
 
 ## Manual QA Notes
 
-Record device model, Android version, and any issues found during preview APK testing.
+Record emulator model, Android version, APK source, and any issues found during
+PC-based APK testing.
 
 ## Verification Runs
 
@@ -58,10 +52,8 @@ Record device model, Android version, and any issues found during preview APK te
 - `npx eas-cli build --platform android --profile preview --non-interactive`: blocked before build start because no Expo account login or `EXPO_TOKEN` is available.
 - `adb devices`: blocked because `adb` is not installed or not on `PATH` in this environment.
 
-Pending before issue #16 can be closed:
+Superseded physical-device notes:
 
-- Set `EXPO_TOKEN` or run `eas login` in an approved environment.
-- Run `eas build --platform android --profile preview --non-interactive`.
-- Record the preview EAS build URL above.
-- Install the generated APK on a real Android device.
-- Record device model, Android version, pass/fail status for core flows, and any defects.
+- The old physical-phone preview APK gate was superseded by issue #54.
+- V1 dev-complete verification should use the PC/emulator matrix in `docs/testing/`.
+- EAS preview builds remain optional unless explicitly requested.

--- a/docs/roadmap/v1-mvp-spec.md
+++ b/docs/roadmap/v1-mvp-spec.md
@@ -24,7 +24,7 @@ The user can record trades quickly, see current holdings and portfolio value in 
 - Cash screen for additions and withdrawals.
 - Simple settings with value masking.
 - Empty states with direct CTAs.
-- Android preview APK build documentation and V1 release checklist.
+- Android PC verification harness, local APK smoke path, and V1 release checklist.
 
 ## Explicitly Excluded Features
 
@@ -89,9 +89,9 @@ Do not persist holdings, allocation, dashboard totals, or insights.
 
 - Unit tests for domain calculations, formatters, validators, selectors, and store actions.
 - Component tests for empty states, value masking, conviction selector, and Add Trade validation.
-- Manual Android checks for navigation, trade entry, holdings, dashboard, cash, masking, and persistence.
+- PC-based Android Emulator checks for navigation, trade entry, holdings, dashboard, cash, masking, and persistence.
 
-## Manual QA Checklist
+## PC Verification Checklist
 
 - Add a buy trade for BTC.
 - Add a buy trade for RELIANCE.
@@ -106,16 +106,15 @@ Do not persist holdings, allocation, dashboard totals, or insights.
 ## Definition of Done
 
 - All V1 issues complete or intentionally deferred with notes.
-- `npm run typecheck` passes.
-- `npm test` passes.
-- `npx expo doctor` passes.
-- App launches with `npx expo start`.
-- Preview APK builds and installs on a real Android device.
+- `npm run test:v1:pc` passes.
+- App launches on Android Emulator.
+- Local APK builds and installs on Android Emulator.
+- Core V1 matrix passes or defects are logged.
 
 ## Release Gate
 
 Dev-complete gate:
-- typecheck, tests, Expo doctor, app launch, manual V1 flows, preview APK build, preview APK device install.
+- `npm run test:v1:pc`, Android Emulator app launch, local APK build/install, and `docs/testing/v1-core-flow-test-matrix.md`.
 
 Release-candidate gate:
 - production AAB builds, EAS build URL recorded, Play Console internal testing upload ready/manual.

--- a/docs/testing/android-emulator-checklist.md
+++ b/docs/testing/android-emulator-checklist.md
@@ -11,6 +11,7 @@
 - [ ] `npm run typecheck` passes.
 - [ ] `npm test` passes.
 - [ ] `npm run doctor` passes.
+- [ ] `npm run test:v1:pc` passes after CogVest is installed.
 - [ ] `npm run android:doctor` prints readable PASS/FAIL/WARNING output.
 - [ ] `npm run android:smoke` prints connected emulator/app-install status.
 - [ ] `npm run start:clear` starts Metro.
@@ -22,6 +23,7 @@
 - [ ] Cash tab renders.
 - [ ] Settings opens.
 - [ ] App can be closed and reopened.
+- [ ] `docs/testing/v1-core-flow-test-matrix.md` is completed or defects are logged.
 
 ## Notes
 

--- a/docs/testing/android-pc-test-harness.md
+++ b/docs/testing/android-pc-test-harness.md
@@ -65,6 +65,15 @@ npm test
 npm run doctor
 ```
 
+For the full V1 PC verification gate, run:
+
+```powershell
+npm run test:v1:pc
+```
+
+This extends `test:verify` with `android:doctor` and strict installed-app
+smoke status. It is intentionally not part of default GitHub PR CI.
+
 ## Android Harness Checks
 
 Run:
@@ -151,16 +160,17 @@ Run a flow after CogVest is installed on the emulator:
 maestro test e2e/smoke-launch.yaml
 ```
 
-## Recommended Future testIDs
+## Stable V1 testIDs
 
-Several screen-level testIDs already exist, but robust form E2E flows need more
-stable controls. Recommended follow-up testIDs:
+Stable Android E2E IDs are available for V1 flows:
 
 - `dashboard-screen`
 - `holdings-screen`
 - `add-trade-screen`
 - `add-trade-button`
 - `asset-input`
+- `symbol-input`
+- `ticker-input`
 - `quantity-input`
 - `price-input`
 - `conviction-1`
@@ -168,8 +178,17 @@ stable controls. Recommended follow-up testIDs:
 - `conviction-3`
 - `conviction-4`
 - `conviction-5`
+- `review-trade-button`
 - `save-trade-button`
 - `value-mask-toggle`
+- `cash-screen`
+- `cash-amount-input`
+- `cash-label-input`
+- `cash-date-input`
+- `save-cash-entry-button`
+
+See `docs/testing/v1-core-flow-test-matrix.md` for the full feature coverage
+map.
 
 ## Troubleshooting
 

--- a/docs/testing/apk-smoke-test-checklist.md
+++ b/docs/testing/apk-smoke-test-checklist.md
@@ -1,6 +1,6 @@
 # APK Smoke Test Checklist
 
-- [ ] Download APK from EAS/Expo.
+- [ ] Build or download an APK. Prefer local PC builds for developer smoke tests.
 - [ ] Start Android Emulator.
 - [ ] Confirm emulator is ready with `adb devices`.
 - [ ] Install APK with `adb install -r path/to/app.apk`.
@@ -11,7 +11,7 @@
 - [ ] Verify Settings opens.
 - [ ] Verify app survives close/reopen.
 - [ ] Run `npm run android:smoke -- --strict`.
-- [ ] Record APK build URL.
+- [ ] Record APK source. Use a local path for local builds or a build URL for EAS.
 - [ ] Record emulator/device name.
 - [ ] Record Android version.
 - [ ] Record result.
@@ -19,7 +19,7 @@
 ## Evidence
 
 ```text
-APK build URL:
+APK source:
 Emulator/device name:
 Android version:
 Install command:

--- a/docs/testing/v1-core-flow-test-matrix.md
+++ b/docs/testing/v1-core-flow-test-matrix.md
@@ -1,0 +1,92 @@
+# V1 Core Flow Test Matrix
+
+## Purpose
+
+This matrix is the canonical V1 PC-only verification map. It replaces
+physical-phone manual acceptance with repeatable checks that run on the
+developer PC, Android Emulator, adb, Jest, React Native Testing Library, and
+optional Maestro.
+
+Default PR CI must stay lightweight. Emulator, APK install, and Maestro checks
+are local verification gates, not required pull-request checks.
+
+## Required PC Gate
+
+Run before marking V1 core flows verified:
+
+```powershell
+npm run test:v1:pc
+```
+
+This runs:
+
+```powershell
+npm run typecheck
+npm test
+npm run doctor
+npm run android:doctor
+npm run android:smoke -- --strict
+```
+
+If the installed Android app needs to be refreshed locally, build and install a
+local APK from this machine. Do not run EAS cloud builds unless explicitly
+approved.
+
+## Feature Matrix
+
+| V1 feature | Primary verification | Emulator / E2E coverage | Evidence |
+| --- | --- | --- | --- |
+| Cold launch | `src/__tests__/rootRoute.test.ts` | `e2e/smoke-launch.yaml` launches `com.abdulshaikh.cogvest` and asserts `dashboard-screen` | UI tree or Maestro output shows Dashboard, not Unmatched Route |
+| Dashboard empty state | `src/features/dashboard/__tests__/DashboardScreen.test.tsx` | `e2e/smoke-launch.yaml` asserts `dashboard-screen` and tab labels | Dashboard shows portfolio value and Add Trade path |
+| Add Trade buy flow | `src/features/trades/__tests__/AddTradeForm.test.tsx` | `e2e/add-trade.yaml` uses stable form IDs and saves a buy trade | Trade logged message or holding appears |
+| Add Trade validation | `src/features/trades/__tests__/AddTradeForm.test.tsx`, `src/domain/validators/__tests__/trade.test.ts` | Optional Maestro follow-up for validation text | Invalid oversell and missing fields are rejected |
+| Holdings derivation | `src/features/holdings/__tests__/HoldingsScreen.test.tsx`, `src/domain/calculations/__tests__/holdings.test.ts` | `e2e/holdings.yaml` asserts holdings after Add Trade | Holding row shows symbol, quantity, value |
+| Quote refresh and fallback | `src/services/quotes/__tests__/quotes.test.ts`, `src/services/quotes/__tests__/useQuoteRefresh.test.tsx`, Holdings tests | Manual emulator pull-to-refresh or Refresh Quotes action where network is available | Failures keep manual prices visible |
+| Cash tracking | `src/features/cash/__tests__/CashScreen.test.tsx`, `src/features/cash/__tests__/useCash.test.tsx` | `e2e/cash.yaml` adds cash by stable IDs | Cash balance and cash history update |
+| Value masking | `src/features/settings/__tests__/SettingsScreen.test.tsx`, dashboard/holdings/cash masked-value tests | `e2e/value-masking.yaml` opens `cogvest://settings` and toggles `value-mask-toggle` | Wealth values mask; quantities and percentages remain visible |
+| Persistence after close/reopen | `src/store/__tests__/portfolioStore.test.ts`, storage tests | `e2e/persistence.yaml` saves data, stops app, relaunches, and verifies data remains | State remains after app restart |
+| No backend/auth/cloud | Smoke tests and release review | Manual repo inspection before release | No backend, auth, analytics, cloud sync, or push notification feature is added |
+
+## Optional Maestro Command Set
+
+Install Maestro separately if needed. The repo does not add Maestro as a npm
+dependency.
+
+```powershell
+maestro test e2e/smoke-launch.yaml
+maestro test e2e/add-trade.yaml
+maestro test e2e/holdings.yaml
+maestro test e2e/cash.yaml
+maestro test e2e/value-masking.yaml
+maestro test e2e/persistence.yaml
+```
+
+If Maestro is unavailable, record that as:
+
+```text
+Maestro E2E not run: Maestro unavailable.
+```
+
+## Defect Logging
+
+Every failed core flow must become a GitHub issue with:
+
+- Title beginning with `[V1 QA]`.
+- Environment: OS, emulator name, Android version, app package, APK source.
+- Repro steps.
+- Expected result.
+- Actual result.
+- Evidence: screenshot, UI tree, logcat excerpt, or test output.
+- Link to the failed matrix row.
+
+## Uncovered Or Manual-Only Items
+
+These items are intentionally not default PR CI:
+
+- Android Emulator launch and installed APK checks.
+- Maestro flows.
+- Local APK build/install.
+- Any EAS preview or production build.
+
+If a V1 feature cannot be covered by Jest, RNTL, adb, or Maestro, create a
+follow-up issue and link it from this matrix.

--- a/docs/testing/v1-defect-report-template.md
+++ b/docs/testing/v1-defect-report-template.md
@@ -1,0 +1,37 @@
+# V1 Defect Report Template
+
+Use this template when a PC verification flow fails.
+
+```markdown
+## Environment
+
+- OS:
+- Emulator:
+- Android version:
+- App package: com.abdulshaikh.cogvest
+- APK source:
+- Branch/commit:
+
+## Repro Steps
+
+1. 
+2. 
+3. 
+
+## Expected Result
+
+
+## Actual Result
+
+
+## Evidence
+
+- Screenshot:
+- UI tree:
+- Logcat:
+- Command output:
+
+## Matrix Row
+
+Link to `docs/testing/v1-core-flow-test-matrix.md` row:
+```

--- a/docs/testing/v1-pc-verification-checklist.md
+++ b/docs/testing/v1-pc-verification-checklist.md
@@ -1,0 +1,58 @@
+# V1 PC Verification Checklist
+
+Use this checklist before marking V1 core flows verified. It requires an
+Android Emulator, not a physical Android phone.
+
+## Static And Unit Gate
+
+- [ ] `npm install` has completed successfully.
+- [ ] `npm run test:v1:pc` passes.
+- [ ] `npm run doctor` reports 17/17 checks passing.
+- [ ] `npm run android:doctor` reports adb and emulator readiness.
+- [ ] `npm run android:smoke -- --strict` finds `com.abdulshaikh.cogvest`.
+
+## Local APK Gate
+
+- [ ] Local APK is built on this PC, not through EAS cloud build.
+- [ ] APK is installed on the emulator with `adb install -r path/to/app.apk`.
+- [ ] App cold-launches from launcher or `.MainActivity`.
+- [ ] Dashboard opens, not Unmatched Route.
+- [ ] App closes and reopens without losing local data.
+
+## Core Flow Gate
+
+- [ ] Dashboard shows portfolio value and bottom tabs.
+- [ ] Add Trade can save a buy trade.
+- [ ] Holdings reflect the saved trade.
+- [ ] Invalid trade data shows validation errors.
+- [ ] Cash can be added.
+- [ ] Cash balance appears on Dashboard.
+- [ ] Value masking can be toggled from Settings.
+- [ ] Masked state hides wealth values but not quantities or percentages.
+- [ ] Quote refresh or fallback state is visible where holdings exist.
+- [ ] No backend, auth, analytics, cloud sync, or push notifications are added.
+
+## Optional Maestro Gate
+
+- [ ] `maestro --version` works, or unavailable status is recorded.
+- [ ] `maestro test e2e/smoke-launch.yaml` passes.
+- [ ] `maestro test e2e/add-trade.yaml` passes.
+- [ ] `maestro test e2e/holdings.yaml` passes.
+- [ ] `maestro test e2e/cash.yaml` passes.
+- [ ] `maestro test e2e/value-masking.yaml` passes.
+- [ ] `maestro test e2e/persistence.yaml` passes.
+
+## Evidence
+
+```text
+Date:
+Branch/commit:
+Emulator:
+Android version:
+APK source:
+Installed package:
+Commands run:
+Maestro status:
+Result:
+Defects logged:
+```

--- a/docs/testing/v1-testing-plan.md
+++ b/docs/testing/v1-testing-plan.md
@@ -1,5 +1,9 @@
 # V1 Testing Plan
 
+V1 verification is PC-only. A physical Android phone is not required. The
+canonical feature matrix is `docs/testing/v1-core-flow-test-matrix.md`, and the
+release checklist is `docs/testing/v1-pc-verification-checklist.md`.
+
 ## Automated Tests
 
 Run on every V1 issue:
@@ -12,8 +16,7 @@ npm test
 Run before release gate:
 
 ```bash
-npx expo doctor
-npx expo start
+npm run test:v1:pc
 ```
 
 ## Unit Tests
@@ -40,7 +43,7 @@ Cover:
 - MaskedValue display.
 - Cash add/withdraw rows.
 
-## Manual Android QA
+## Android Emulator QA
 
 - Add buy trade.
 - Add sell trade.
@@ -55,13 +58,18 @@ Cover:
 
 ## E2E Scope
 
-Maestro is optional for V1 development but recommended before release:
+Maestro is optional for V1 development but recommended before release. It must
+run locally against Android Emulator and must not be required in default PR CI:
+
 - add trade
 - holdings update
 - dashboard total
 - cash flow
 - value masking
+- persistence
+- cold launch
 
 ## Known Test Boundaries
 
-Default CI should not require Android emulator. Device/emulator testing is manual or release-gate only.
+Default CI should not require Android emulator. Emulator, APK, and Maestro
+testing are local PC verification gates only unless explicitly opted in.

--- a/e2e/add-trade.yaml
+++ b/e2e/add-trade.yaml
@@ -1,7 +1,30 @@
 appId: com.abdulshaikh.cogvest
 ---
-- launchApp
-- tapOn: "Add Trade"
-- assertVisible: "Add Trade"
-- assertVisible: "Log a buy or sell"
-# Full form entry is intentionally deferred until stable form testIDs exist.
+- launchApp:
+    clearState: true
+- tapOn: "Add"
+- assertVisible:
+    id: "add-trade-screen"
+- tapOn:
+    id: "asset-input"
+- inputText: "Reliance Industries"
+- tapOn:
+    id: "symbol-input"
+- inputText: "RELIANCE"
+- tapOn:
+    id: "ticker-input"
+- inputText: "RELIANCE.NS"
+- tapOn:
+    id: "quantity-input"
+- inputText: "2"
+- tapOn:
+    id: "price-input"
+- inputText: "100"
+- tapOn:
+    id: "conviction-4"
+- tapOn:
+    id: "review-trade-button"
+- assertVisible: "Review buy"
+- tapOn:
+    id: "save-trade-button"
+- assertVisible: "Trade logged."

--- a/e2e/cash.yaml
+++ b/e2e/cash.yaml
@@ -1,0 +1,20 @@
+appId: com.abdulshaikh.cogvest
+---
+- launchApp:
+    clearState: true
+- tapOn: "Cash"
+- assertVisible:
+    id: "cash-screen"
+- tapOn:
+    id: "cash-amount-input"
+- inputText: "1000"
+- tapOn:
+    id: "cash-label-input"
+- inputText: "Broker cash"
+- tapOn:
+    id: "cash-date-input"
+- inputText: "2026-04-20"
+- tapOn:
+    id: "save-cash-entry-button"
+- assertVisible: "Broker cash"
+- assertVisible: "Cash balance"

--- a/e2e/holdings.yaml
+++ b/e2e/holdings.yaml
@@ -1,6 +1,29 @@
 appId: com.abdulshaikh.cogvest
 ---
-- launchApp
+- launchApp:
+    clearState: true
+- tapOn: "Add"
+- tapOn:
+    id: "asset-input"
+- inputText: "Reliance Industries"
+- tapOn:
+    id: "symbol-input"
+- inputText: "RELIANCE"
+- tapOn:
+    id: "ticker-input"
+- inputText: "RELIANCE.NS"
+- tapOn:
+    id: "quantity-input"
+- inputText: "2"
+- tapOn:
+    id: "price-input"
+- inputText: "100"
+- tapOn:
+    id: "review-trade-button"
+- tapOn:
+    id: "save-trade-button"
 - tapOn: "Holdings"
-- assertVisible: "Holdings"
-- assertVisible: "Add Trade"
+- assertVisible:
+    id: "holdings-screen"
+- assertVisible: "Reliance Industries"
+- assertVisible: "Qty 2"

--- a/e2e/persistence.yaml
+++ b/e2e/persistence.yaml
@@ -1,0 +1,21 @@
+appId: com.abdulshaikh.cogvest
+---
+- launchApp:
+    clearState: true
+- tapOn: "Cash"
+- tapOn:
+    id: "cash-amount-input"
+- inputText: "1000"
+- tapOn:
+    id: "cash-label-input"
+- inputText: "Broker cash"
+- tapOn:
+    id: "cash-date-input"
+- inputText: "2026-04-20"
+- tapOn:
+    id: "save-cash-entry-button"
+- assertVisible: "Broker cash"
+- stopApp
+- launchApp
+- tapOn: "Cash"
+- assertVisible: "Broker cash"

--- a/e2e/smoke-launch.yaml
+++ b/e2e/smoke-launch.yaml
@@ -1,6 +1,10 @@
 appId: com.abdulshaikh.cogvest
 ---
-- launchApp
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "dashboard-screen"
 - assertVisible: "Dashboard"
 - assertVisible: "Holdings"
-- assertVisible: "Add Trade"
+- assertVisible: "Add"
+- assertNotVisible: "Unmatched Route"

--- a/e2e/value-masking.yaml
+++ b/e2e/value-masking.yaml
@@ -1,7 +1,9 @@
 appId: com.abdulshaikh.cogvest
 ---
-- launchApp
-- tapOn: "Settings"
+- launchApp:
+    clearState: true
+- openLink: "cogvest://settings"
 - assertVisible: "Value masking"
-- tapOn: "Value masking"
+- tapOn:
+    id: "value-mask-toggle"
 - assertVisible: "Values masked"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "typecheck": "tsc --noEmit",
     "android:doctor": "node scripts/android-doctor.mjs",
     "android:smoke": "node scripts/android-smoke-check.mjs",
-    "test:verify": "npm run typecheck && npm test && npm run doctor"
+    "test:verify": "npm run typecheck && npm test && npm run doctor",
+    "test:v1:pc": "npm run test:verify && npm run android:doctor && npm run android:smoke -- --strict"
   },
   "jest": {
     "preset": "jest-expo",

--- a/scripts/android-doctor.mjs
+++ b/scripts/android-doctor.mjs
@@ -13,6 +13,7 @@ const requiredScripts = [
   "android:doctor",
   "android:smoke",
   "test:verify",
+  "test:v1:pc",
 ];
 
 function run(command, args = []) {

--- a/src/features/cash/CashScreen.tsx
+++ b/src/features/cash/CashScreen.tsx
@@ -147,6 +147,7 @@ export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
             label="Amount"
             onChangeText={setAmount}
             placeholder="1000"
+            testID="cash-amount-input"
             value={amount}
           />
           <FormTextField
@@ -154,6 +155,7 @@ export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
             label="Label"
             onChangeText={setLabel}
             placeholder={type === "addition" ? "Broker cash" : "Withdrawal"}
+            testID="cash-label-input"
             value={label}
           />
           <FormTextField
@@ -161,6 +163,7 @@ export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
             label="Date"
             onChangeText={setDate}
             placeholder="YYYY-MM-DD"
+            testID="cash-date-input"
             value={date}
           />
           <FormTextField
@@ -170,7 +173,11 @@ export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
             placeholder="Optional note"
             value={notes}
           />
-          <AppButton title="Save Cash Entry" onPress={submit} />
+          <AppButton
+            title="Save Cash Entry"
+            testID="save-cash-entry-button"
+            onPress={submit}
+          />
         </View>
 
         {entries.length === 0 ? (

--- a/src/features/cash/__tests__/CashScreen.test.tsx
+++ b/src/features/cash/__tests__/CashScreen.test.tsx
@@ -9,8 +9,13 @@ describe("CashScreen", () => {
   it("shows an empty cash state with zero balance", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
 
-    const { getByText } = render(<CashScreen store={store} />);
+    const { getByTestId, getByText } = render(<CashScreen store={store} />);
 
+    expect(getByTestId("cash-screen")).toBeTruthy();
+    expect(getByTestId("cash-amount-input")).toBeTruthy();
+    expect(getByTestId("cash-label-input")).toBeTruthy();
+    expect(getByTestId("cash-date-input")).toBeTruthy();
+    expect(getByTestId("save-cash-entry-button")).toBeTruthy();
     expect(getByText("₹0.00")).toBeTruthy();
     expect(getByText("No cash entries yet")).toBeTruthy();
     expect(getByText("Add available broker or bank cash to include it in portfolio value.")).toBeTruthy();

--- a/src/features/trades/__tests__/AddTradeForm.test.tsx
+++ b/src/features/trades/__tests__/AddTradeForm.test.tsx
@@ -46,6 +46,8 @@ describe("AddTradeForm", () => {
 
     expect(getByTestId("add-trade-screen")).toBeTruthy();
     expect(getByTestId("asset-input")).toBeTruthy();
+    expect(getByTestId("symbol-input")).toBeTruthy();
+    expect(getByTestId("ticker-input")).toBeTruthy();
     expect(getByTestId("quantity-input")).toBeTruthy();
     expect(getByTestId("price-input")).toBeTruthy();
     expect(getByTestId("conviction-1")).toBeTruthy();
@@ -53,6 +55,7 @@ describe("AddTradeForm", () => {
     expect(getByTestId("conviction-3")).toBeTruthy();
     expect(getByTestId("conviction-4")).toBeTruthy();
     expect(getByTestId("conviction-5")).toBeTruthy();
+    expect(getByTestId("review-trade-button")).toBeTruthy();
     expect(getByTestId("save-trade-button")).toBeTruthy();
 
     fireEvent.changeText(getByLabelText("Asset name"), "Reliance Industries");

--- a/src/features/trades/add-trade-form.tsx
+++ b/src/features/trades/add-trade-form.tsx
@@ -270,6 +270,7 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
                 resetReview();
               }}
               placeholder="RELIANCE"
+              testID="symbol-input"
               value={symbol}
             />
           </View>
@@ -283,6 +284,7 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
                 resetReview();
               }}
               placeholder="RELIANCE.NS"
+              testID="ticker-input"
               value={ticker}
             />
           </View>
@@ -426,7 +428,11 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
       ) : null}
 
       <View style={styles.actions}>
-        <AppButton title="Review Trade" onPress={handleReview} />
+        <AppButton
+          title="Review Trade"
+          testID="review-trade-button"
+          onPress={handleReview}
+        />
         <AppButton
           disabled={!reviewTrade}
           testID="save-trade-button"


### PR DESCRIPTION
## Summary
- Add the canonical V1 PC verification matrix, checklist, and defect report template.
- Add a 	est:v1:pc script that runs static checks, Expo doctor, Android doctor, and strict installed-app smoke.
- Update release, roadmap, AGENTS, and testing docs to use Android Emulator and local APK verification instead of physical-phone gates.
- Expand Maestro flow drafts to stable IDs and add cash plus persistence flows.
- Add missing cash and Add Trade E2E testIDs needed by the flows.

## Verification
- npm test -- src/features/trades/__tests__/AddTradeForm.test.tsx src/features/cash/__tests__/CashScreen.test.tsx
- npm run typecheck
- npm test
- npm run doctor
- npm run test:v1:pc

## Android PC Evidence
- adb emulator detected: emulator-5554
- installed app package found: com.abdulshaikh.cogvest
- Maestro status: not installed; documented as optional and android:doctor reports WARNING only

Closes #54