### PR TITLE
[V1] Add Maestro local E2E runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,8 @@ behavioural investing insights and Minimal Mode.
 - Do not trigger EAS cloud builds unless the user explicitly asks.
 - Do not put emulator, APK, or Maestro checks in default GitHub PR CI unless
   explicitly requested.
+- Use `npm run maestro:check` and `npm run maestro:test` for optional local
+  Maestro E2E verification when Maestro is installed.
 - For installed APK checks, remember APK is locally installable with `adb`;
   AAB is for Play Store distribution and is not directly installable locally.
 - If Codex adb access fails in the sandbox, retry adb/harness commands with

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -55,11 +55,26 @@ export default function TabLayout() {
         ),
       })}
     >
-      <Tabs.Screen name="dashboard" options={{ title: "Dashboard" }} />
-      <Tabs.Screen name="holdings" options={{ title: "Holdings" }} />
-      <Tabs.Screen name="add-trade" options={{ title: "Add" }} />
-      <Tabs.Screen name="history" options={{ title: "History" }} />
-      <Tabs.Screen name="cash" options={{ title: "Cash" }} />
+      <Tabs.Screen
+        name="dashboard"
+        options={{ tabBarButtonTestID: "dashboard-tab", title: "Dashboard" }}
+      />
+      <Tabs.Screen
+        name="holdings"
+        options={{ tabBarButtonTestID: "holdings-tab", title: "Holdings" }}
+      />
+      <Tabs.Screen
+        name="add-trade"
+        options={{ tabBarButtonTestID: "add-trade-tab", title: "Add" }}
+      />
+      <Tabs.Screen
+        name="history"
+        options={{ tabBarButtonTestID: "history-tab", title: "History" }}
+      />
+      <Tabs.Screen
+        name="cash"
+        options={{ tabBarButtonTestID: "cash-tab", title: "Cash" }}
+      />
     </Tabs>
   );
 }

--- a/docs/testing/android-pc-test-harness.md
+++ b/docs/testing/android-pc-test-harness.md
@@ -151,14 +151,22 @@ installed, the harness should not fail.
 Check Maestro:
 
 ```powershell
-maestro --version
+npm run maestro:check
 ```
 
 Run a flow after CogVest is installed on the emulator:
 
 ```powershell
-maestro test e2e/smoke-launch.yaml
+npm run maestro:test -- e2e/smoke-launch.yaml
 ```
+
+Run the full local Maestro suite:
+
+```powershell
+npm run maestro:test
+```
+
+See `docs/testing/maestro-e2e.md` for install and troubleshooting notes.
 
 ## Stable V1 testIDs
 

--- a/docs/testing/maestro-e2e.md
+++ b/docs/testing/maestro-e2e.md
@@ -1,0 +1,95 @@
+# Maestro E2E On Android Emulator
+
+## Purpose
+
+Maestro runs black-box mobile E2E flows against the installed CogVest Android
+app. It drives the Android Emulator like a user by launching the app, tapping
+tabs, entering form values, saving records, and asserting stable `testID`s or
+visible text.
+
+Maestro is optional local tooling. It is not an app runtime dependency and is
+not part of default GitHub PR CI.
+
+## Prerequisites
+
+- Java 17 or newer.
+- `JAVA_HOME` points to the Java installation.
+- Android Studio and a running Android Emulator.
+- `adb devices` shows an emulator in `device` state.
+- CogVest package `com.abdulshaikh.cogvest` is installed on the emulator.
+- Maestro CLI is installed and available on `PATH`.
+
+Official install docs:
+
+- https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli
+- https://docs.maestro.dev/getting-started/installing-maestro/
+
+## Windows Install Notes
+
+The official Maestro CLI docs support Windows. Use either:
+
+- The official installer script from a shell with `curl`.
+- The GitHub release `maestro.zip`, extracted to a stable location such as
+  `C:\maestro`, with `C:\maestro\bin` added to `PATH`.
+
+After installing, restart PowerShell and run:
+
+```powershell
+maestro --help
+```
+
+If Java is missing, install Java 17+ first and set `JAVA_HOME`.
+
+## CogVest Commands
+
+Check readiness:
+
+```powershell
+npm run maestro:check
+```
+
+Run the full local flow suite:
+
+```powershell
+npm run maestro:test
+```
+
+Run one flow:
+
+```powershell
+npm run maestro:test -- e2e/smoke-launch.yaml
+```
+
+## Flow Set
+
+- `e2e/smoke-launch.yaml`: cold-launch and Dashboard smoke.
+- `e2e/add-trade.yaml`: add a buy trade with stable form IDs.
+- `e2e/holdings.yaml`: create a trade and verify Holdings.
+- `e2e/cash.yaml`: add cash and verify Cash.
+- `e2e/value-masking.yaml`: open Settings by deep link and toggle masking.
+- `e2e/persistence.yaml`: create local data, close/reopen, and verify it remains.
+
+## Expected Missing-Tool Behavior
+
+If Maestro is not installed:
+
+```text
+FAIL maestro not found
+Install guidance:
+...
+```
+
+This is expected on machines that have not opted into Maestro. Default static
+checks and Android smoke checks should still work.
+
+## Troubleshooting
+
+- `maestro not found`: add Maestro `bin` folder to `PATH`, restart PowerShell,
+  and rerun `npm run maestro:check`.
+- `java not found`: install Java 17+ and set `JAVA_HOME`.
+- `no Android emulator/device`: start Pixel 8 from Android Studio and confirm
+  `adb devices`.
+- `app package not installed`: install a local APK with
+  `adb install -r path/to/app.apk`.
+- Flow cannot find a control: verify the app build includes the stable testIDs
+  from issue #50 and rerun from a clean app state.

--- a/docs/testing/v1-core-flow-test-matrix.md
+++ b/docs/testing/v1-core-flow-test-matrix.md
@@ -53,12 +53,14 @@ Install Maestro separately if needed. The repo does not add Maestro as a npm
 dependency.
 
 ```powershell
-maestro test e2e/smoke-launch.yaml
-maestro test e2e/add-trade.yaml
-maestro test e2e/holdings.yaml
-maestro test e2e/cash.yaml
-maestro test e2e/value-masking.yaml
-maestro test e2e/persistence.yaml
+npm run maestro:check
+npm run maestro:test
+```
+
+To run one flow:
+
+```powershell
+npm run maestro:test -- e2e/smoke-launch.yaml
 ```
 
 If Maestro is unavailable, record that as:

--- a/docs/testing/v1-pc-verification-checklist.md
+++ b/docs/testing/v1-pc-verification-checklist.md
@@ -34,13 +34,8 @@ Android Emulator, not a physical Android phone.
 
 ## Optional Maestro Gate
 
-- [ ] `maestro --version` works, or unavailable status is recorded.
-- [ ] `maestro test e2e/smoke-launch.yaml` passes.
-- [ ] `maestro test e2e/add-trade.yaml` passes.
-- [ ] `maestro test e2e/holdings.yaml` passes.
-- [ ] `maestro test e2e/cash.yaml` passes.
-- [ ] `maestro test e2e/value-masking.yaml` passes.
-- [ ] `maestro test e2e/persistence.yaml` passes.
+- [ ] `npm run maestro:check` works, or unavailable status is recorded.
+- [ ] `npm run maestro:test` passes.
 
 ## Evidence
 

--- a/e2e/add-trade.yaml
+++ b/e2e/add-trade.yaml
@@ -2,7 +2,8 @@ appId: com.abdulshaikh.cogvest
 ---
 - launchApp:
     clearState: true
-- tapOn: "Add"
+- tapOn:
+    id: "add-trade-tab"
 - assertVisible:
     id: "add-trade-screen"
 - tapOn:
@@ -20,11 +21,16 @@ appId: com.abdulshaikh.cogvest
 - tapOn:
     id: "price-input"
 - inputText: "100"
+- hideKeyboard
 - tapOn:
     id: "conviction-4"
 - tapOn:
     id: "review-trade-button"
 - assertVisible: "Review buy"
+- scrollUntilVisible:
+    element:
+      id: "save-trade-button"
+    direction: DOWN
 - tapOn:
     id: "save-trade-button"
 - assertVisible: "Trade logged."

--- a/e2e/cash.yaml
+++ b/e2e/cash.yaml
@@ -2,7 +2,8 @@ appId: com.abdulshaikh.cogvest
 ---
 - launchApp:
     clearState: true
-- tapOn: "Cash"
+- tapOn:
+    id: "cash-tab"
 - assertVisible:
     id: "cash-screen"
 - tapOn:
@@ -14,6 +15,7 @@ appId: com.abdulshaikh.cogvest
 - tapOn:
     id: "cash-date-input"
 - inputText: "2026-04-20"
+- hideKeyboard
 - tapOn:
     id: "save-cash-entry-button"
 - assertVisible: "Broker cash"

--- a/e2e/holdings.yaml
+++ b/e2e/holdings.yaml
@@ -2,7 +2,8 @@ appId: com.abdulshaikh.cogvest
 ---
 - launchApp:
     clearState: true
-- tapOn: "Add"
+- tapOn:
+    id: "add-trade-tab"
 - tapOn:
     id: "asset-input"
 - inputText: "Reliance Industries"
@@ -18,11 +19,22 @@ appId: com.abdulshaikh.cogvest
 - tapOn:
     id: "price-input"
 - inputText: "100"
+- hideKeyboard
+- scrollUntilVisible:
+    element:
+      id: "review-trade-button"
+    direction: DOWN
 - tapOn:
     id: "review-trade-button"
+- assertVisible: "Review buy"
+- scrollUntilVisible:
+    element:
+      id: "save-trade-button"
+    direction: DOWN
 - tapOn:
     id: "save-trade-button"
-- tapOn: "Holdings"
+- tapOn:
+    id: "holdings-tab"
 - assertVisible:
     id: "holdings-screen"
 - assertVisible: "Reliance Industries"

--- a/e2e/persistence.yaml
+++ b/e2e/persistence.yaml
@@ -2,7 +2,8 @@ appId: com.abdulshaikh.cogvest
 ---
 - launchApp:
     clearState: true
-- tapOn: "Cash"
+- tapOn:
+    id: "cash-tab"
 - tapOn:
     id: "cash-amount-input"
 - inputText: "1000"
@@ -12,10 +13,12 @@ appId: com.abdulshaikh.cogvest
 - tapOn:
     id: "cash-date-input"
 - inputText: "2026-04-20"
+- hideKeyboard
 - tapOn:
     id: "save-cash-entry-button"
 - assertVisible: "Broker cash"
 - stopApp
 - launchApp
-- tapOn: "Cash"
+- tapOn:
+    id: "cash-tab"
 - assertVisible: "Broker cash"

--- a/e2e/value-masking.yaml
+++ b/e2e/value-masking.yaml
@@ -2,7 +2,8 @@ appId: com.abdulshaikh.cogvest
 ---
 - launchApp:
     clearState: true
-- openLink: "cogvest://settings"
+- stopApp
+- openLink: "cogvest:///settings"
 - assertVisible: "Value masking"
 - tapOn:
     id: "value-mask-toggle"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "android:doctor": "node scripts/android-doctor.mjs",
     "android:smoke": "node scripts/android-smoke-check.mjs",
     "test:verify": "npm run typecheck && npm test && npm run doctor",
-    "test:v1:pc": "npm run test:verify && npm run android:doctor && npm run android:smoke -- --strict"
+    "test:v1:pc": "npm run test:verify && npm run android:doctor && npm run android:smoke -- --strict",
+    "maestro:check": "node scripts/maestro-check.mjs",
+    "maestro:test": "node scripts/maestro-run.mjs"
   },
   "jest": {
     "preset": "jest-expo",

--- a/scripts/android-doctor.mjs
+++ b/scripts/android-doctor.mjs
@@ -147,7 +147,7 @@ if (existsSync("package.json")) {
 if (findExecutable("maestro")) {
   pass("Maestro found");
 } else {
-  warning("Maestro not found");
+  warning("Maestro not found. Run npm run maestro:check for setup guidance.");
 }
 
 if (!nodeOk || !npmPath) {

--- a/scripts/maestro-check.mjs
+++ b/scripts/maestro-check.mjs
@@ -1,0 +1,157 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const packageName = "com.abdulshaikh.cogvest";
+let hardFailure = false;
+
+function candidateNames(command) {
+  if (process.platform !== "win32") {
+    return [command];
+  }
+
+  if (/\.(exe|cmd|bat)$/i.test(command)) {
+    return [command];
+  }
+
+  return [`${command}.exe`, `${command}.cmd`, `${command}.bat`, command];
+}
+
+function findExecutable(command) {
+  const pathValue = process.env.PATH ?? "";
+
+  for (const directory of pathValue.split(process.platform === "win32" ? ";" : ":")) {
+    for (const candidate of candidateNames(command)) {
+      const fullPath = join(directory, candidate);
+      if (existsSync(fullPath)) {
+        return fullPath;
+      }
+    }
+  }
+
+  return null;
+}
+
+function run(command, args = []) {
+  return spawnSync(command, args, {
+    encoding: "utf8",
+  });
+}
+
+function pass(message) {
+  console.log(`PASS ${message}`);
+}
+
+function fail(message) {
+  console.log(`FAIL ${message}`);
+  hardFailure = true;
+}
+
+function warning(message) {
+  console.log(`WARNING ${message}`);
+}
+
+function parseAdbDevices(output) {
+  return output
+    .split(/\r?\n/)
+    .slice(1)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [id, state] = line.split(/\s+/);
+      return { id, state };
+    });
+}
+
+function printInstallGuidance() {
+  console.log("Install guidance:");
+  console.log("- Install Java 17+ and set JAVA_HOME.");
+  console.log("- Windows option 1: run the official Maestro installer script from a shell with curl.");
+  console.log("- Windows option 2: download maestro.zip from Maestro releases, extract to C:\\maestro, and add C:\\maestro\\bin to PATH.");
+  console.log("- Restart PowerShell, then run: maestro --help");
+  console.log("- Official docs: https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli");
+}
+
+const javaPath = findExecutable("java");
+if (!javaPath) {
+  fail("java not found");
+  warning("Maestro CLI requires Java 17 or newer.");
+} else {
+  const javaResult = run(javaPath, ["-version"]);
+  const versionOutput = `${javaResult.stderr ?? ""}${javaResult.stdout ?? ""}`.trim();
+  if (javaResult.status === 0) {
+    pass("java found");
+    console.log(versionOutput.split(/\r?\n/)[0]);
+  } else {
+    fail("java -version failed");
+    if (versionOutput) {
+      warning(versionOutput);
+    }
+  }
+}
+
+const adbPath = findExecutable("adb");
+if (!adbPath) {
+  fail("adb not found");
+} else {
+  pass("adb found");
+  const devicesResult = run(adbPath, ["devices"]);
+  if (devicesResult.status !== 0) {
+    fail("adb devices could not run");
+  } else {
+    const readyDevices = parseAdbDevices(devicesResult.stdout).filter(
+      (device) => device.state === "device",
+    );
+    if (readyDevices.length === 0) {
+      fail("no Android emulator/device in device state");
+    } else {
+      readyDevices.forEach((device) => pass(`connected device: ${device.id}`));
+    }
+  }
+}
+
+const maestroPath = findExecutable("maestro");
+if (!maestroPath) {
+  fail("maestro not found");
+  printInstallGuidance();
+} else {
+  const maestroResult = run(maestroPath, ["--version"]);
+  if (maestroResult.status === 0) {
+    pass(`maestro found: ${maestroResult.stdout.trim()}`);
+  } else {
+    fail("maestro --version failed");
+    const details = `${maestroResult.stderr ?? maestroResult.stdout ?? ""}`.trim();
+    if (details) {
+      warning(details);
+    }
+  }
+}
+
+if (adbPath) {
+  const devicesResult = run(adbPath, ["devices"]);
+  const readyDevice = parseAdbDevices(devicesResult.stdout).find(
+    (device) => device.state === "device",
+  );
+
+  if (readyDevice) {
+    const packageResult = run(adbPath, [
+      "-s",
+      readyDevice.id,
+      "shell",
+      "pm",
+      "list",
+      "packages",
+      packageName,
+    ]);
+
+    if (packageResult.stdout.includes(`package:${packageName}`)) {
+      pass(`app package found: ${packageName}`);
+    } else {
+      fail(`app package not installed: ${packageName}`);
+      console.log("Install an APK with: adb install -r path/to/app.apk");
+    }
+  }
+}
+
+console.log("DONE Maestro local E2E readiness check complete");
+process.exit(hardFailure ? 1 : 0);

--- a/scripts/maestro-check.mjs
+++ b/scripts/maestro-check.mjs
@@ -18,9 +18,12 @@ function candidateNames(command) {
 }
 
 function findExecutable(command) {
-  const pathValue = process.env.PATH ?? "";
+  const delimiter = process.platform === "win32" ? ";" : ":";
+  const pathValue = [process.env.PATH, process.env.Path, process.env.path]
+    .filter(Boolean)
+    .join(delimiter);
 
-  for (const directory of pathValue.split(process.platform === "win32" ? ";" : ":")) {
+  for (const directory of pathValue.split(delimiter)) {
     for (const candidate of candidateNames(command)) {
       const fullPath = join(directory, candidate);
       if (existsSync(fullPath)) {
@@ -33,6 +36,13 @@ function findExecutable(command) {
 }
 
 function run(command, args = []) {
+  if (process.platform === "win32" && /\.(cmd|bat)$/i.test(command)) {
+    return spawnSync(command, args, {
+      encoding: "utf8",
+      shell: true,
+    });
+  }
+
   return spawnSync(command, args, {
     encoding: "utf8",
   });

--- a/scripts/maestro-run.mjs
+++ b/scripts/maestro-run.mjs
@@ -20,9 +20,12 @@ function candidateNames(command) {
 }
 
 function findExecutable(command) {
-  const pathValue = process.env.PATH ?? "";
+  const delimiter = process.platform === "win32" ? ";" : ":";
+  const pathValue = [process.env.PATH, process.env.Path, process.env.path]
+    .filter(Boolean)
+    .join(delimiter);
 
-  for (const directory of pathValue.split(process.platform === "win32" ? ";" : ":")) {
+  for (const directory of pathValue.split(delimiter)) {
     for (const candidate of candidateNames(command)) {
       const fullPath = join(directory, candidate);
       if (existsSync(fullPath)) {
@@ -35,6 +38,14 @@ function findExecutable(command) {
 }
 
 function run(command, args = []) {
+  if (process.platform === "win32" && /\.(cmd|bat)$/i.test(command)) {
+    return spawnSync(command, args, {
+      encoding: "utf8",
+      shell: true,
+      stdio: "inherit",
+    });
+  }
+
   return spawnSync(command, args, {
     encoding: "utf8",
     stdio: "inherit",

--- a/scripts/maestro-run.mjs
+++ b/scripts/maestro-run.mjs
@@ -1,0 +1,70 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const defaultFlows = [
+  "e2e/smoke-launch.yaml",
+  "e2e/add-trade.yaml",
+  "e2e/holdings.yaml",
+  "e2e/cash.yaml",
+  "e2e/value-masking.yaml",
+  "e2e/persistence.yaml",
+];
+
+function candidateNames(command) {
+  if (process.platform !== "win32") {
+    return [command];
+  }
+
+  return [`${command}.exe`, `${command}.cmd`, `${command}.bat`, command];
+}
+
+function findExecutable(command) {
+  const pathValue = process.env.PATH ?? "";
+
+  for (const directory of pathValue.split(process.platform === "win32" ? ";" : ":")) {
+    for (const candidate of candidateNames(command)) {
+      const fullPath = join(directory, candidate);
+      if (existsSync(fullPath)) {
+        return fullPath;
+      }
+    }
+  }
+
+  return null;
+}
+
+function run(command, args = []) {
+  return spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: "inherit",
+  });
+}
+
+const maestroPath = findExecutable("maestro");
+if (!maestroPath) {
+  console.log("FAIL maestro not found");
+  console.log("Run `npm run maestro:check` for install guidance.");
+  process.exit(1);
+}
+
+const requestedFlows = process.argv.slice(2);
+const flows = requestedFlows.length > 0 ? requestedFlows : defaultFlows;
+
+for (const flow of flows) {
+  if (!existsSync(flow)) {
+    console.log(`FAIL flow not found: ${flow}`);
+    process.exit(1);
+  }
+}
+
+for (const flow of flows) {
+  console.log(`RUN maestro test ${flow}`);
+  const result = run(maestroPath, ["test", flow]);
+  if (result.status !== 0) {
+    console.log(`FAIL Maestro flow failed: ${flow}`);
+    process.exit(result.status ?? 1);
+  }
+}
+
+console.log("DONE Maestro local E2E flows complete");


### PR DESCRIPTION
## Summary
- Add maestro:check and maestro:test scripts for optional local Android E2E runs.
- Add friendly Java/adb/Maestro/app-package readiness checks with install guidance.
- Add a Maestro setup doc for Windows/PC emulator usage and flow commands.
- Link Maestro scripts from the PC harness and V1 verification docs.
- Keep Maestro out of default PR CI and app dependencies.

## Verification
- node --check scripts/maestro-check.mjs
- node --check scripts/maestro-run.mjs
- package.json parse check
- npm run maestro:check: expected failure because Java and Maestro are not on PATH; adb/emulator and installed app were detected and install guidance printed
- npm run typecheck
- npm test
- npm run doctor
- npm run test:v1:pc

## Notes
- Current machine result: maestro:check reports FAIL java not found and FAIL maestro not found.
- Official install docs: https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli

Closes #57