### PR TITLE
Refine V1 premium UI and Figma mockups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ into behaviour insights and Minimal Mode.
 ## Current Roadmap
 - Build in phases from docs/roadmap/cogvest-version-roadmap.md.
 - Current execution focus: V1 MVP plus Excel tracker parity from issue #60.
-- V1 goal: local-first Android tracker with live current quotes, Add Trade,
+- V1 goal: local-first Android tracker with live current quotes, Add Holding,
   derived holdings, dashboard, cash tracking, value masking, and lightweight
   conviction capture/state.
 - V2 adds Minimal Mode, basic LTCG, patience/frequency analysis, behaviour
@@ -31,7 +31,7 @@ into behaviour insights and Minimal Mode.
   explicitly changes priority.
 
 ## Stack
-- React Native + Expo SDK 52+
+- React Native + Expo SDK 54
 - TypeScript only. No JavaScript.
 - Expo Router (file-based navigation)
 - MMKV for persistence
@@ -53,6 +53,9 @@ into behaviour insights and Minimal Mode.
   user explicitly changes priority.
 - V2/V3 GitHub issues are placeholders and should not be expanded until V1 is
   validated.
+- User-facing V1 language should prefer Dashboard, Holdings, Add Holding,
+  Progress, Cash, and Settings. Keep "trade" wording internal unless an
+  existing domain API requires it.
 
 ## Design
 - Follow root `DESIGN.md` for every UI task unless an issue explicitly
@@ -63,6 +66,9 @@ into behaviour insights and Minimal Mode.
   templates and trading-app/crypto-exchange energy.
 - Green is an accent, not decoration. Financial values must be readable,
   maskable, and INR-first.
+- Current V1 Figma source is
+  `docs/design/figma/issue-69-v1-screens/code.js`: main tabs are Dashboard,
+  Holdings, Progress, Cash, Settings; Add Holding is a secondary screen.
 - Use docs/design/v1-ui-mockup-plan.md and the Figma file for V1 UI context.
 
 ## Release Gates

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -42,18 +42,18 @@ Use these colors as the canonical CogVest palette.
 
 | Token | Hex | Role |
 | --- | --- | --- |
-| Background | `#1C1B1F` | App background, root canvas, tab bar base |
-| Surface | `#242329` | Default cards, panels, grouped content |
-| Elevated Surface | `#2B2930` | Inputs, active cards, selected panels |
-| Primary Text | `#E6E1E5` | Headings, primary values, selected labels |
-| Secondary Text | `#CAC4D0` | Body copy, labels, supporting metrics |
-| Muted Text | `#938F99` | Captions, timestamps, empty-state helper text |
-| Primary Green | `#2E7D52` | Main CTA, active tab, selected state, positive brand emphasis |
-| Deep Green | `#0E6B4F` | Pressed states, deeper accents, selected backgrounds |
-| Border | `#3A3740` | Card borders, input strokes, separators |
-| Positive | `#22C55E` | Gains, positive returns, successful states |
+| Background | `#000000` | OLED root canvas and app background |
+| Surface | `#1C1C1E` | Default cards, panels, grouped content |
+| Elevated Surface | `#2C2C2E` | Inputs, active cards, selected panels, action wells |
+| Primary Text | `#F5F5F7` | Headings, primary values, selected labels |
+| Secondary Text | `#98989D` | Body copy, labels, supporting metrics |
+| Muted Text | `#636366` | Captions, timestamps, empty-state helper text |
+| Primary Green | `#34C759` | Main CTA, active tab, selected state, positive brand emphasis |
+| Deep Green | `#248A3D` | Pressed states and selected backgrounds |
+| Separator | `rgba(255,255,255,0.10)` | Hairline separators only when needed |
+| Positive | `#34C759` | Gains, positive returns, successful states |
 | Warning | `#F59E0B` | Incomplete data, stale quotes, non-blocking risk |
-| Negative | `#EF4444` | Losses, destructive actions, validation errors |
+| Negative | `#FF453A` | Losses, destructive actions, validation errors |
 
 Rules:
 
@@ -63,7 +63,7 @@ Rules:
 - Avoid saturated gradient cards unless an issue explicitly asks for them.
 - Use `Positive` and `Negative` only for financial state, not generic ornament.
 - Warning should be sparse and explanatory, never alarming.
-- Borders should define structure more often than shadows.
+- Prefer borderless true-dark surfaces. Use only subtle hairline separators when structure needs extra clarity.
 - Financial values must remain readable on all surfaces.
 - All financial values must be maskable and INR-first.
 
@@ -107,23 +107,23 @@ Components should feel tactile, quiet, and clearly Android-native.
 
 Cards:
 
-- Use spacious cards with 1px borders.
+- Use spacious borderless cards with 16-20px radius.
 - Prefer `Surface` for standard cards and `Elevated Surface` for interactive or nested surfaces.
-- Use consistent radii.
+- Use consistent large radii that feel closer to continuous/squircle curves than sharp Material boxes.
 - Avoid coloured card shadows.
 - Avoid dense card grids unless the screen is explicitly analytical.
 
 Buttons:
 
 - Primary actions use `Primary Green`.
-- Secondary actions use bordered or elevated neutral surfaces.
+- Secondary actions use elevated neutral surfaces or subtle hairline separators.
 - Destructive actions use `Negative` only when the action is genuinely destructive.
 - Button labels should be direct: `Add Trade`, `Save`, `Refresh Quotes`, `Add Cash`.
 - Avoid marketing-style CTA language.
 
 Inputs:
 
-- Inputs use `Elevated Surface`, clear labels, and visible borders.
+- Inputs use `Elevated Surface`, clear labels, and subtle separators only where needed.
 - Validation errors use `Negative` with concise copy.
 - Keep finance inputs explicit: quantity, price per unit, fees, date, currency.
 - Preserve keyboard ergonomics on Android.
@@ -196,8 +196,8 @@ Depth should be quiet and structural.
 
 Rules:
 
-- Use dark surface shifts and borders before shadows.
-- Use 1px borders for cards and inputs.
+- Use OLED black background with dark surface shifts before shadows.
+- Avoid solid card borders. Use `Separator` hairlines only for internal dividers or rare edge clarity.
 - Shadows should be rare and subtle.
 - Do not use coloured shadows.
 - Elevation should imply interaction or grouping, not decoration.
@@ -208,7 +208,7 @@ Recommended hierarchy:
 - Background: root app canvas.
 - Surface: default card.
 - Elevated Surface: inputs, selected panels, nested cards.
-- Border: separation and scannability.
+- Separator: subtle internal grouping and scannability.
 - Green accent: selected/action state only.
 
 ## 7. Motion Rules

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -2,18 +2,17 @@ import { Ionicons } from "@expo/vector-icons";
 import { Tabs } from "expo-router";
 import { StyleSheet, View } from "react-native";
 
-const TAB_BAR_BACKGROUND = "#1C1B1F";
-const ACTIVE_TINT = "#2E7D52";
-const INACTIVE_TINT = "#CAC4D0";
+import { colors } from "@/src/theme";
 
 type TabIconName = keyof typeof Ionicons.glyphMap;
 
 const tabIcons: Record<string, TabIconName> = {
-  dashboard: "grid-outline",
-  holdings: "wallet-outline",
+  dashboard: "home-outline",
+  holdings: "pie-chart-outline",
   "add-trade": "add",
-  history: "time-outline",
-  cash: "cash-outline",
+  history: "analytics-outline",
+  cash: "wallet-outline",
+  settings: "settings-outline",
 };
 
 function TabIcon({
@@ -28,7 +27,7 @@ function TabIcon({
   if (routeName === "add-trade") {
     return (
       <View style={styles.fab}>
-        <Ionicons name="add" color="#E6E1E5" size={size + 4} />
+        <Ionicons name="add" color={colors.text.primary} size={size + 4} />
       </View>
     );
   }
@@ -47,8 +46,8 @@ export default function TabLayout() {
     <Tabs
       screenOptions={({ route }) => ({
         headerShown: false,
-        tabBarActiveTintColor: ACTIVE_TINT,
-        tabBarInactiveTintColor: INACTIVE_TINT,
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.text.secondary,
         tabBarStyle: styles.tabBar,
         tabBarIcon: ({ color, size }) => (
           <TabIcon routeName={route.name} color={color} size={size} />
@@ -57,23 +56,27 @@ export default function TabLayout() {
     >
       <Tabs.Screen
         name="dashboard"
-        options={{ tabBarButtonTestID: "dashboard-tab", title: "Dashboard" }}
+        options={{ tabBarButtonTestID: "tab-dashboard", title: "Dashboard" }}
       />
       <Tabs.Screen
         name="holdings"
-        options={{ tabBarButtonTestID: "holdings-tab", title: "Holdings" }}
+        options={{ tabBarButtonTestID: "tab-holdings", title: "Holdings" }}
       />
       <Tabs.Screen
         name="add-trade"
-        options={{ tabBarButtonTestID: "add-trade-tab", title: "Add" }}
-      />
-      <Tabs.Screen
-        name="history"
-        options={{ tabBarButtonTestID: "history-tab", title: "History" }}
+        options={{ tabBarButtonTestID: "tab-add", title: "Add" }}
       />
       <Tabs.Screen
         name="cash"
-        options={{ tabBarButtonTestID: "cash-tab", title: "Cash" }}
+        options={{ tabBarButtonTestID: "tab-cash", title: "Cash" }}
+      />
+      <Tabs.Screen
+        name="settings"
+        options={{ tabBarButtonTestID: "tab-settings", title: "Settings" }}
+      />
+      <Tabs.Screen
+        name="history"
+        options={{ href: null, title: "Progress" }}
       />
     </Tabs>
   );
@@ -82,7 +85,7 @@ export default function TabLayout() {
 const styles = StyleSheet.create({
   fab: {
     alignItems: "center",
-    backgroundColor: ACTIVE_TINT,
+    backgroundColor: colors.primary,
     borderRadius: 28,
     height: 56,
     justifyContent: "center",
@@ -90,10 +93,10 @@ const styles = StyleSheet.create({
     width: 56,
   },
   tabBar: {
-    backgroundColor: TAB_BAR_BACKGROUND,
-    borderTopColor: "#2A2A2A",
-    height: 72,
-    paddingBottom: 10,
+    backgroundColor: colors.surface.card,
+    borderTopColor: colors.border.subtle,
+    height: 78,
+    paddingBottom: 12,
     paddingTop: 8,
   },
 });

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Tabs } from "expo-router";
-import { StyleSheet, View } from "react-native";
+import { StyleSheet } from "react-native";
 
 import { colors } from "@/src/theme";
 
@@ -9,7 +9,6 @@ type TabIconName = keyof typeof Ionicons.glyphMap;
 const tabIcons: Record<string, TabIconName> = {
   dashboard: "home-outline",
   holdings: "pie-chart-outline",
-  "add-trade": "add",
   history: "analytics-outline",
   cash: "wallet-outline",
   settings: "settings-outline",
@@ -24,14 +23,6 @@ function TabIcon({
   color: string;
   size: number;
 }) {
-  if (routeName === "add-trade") {
-    return (
-      <View style={styles.fab}>
-        <Ionicons name="add" color={colors.text.primary} size={size + 4} />
-      </View>
-    );
-  }
-
   return (
     <Ionicons
       name={tabIcons[routeName] ?? "ellipse-outline"}
@@ -63,8 +54,8 @@ export default function TabLayout() {
         options={{ tabBarButtonTestID: "tab-holdings", title: "Holdings" }}
       />
       <Tabs.Screen
-        name="add-trade"
-        options={{ tabBarButtonTestID: "tab-add", title: "Add" }}
+        name="history"
+        options={{ tabBarButtonTestID: "tab-progress", title: "Progress" }}
       />
       <Tabs.Screen
         name="cash"
@@ -75,23 +66,14 @@ export default function TabLayout() {
         options={{ tabBarButtonTestID: "tab-settings", title: "Settings" }}
       />
       <Tabs.Screen
-        name="history"
-        options={{ href: null, title: "Progress" }}
+        name="add-trade"
+        options={{ href: null, title: "Add Holding" }}
       />
     </Tabs>
   );
 }
 
 const styles = StyleSheet.create({
-  fab: {
-    alignItems: "center",
-    backgroundColor: colors.primary,
-    borderRadius: 28,
-    height: 56,
-    justifyContent: "center",
-    marginBottom: 20,
-    width: 56,
-  },
   tabBar: {
     backgroundColor: colors.surface.card,
     borderTopColor: colors.border.subtle,

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -6,7 +6,7 @@ export default function DashboardScreen() {
   return (
     <DashboardFeatureScreen
       onAddTrade={() => {
-        router.push("/(tabs)/add-trade");
+        router.push("/add-holding");
       }}
     />
   );

--- a/app/(tabs)/holdings.tsx
+++ b/app/(tabs)/holdings.tsx
@@ -6,7 +6,7 @@ export default function HoldingsScreen() {
   return (
     <HoldingsFeatureScreen
       onAddTrade={() => {
-        router.push("/(tabs)/add-trade");
+        router.push("/add-holding");
       }}
     />
   );

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,0 +1,5 @@
+import { SettingsScreen } from "@/src/features/settings";
+
+export default function SettingsTabScreen() {
+  return <SettingsScreen />;
+}

--- a/app/add-holding.tsx
+++ b/app/add-holding.tsx
@@ -1,0 +1,5 @@
+import { AddTradeForm } from "@/src/features/trades";
+
+export default function AddHoldingScreen() {
+  return <AddTradeForm />;
+}

--- a/app/progress.tsx
+++ b/app/progress.tsx
@@ -1,5 +1,5 @@
 import { ProgressScreen } from "@/src/features/progress";
 
-export default function HistoryScreen() {
+export default function ProgressRoute() {
   return <ProgressScreen />;
 }

--- a/docs/design/figma/issue-69-v1-screens/README.md
+++ b/docs/design/figma/issue-69-v1-screens/README.md
@@ -1,0 +1,38 @@
+# CogVest Issue 69 V1 Figma Screens
+
+This folder contains a deterministic Figma development plugin that creates
+editable V1 screen frames for issue #69.
+
+## Why This Exists
+
+Generated PNG mockups are useful for exploration, but they are unstable design
+sources. This plugin recreates the approved direction as editable Figma layers:
+frames, cards, text, vector icons, and simple shapes.
+
+## How To Run
+
+1. Open the CogVest Figma file:
+   `https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d`
+2. In Figma desktop, go to `Plugins -> Development -> Import plugin from manifest...`.
+3. Select `docs/design/figma/issue-69-v1-screens/manifest.json`.
+4. Run `Plugins -> Development -> CogVest Issue 69 V1 Screens`.
+5. The plugin creates or replaces the page `Issue 69 - V1 UI Concepts`.
+
+## Output
+
+The plugin creates six editable Android frames:
+
+- Dashboard
+- Holdings
+- Add Holding
+- Cash
+- Monthly Progression
+- Settings
+
+## Notes
+
+- The plugin deletes and recreates only the page named
+  `Issue 69 - V1 UI Concepts`.
+- It does not modify the existing roadmap pages.
+- Use these frames as the stable source for later Figma refinements.
+- Keep `DESIGN.md` as the product design contract.

--- a/docs/design/figma/issue-69-v1-screens/README.md
+++ b/docs/design/figma/issue-69-v1-screens/README.md
@@ -6,8 +6,9 @@ editable V1 screen frames for issue #69.
 ## Why This Exists
 
 Generated PNG mockups are useful for exploration, but they are unstable design
-sources. This plugin recreates the approved direction as editable Figma layers:
-frames, cards, text, vector icons, and simple shapes.
+sources. This plugin recreates the approved true-dark private ledger direction
+as editable Figma layers: frames, borderless cards, text, vector icons, and
+simple shapes.
 
 ## How To Run
 

--- a/docs/design/figma/issue-69-v1-screens/README.md
+++ b/docs/design/figma/issue-69-v1-screens/README.md
@@ -16,7 +16,7 @@ frames, cards, text, vector icons, and simple shapes.
 2. In Figma desktop, go to `Plugins -> Development -> Import plugin from manifest...`.
 3. Select `docs/design/figma/issue-69-v1-screens/manifest.json`.
 4. Run `Plugins -> Development -> CogVest Issue 69 V1 Screens`.
-5. The plugin creates or replaces the page `Issue 69 - V1 UI Concepts`.
+5. The plugin creates or refreshes the page `Issue 69 - V1 UI Concepts`.
 
 ## Output
 
@@ -31,7 +31,7 @@ The plugin creates six editable Android frames:
 
 ## Notes
 
-- The plugin deletes and recreates only the page named
+- The plugin clears and recreates only the child layers inside the page named
   `Issue 69 - V1 UI Concepts`.
 - It does not modify the existing roadmap pages.
 - Use these frames as the stable source for later Figma refinements.

--- a/docs/design/figma/issue-69-v1-screens/code.js
+++ b/docs/design/figma/issue-69-v1-screens/code.js
@@ -1,12 +1,8 @@
-// CogVest — V1 editable Figma screens
+// CogVest — Figma Plugin
 // Run from Figma Desktop as a development plugin.
-// Improvements: conviction stars, better spacing system,
-// improved hero card, insight card, consistent borders,
-// better typography contrast.
-// Navigation model fixed:
+//
 // Main tabs: Dashboard, Holdings, Progress, Cash, Settings
-// Quick Add: header action button, not middle FAB
-// Secondary screen: Add Holding
+// Secondary screens: Add Holding
 
 async function main() {
   await figma.loadFontAsync({ family: "Inter", style: "Regular" });
@@ -65,7 +61,7 @@ async function main() {
   };
 
   // ─── PAGE SETUP ──────────────────────────────────────────────
-  const PAGE_NAME = "Issue 69 - V1 UI Concepts";
+  const PAGE_NAME = "CogVest — Screens";
   let page = figma.root.children.find((p) => p.name === PAGE_NAME);
   if (!page) {
     page = figma.createPage();
@@ -189,7 +185,7 @@ async function main() {
 
       check: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M5 12l5 5L20 7" stroke="${s}" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
 
-      sparkle: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M12 2l2.4 7.2H22l-6.2 4.6 2.4 7.2L12 16.6l-6.2 4.4 2.4-7.2L2 9.2h7.6L12 2Z" stroke="${s}" stroke-width="1.8" stroke-linejoin="round"/></svg>`,
+      sparkle: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M12 3l1.8 5.2L19 10l-5.2 1.8L12 17l-1.8-5.2L5 10l5.2-1.8L12 3Z" stroke="${s}" stroke-width="1.8" stroke-linejoin="round"/></svg>`,
 
       info: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" stroke="${s}" stroke-width="1.8"/><path d="M12 11v6" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/><circle cx="12" cy="7.5" r="1" fill="${s}"/></svg>`,
 
@@ -232,14 +228,13 @@ async function main() {
     return pillW;
   }
 
-  function convictionStars(parent, x, y, filled, outOf = 5) {
-    const starSize = 11;
-    const gap = 2;
+  function convictionDots(parent, x, y, selected = 4, outOf = 5) {
+    for (let i = 1; i <= outOf; i++) {
+      const dotX = x + (i - 1) * 30;
+      const active = i <= selected;
 
-    for (let i = 0; i < outOf; i++) {
-      const starX = x + i * (starSize + gap);
-      const isFilled = i < filled;
-      t(parent, "★", starX, y, starSize, isFilled ? C.warning : C.muted, "Semi Bold", starSize + 2);
+      rect(parent, dotX, y, 22, 22, S.radius.full, active ? C.greenDim : C.elevated, active ? C.green : C.border, 0.35);
+      t(parent, String(i), dotX, y + 6, 10, active ? C.greenText : C.secondary, "Semi Bold", 22, "CENTER");
     }
   }
 
@@ -470,7 +465,6 @@ async function main() {
         pnl: "+₹18.6K",
         pnlPct: "+11.4%",
         alloc: "14.6%",
-        conviction: 4,
       },
       {
         type: "equity",
@@ -481,7 +475,6 @@ async function main() {
         pnl: "+₹6.5K",
         pnlPct: "+14.7%",
         alloc: "4.1%",
-        conviction: 3,
       },
       {
         type: "debt",
@@ -492,7 +485,6 @@ async function main() {
         pnl: "+₹4.1K",
         pnlPct: "+7.7%",
         alloc: "4.6%",
-        conviction: 5,
       },
       {
         type: "crypto",
@@ -503,7 +495,6 @@ async function main() {
         pnl: "+₹2.85L",
         pnlPct: "+25.7%",
         alloc: "11.1%",
-        conviction: 4,
       },
       {
         type: "debt",
@@ -514,7 +505,6 @@ async function main() {
         pnl: "+₹250",
         pnlPct: "+0.1%",
         alloc: "2.0%",
-        conviction: null,
       },
       {
         type: "cash",
@@ -525,7 +515,6 @@ async function main() {
         pnl: "+₹70K",
         pnlPct: "",
         alloc: "10.0%",
-        conviction: null,
       },
     ];
 
@@ -561,10 +550,6 @@ async function main() {
 
       t(frame, row.pnl, x + 282, rowY + 8, 13, pnlColor, "Semi Bold", 68, "RIGHT");
       t(frame, row.pnlPct, x + 282, rowY + 28, 10, C.secondary, "Regular", 68, "RIGHT");
-
-      if (row.conviction) {
-        convictionStars(frame, x + W - 80, rowY + 10, row.conviction);
-      }
     });
   }
 
@@ -638,16 +623,14 @@ async function main() {
 
   donutChart(dashboard, S.screenPad, 312);
 
-  const insightY = 546;
+  const convictionY = 546;
 
-  rect(dashboard, S.screenPad, insightY, 353, 76, S.radius.md, "#1A1530", C.purple, 0.4);
-  ico(dashboard, "sparkle", S.screenPad + 14, insightY + 14, 18, C.purple);
-  t(dashboard, "INSIGHT", S.screenPad + 40, insightY + 14, 9, C.purple, "Semi Bold", 80);
-  t(dashboard, "Conviction data still building", S.screenPad + 14, insightY + 36, 13, C.text, "Semi Bold", 230);
-  t(dashboard, "Rate your next 3 trades to unlock personalised insights.", S.screenPad + 14, insightY + 54, 11, C.secondary, "Regular", 280);
-  t(dashboard, "×", 353, insightY + 10, 16, C.muted, "Regular", 22, "CENTER");
+  card(dashboard, S.screenPad, convictionY, 353, 72, S.radius.md);
+  ico(dashboard, "sparkle", S.screenPad + 14, convictionY + 17, 18, C.secondary);
+  t(dashboard, "Conviction data is still building", S.screenPad + 44, convictionY + 14, 13, C.text, "Semi Bold", 230);
+  t(dashboard, "Optional conviction improves context over time.", S.screenPad + 44, convictionY + 36, 11, C.secondary, "Regular", 250);
 
-  const monthY = 638;
+  const monthY = 632;
 
   card(dashboard, S.screenPad, monthY, 353, 90, S.radius.md);
   t(dashboard, "This month", S.screenPad + 14, monthY + 14, 13, C.text, "Semi Bold", 120);
@@ -778,19 +761,12 @@ async function main() {
     t(addTrade, val, vx, previewY + 52, 14, vColor, "Semi Bold", 76);
   });
 
-  const convY = 606;
+  const addConvictionY = 606;
 
-  rect(addTrade, S.screenPad, convY, 353, 56, S.radius.md, C.elevated, C.border, 0.2);
-  t(addTrade, "Conviction  ", S.screenPad + 14, convY + 10, 12, C.text, "Medium", 100);
-  t(addTrade, "optional", S.screenPad + 100, convY + 11, 11, C.secondary, "Regular", 60);
-
-  [1, 2, 3, 4, 5].forEach((n, i) => {
-    const bx = S.screenPad + 14 + i * 46;
-    const active = n === 4;
-
-    rect(addTrade, bx, convY + 30, 38, 22, S.radius.sm, active ? C.greenDim : C.elevated, active ? C.green : C.border, 0.4);
-    t(addTrade, String(n), bx, convY + 36, 12, active ? C.green : C.secondary, "Semi Bold", 38, "CENTER");
-  });
+  card(addTrade, S.screenPad, addConvictionY, 353, 58, S.radius.md);
+  t(addTrade, "Conviction optional", S.screenPad + 14, addConvictionY + 10, 13, C.text, "Semi Bold", 160);
+  t(addTrade, "1 low · 5 high", S.screenPad + 14, addConvictionY + 31, 10, C.secondary, "Regular", 100);
+  convictionDots(addTrade, S.screenPad + 184, addConvictionY + 18, 4);
 
   rect(addTrade, S.screenPad, 676, 353, 48, S.radius.md, C.green, null);
   t(addTrade, "Save holding", S.screenPad, 692, 14, C.text, "Bold", 353, "CENTER");
@@ -1011,10 +987,10 @@ async function main() {
   nav(settings, "Settings");
 
   // ─── PAGE TITLE ──────────────────────────────────────────────
-  t(page, "CogVest — V1 UI Concepts", 24, 24, 28, C.text, "Bold", 900);
+  t(page, "CogVest — Screens", 24, 24, 28, C.text, "Bold", 900);
   t(
     page,
-    "6 screens · Dashboard · Holdings · Add Holding · Cash · Progress · Settings · Quick actions moved to header · Bottom nav is navigation only",
+    "6 screens · Dashboard · Holdings · Add Holding · Cash · Progress · Settings",
     24,
     62,
     13,
@@ -1033,7 +1009,7 @@ async function main() {
     settings,
   ]);
 
-  figma.closePlugin("✓ CogVest V1 screens generated — quick actions moved to header.");
+  figma.closePlugin("✓ CogVest screens generated.");
 }
 
 main().catch((err) => figma.closePlugin(`Failed: ${err.message}`));

--- a/docs/design/figma/issue-69-v1-screens/code.js
+++ b/docs/design/figma/issue-69-v1-screens/code.js
@@ -232,7 +232,7 @@ async function main() {
       ["cash", "Cash", "10%", "₹1,65,600"]
     ];
     rows.forEach(([type, label, pct, value], i) => {
-      const yy = y + i * 56;
+      const yy = y + i * 42;
       iconCircle(frame, x, yy, type, 34);
       text(frame, label, x + 50, yy + 4, 14, C.text, "Medium", 80);
       text(frame, pct, x + 230, yy + 4, 14, C.text, "Medium", 45, "RIGHT");
@@ -245,15 +245,15 @@ async function main() {
   }
 
   function holdingRow(frame, y, type, name, meta, current, invested, pnl, alloc, note = "") {
-    card(frame, 24, y, 345, 72, 12);
+    card(frame, 24, y, 345, 68, 12);
     iconCircle(frame, 36, y + 14, type, 32);
     text(frame, name, 78, y + 12, 14, C.text, "Medium", 150);
     text(frame, meta, 78, y + 33, 10, C.secondary, "Regular", 178);
-    if (note) text(frame, note, 78, y + 50, 9, C.warning, "Regular", 130);
+    if (note) text(frame, note, 78, y + 49, 9, C.warning, "Regular", 120);
     text(frame, current, 265, y + 14, 14, C.text, "Medium", 82, "RIGHT");
-    text(frame, `Invested ${invested}`, 36, y + 52, 9, C.secondary, "Regular", 106);
-    text(frame, `P&L ${pnl}`, 158, y + 52, 9, C.positive, "Regular", 88);
-    text(frame, alloc, 318, y + 52, 9, C.secondary, "Regular", 36, "RIGHT");
+    text(frame, `Invested ${invested}`, 36, y + 50, 9, C.secondary, "Regular", 106);
+    text(frame, `P&L ${pnl}`, 170, y + 50, 9, C.positive, "Regular", 76);
+    text(frame, alloc, 318, y + 50, 9, C.secondary, "Regular", 36, "RIGHT");
   }
 
   text(page, "CogVest V1 UI Concepts - Issue #69", 24, 24, 28, C.text, "Bold", 620);
@@ -265,20 +265,20 @@ async function main() {
   card(dashboard, 24, 246, 345, 42, 12);
   text(dashboard, "●  Quotes updated 2m ago  •  Manual fallback ready", 38, 259, 12, C.secondary, "Regular", 250);
   svg(dashboard, "refresh", 324, 255, 18);
-  card(dashboard, 24, 304, 345, 230);
+  card(dashboard, 24, 304, 345, 212);
   text(dashboard, "Allocation", 38, 320, 16, C.text, "Semi Bold", 150);
   text(dashboard, "View details", 274, 322, 12, C.positive, "Medium", 80, "RIGHT");
-  allocationRows(dashboard, 38, 364);
-  card(dashboard, 24, 552, 345, 100);
-  text(dashboard, "This month", 38, 568, 16, C.text, "Semi Bold", 130);
-  text(dashboard, "May 2026", 294, 570, 12, C.positive, "Medium", 60, "RIGHT");
-  metric(dashboard, "Invested", "₹1.20L", 42, 606, 92);
-  metric(dashboard, "Savings rate", "42%", 154, 606, 92);
-  metric(dashboard, "Cash change", "+₹70K", 266, 606, 84);
-  card(dashboard, 24, 668, 345, 64);
-  iconCircle(dashboard, 38, 683, "neutral", 32);
-  text(dashboard, "Conviction data is still building", 82, 682, 14, C.text, "Medium", 230);
-  text(dashboard, "Optional conviction improves context over time.", 82, 704, 11, C.secondary, "Regular", 240);
+  allocationRows(dashboard, 38, 356);
+  card(dashboard, 24, 532, 345, 96);
+  text(dashboard, "This month", 38, 548, 16, C.text, "Semi Bold", 130);
+  text(dashboard, "May 2026", 294, 550, 12, C.positive, "Medium", 60, "RIGHT");
+  metric(dashboard, "Invested", "₹1.20L", 42, 586, 92);
+  metric(dashboard, "Savings rate", "42%", 154, 586, 92);
+  metric(dashboard, "Cash change", "+₹70K", 266, 586, 84);
+  card(dashboard, 24, 646, 345, 64);
+  iconCircle(dashboard, 38, 661, "neutral", 32);
+  text(dashboard, "Conviction data is still building", 82, 660, 14, C.text, "Medium", 230);
+  text(dashboard, "Optional conviction improves context over time.", 82, 682, 11, C.secondary, "Regular", 240);
   nav(dashboard, "Dashboard");
 
   const holdings = screen("Holdings", 448);
@@ -290,7 +290,7 @@ async function main() {
   holdingRow(holdings, 334, "equity", "HDFC Bank", "Equity · Financial Services", "₹1.83L", "₹1.64L", "+₹18.6K", "14.6%");
   holdingRow(holdings, 414, "equity", "Nifty 50 ETF", "Equity · Index Fund", "₹50.7K", "₹44.2K", "+₹6.4K", "4.1%");
   holdingRow(holdings, 494, "debt", "Sovereign Gold Bond", "Debt · Government Bond", "₹57.1K", "₹53.0K", "+₹4.2K", "4.6%");
-  holdingRow(holdings, 574, "crypto", "Bitcoin", "Crypto · Coin", "₹13.90L", "₹11.05L", "+₹2.85L", "11.1%", "● Manual · 8h ago");
+  holdingRow(holdings, 574, "crypto", "Bitcoin", "Crypto · Manual price", "₹13.90L", "₹11.05L", "+₹2.85L", "11.1%");
   holdingRow(holdings, 654, "debt", "Liquid Fund", "Debt · Liquid / Overnight", "₹2.50L", "₹2.50L", "+₹250", "2.0%");
   nav(holdings, "Holdings");
 
@@ -322,16 +322,16 @@ async function main() {
   chip(addHolding, "Live", 42, 486, true);
   chip(addHolding, "Manual", 112, 486, false);
   text(addHolding, "Date acquired: 15 Apr 2024", 42, 532, 12, C.secondary, "Regular", 210);
-  card(addHolding, 24, 574, 345, 96, 12);
+  card(addHolding, 24, 574, 345, 90, 12);
   text(addHolding, "Derived preview", 82, 592, 16, C.text, "Semi Bold", 150);
-  ["₹36,250", "₹41,956", "+₹5,706", "+2.34%"].forEach((value, i) => metric(addHolding, ["Invested", "Current", "P&L", "Allocation"][i], value, 42 + i * 80, 626, 76, i > 1 ? C.positive : C.text));
-  card(addHolding, 24, 684, 345, 52, 12);
-  text(addHolding, "Conviction optional", 82, 697, 14, C.text, "Medium", 170);
-  text(addHolding, "Add later", 82, 718, 11, C.secondary, "Regular", 100);
-  card(addHolding, 24, 750, 160, 40, 8, C.bg);
-  text(addHolding, "Save and add another", 34, 761, 12, C.text, "Medium", 140, "CENTER");
-  card(addHolding, 202, 750, 166, 40, 8, C.green);
-  text(addHolding, "Save holding", 218, 761, 12, C.text, "Medium", 130, "CENTER");
+  ["₹36K", "₹42K", "+₹5.7K", "+2.34%"].forEach((value, i) => metric(addHolding, ["Invested", "Current", "P&L", "Allocation"][i], value, 42 + i * 80, 624, 76, i > 1 ? C.positive : C.text));
+  card(addHolding, 24, 678, 345, 48, 12);
+  text(addHolding, "Conviction optional", 82, 689, 14, C.text, "Medium", 170);
+  text(addHolding, "Add later", 82, 710, 11, C.secondary, "Regular", 100);
+  card(addHolding, 24, 738, 160, 34, 8, C.bg);
+  text(addHolding, "Save and add another", 34, 747, 11, C.text, "Medium", 140, "CENTER");
+  card(addHolding, 202, 738, 166, 34, 8, C.green);
+  text(addHolding, "Save holding", 218, 747, 11, C.text, "Medium", 130, "CENTER");
   nav(addHolding, "Add");
 
   const cash = screen("Cash", 1296);
@@ -364,10 +364,7 @@ async function main() {
     text(cash, label, 42, y, 11, C.secondary, "Regular", 160);
     text(cash, value, 286, y, 12, color, "Medium", 70, "RIGHT");
   });
-  card(cash, 24, 738, 345, 48, 12);
-  iconCircle(cash, 38, 745, "cash", 28);
-  text(cash, "Cash is included in total allocation", 78, 748, 12, C.text, "Medium", 200);
-  text(cash, "Last updated 03 May 2026, 9:40 AM", 78, 768, 10, C.secondary, "Regular", 200);
+  text(cash, "Cash is included in total allocation", 38, 744, 11, C.secondary, "Regular", 220);
   nav(cash, "Cash");
 
   const monthly = screen("Monthly Progression", 1720);
@@ -391,18 +388,15 @@ async function main() {
   card(monthly, 24, 484, 345, 100);
   text(monthly, "Progression (last 6 months)", 38, 500, 16, C.text, "Semi Bold", 230);
   line(monthly, 60, 568, 270, C.secondary, 0.75);
-  card(monthly, 24, 600, 345, 128);
-  text(monthly, "Asset class snapshot", 38, 616, 16, C.text, "Semi Bold", 200);
+  card(monthly, 24, 596, 345, 138);
+  text(monthly, "Asset class snapshot", 38, 612, 16, C.text, "Semi Bold", 200);
   [["equity", "Equity", "₹12,45,000", "62.6%"], ["debt", "Debt", "₹3,22,000", "16.2%"], ["crypto", "Crypto", "₹1,20,000", "6.0%"], ["cash", "Cash", "₹3,25,470", "16.3%"]].forEach(([type, label, value, pct], i) => {
-    const y = 654 + i * 26;
+    const y = 644 + i * 25;
     iconCircle(monthly, 38, y - 6, type, 24);
     text(monthly, label, 70, y, 12, C.text, "Medium", 70);
     text(monthly, value, 226, y, 12, C.text, "Regular", 80, "RIGHT");
     text(monthly, pct, 322, y, 12, C.secondary, "Regular", 40, "RIGHT");
   });
-  card(monthly, 24, 742, 345, 40, 12);
-  text(monthly, "May note", 76, 750, 13, C.text, "Medium", 120);
-  text(monthly, "Optional note", 246, 752, 10, C.secondary, "Regular", 90);
   nav(monthly, "Dashboard");
 
   const settings = screen("Settings", 2144);
@@ -414,14 +408,14 @@ async function main() {
     text(settings, title, 92, y + 22, 16, C.text, "Semi Bold", 180);
     lines.forEach(([label, color], i) => text(settings, label, 92, y + 48 + i * 22, 12, color || C.secondary, "Regular", 225));
   }
-  settingCard(128, "Privacy", [["Data stays on this device"], ["●  Local storage: Active", C.positive], ["No account • No cloud sync • No analytics"]], 100);
-  settingCard(240, "Value masking", [["Hide amounts on screen and app switcher."], ["Masked preview   ₹••,••,•••"]], 92);
-  settingCard(344, "Quotes", [["Live refresh     Every 15 min"], ["Last refresh     3 May, 10:15 AM"], ["Provider status     Available", C.positive]], 110);
-  settingCard(466, "Currency", [["Base currency     INR"], ["Foreign assets summary     On"], ["USD & crypto fallback     On"]], 110);
-  settingCard(588, "Display & App info", [["Density     Standard (V1)"], ["Minimal Mode     V2 locked", C.muted], ["App version 1.0.0 · preview"]], 110);
-  card(settings, 24, 720, 345, 38, 10, C.bg).strokes = [paint(C.negative, 0.45)];
-  text(settings, "Clear local data", 52, 730, 12, C.negative, "Medium", 150);
-  text(settings, "Deletes local data", 224, 730, 10, C.muted, "Regular", 114, "RIGHT");
+  settingCard(128, "Privacy", [["Data stays on this device"], ["●  Local storage: Active", C.positive], ["No account • No cloud • No analytics"]], 104);
+  settingCard(246, "Value masking", [["Hide amounts on screen"], ["Masked preview   ₹••,••,•••"]], 88);
+  settingCard(348, "Quotes", [["Live refresh     Every 15 min"], ["Last refresh     3 May, 10:15 AM"], ["Provider status     Available", C.positive]], 104);
+  settingCard(466, "Currency", [["Base currency     INR"], ["Foreign assets summary     On"], ["USD & crypto fallback     On"]], 104);
+  settingCard(584, "Display & App info", [["Density     Standard (V1)"], ["Minimal Mode     V2 locked", C.muted], ["App version 1.0.0 · preview"]], 104);
+  card(settings, 24, 704, 345, 38, 10, C.bg).strokes = [paint(C.negative, 0.45)];
+  text(settings, "Clear local data", 52, 714, 12, C.negative, "Medium", 150);
+  text(settings, "Deletes local data", 224, 714, 10, C.muted, "Regular", 114, "RIGHT");
   nav(settings, "Settings");
 
   figma.viewport.scrollAndZoomIntoView([dashboard, holdings, addHolding, cash, monthly, settings]);

--- a/docs/design/figma/issue-69-v1-screens/code.js
+++ b/docs/design/figma/issue-69-v1-screens/code.js
@@ -148,13 +148,24 @@ async function main() {
   }
 
   function top(frame, title, subtitle, actions = []) {
-    text(frame, title, 24, 72, 24, C.text, "Semi Bold", 230);
-    text(frame, subtitle, 24, 104, 14, C.secondary, "Regular", 250);
+    const titleWidth = actions.length > 0 ? 220 : 285;
+    text(frame, title, 24, 72, 23, C.text, "Semi Bold", titleWidth);
+    text(frame, subtitle, 24, 104, 13, C.secondary, "Regular", 255);
     actions.forEach((action, i) => {
       const x = 286 + i * 46;
       card(frame, x, 68, 38, 38, 10);
       svg(frame, action, x + 9, 77, 20, C.text);
     });
+  }
+
+  function topBack(frame, title, subtitle, action = null) {
+    svg(frame, "home", 24, 74, 20);
+    text(frame, title, 70, 70, 22, C.text, "Semi Bold", 230);
+    text(frame, subtitle, 70, 102, 13, C.secondary, "Regular", 240);
+    if (action) {
+      card(frame, 331, 68, 38, 38, 10);
+      svg(frame, action, 340, 77, 20, C.text);
+    }
   }
 
   function nav(frame, selected) {
@@ -224,15 +235,15 @@ async function main() {
   }
 
   function holdingRow(frame, y, type, name, meta, current, invested, pnl, alloc, note = "") {
-    card(frame, 24, y, 345, 80, 12);
-    iconCircle(frame, 36, y + 16, type, 34);
-    text(frame, name, 82, y + 16, 15, C.text, "Medium", 150);
-    text(frame, meta, 82, y + 39, 11, C.secondary, "Regular", 178);
-    if (note) text(frame, note, 82, y + 57, 10, C.warning, "Regular", 130);
-    text(frame, current, 265, y + 18, 15, C.text, "Medium", 82, "RIGHT");
-    text(frame, `Invested  ${invested}`, 36, y + 56, 10, C.secondary, "Regular", 105);
-    text(frame, `P&L  ${pnl}`, 160, y + 56, 10, C.positive, "Regular", 86);
-    text(frame, `Allocation  ${alloc}`, 260, y + 56, 10, C.secondary, "Regular", 84, "RIGHT");
+    card(frame, 24, y, 345, 72, 12);
+    iconCircle(frame, 36, y + 14, type, 32);
+    text(frame, name, 78, y + 12, 14, C.text, "Medium", 150);
+    text(frame, meta, 78, y + 33, 10, C.secondary, "Regular", 178);
+    if (note) text(frame, note, 78, y + 50, 9, C.warning, "Regular", 130);
+    text(frame, current, 265, y + 14, 14, C.text, "Medium", 82, "RIGHT");
+    text(frame, `Invested ${invested}`, 36, y + 52, 9, C.secondary, "Regular", 106);
+    text(frame, `P&L ${pnl}`, 158, y + 52, 9, C.positive, "Regular", 88);
+    text(frame, alloc, 318, y + 52, 9, C.secondary, "Regular", 36, "RIGHT");
   }
 
   text(page, "CogVest V1 UI Concepts - Issue #69", 24, 24, 28, C.text, "Bold", 620);
@@ -244,20 +255,20 @@ async function main() {
   card(dashboard, 24, 258, 345, 44, 12);
   text(dashboard, "●  Quotes updated 2m ago  •  Manual fallback ready", 38, 272, 12, C.secondary, "Regular", 250);
   svg(dashboard, "refresh", 324, 268, 18);
-  card(dashboard, 24, 318, 164, 260);
-  text(dashboard, "Allocation", 38, 334, 16, C.text, "Semi Bold", 120);
-  text(dashboard, "View details", 95, 334, 12, C.positive, "Medium", 80, "RIGHT");
-  allocationRows(dashboard, 38, 382);
-  card(dashboard, 204, 318, 165, 260);
-  text(dashboard, "This month", 220, 334, 16, C.text, "Semi Bold", 120);
-  text(dashboard, "May 2026", 292, 336, 12, C.positive, "Medium", 60, "RIGHT");
-  metric(dashboard, "Invested", "₹1,20,000", 248, 390, 90);
-  metric(dashboard, "Savings rate", "42%", 248, 462, 90);
-  metric(dashboard, "Cash change", "+₹70,000", 248, 534, 90);
-  card(dashboard, 24, 596, 345, 72);
-  iconCircle(dashboard, 38, 613, "neutral", 34);
-  text(dashboard, "Conviction data is still building", 86, 614, 15, C.text, "Medium", 230);
-  text(dashboard, "Optional conviction improves context over time.", 86, 638, 12, C.secondary, "Regular", 240);
+  card(dashboard, 24, 318, 345, 230);
+  text(dashboard, "Allocation", 38, 334, 16, C.text, "Semi Bold", 150);
+  text(dashboard, "View details", 274, 336, 12, C.positive, "Medium", 80, "RIGHT");
+  allocationRows(dashboard, 38, 378);
+  card(dashboard, 24, 562, 345, 98);
+  text(dashboard, "This month", 38, 578, 16, C.text, "Semi Bold", 130);
+  text(dashboard, "May 2026", 294, 580, 12, C.positive, "Medium", 60, "RIGHT");
+  metric(dashboard, "Invested", "₹1,20,000", 42, 616, 92);
+  metric(dashboard, "Savings rate", "42%", 154, 616, 92);
+  metric(dashboard, "Cash change", "+₹70,000", 266, 616, 84);
+  card(dashboard, 24, 674, 345, 64);
+  iconCircle(dashboard, 38, 689, "neutral", 32);
+  text(dashboard, "Conviction data is still building", 82, 688, 14, C.text, "Medium", 230);
+  text(dashboard, "Optional conviction improves context over time.", 82, 710, 11, C.secondary, "Regular", 240);
   nav(dashboard, "Dashboard");
 
   const holdings = screen("Holdings", 448);
@@ -266,16 +277,15 @@ async function main() {
   text(holdings, "●  Quotes updated 2m ago  •  1 manual price", 38, 218, 12, C.secondary, "Regular", 230);
   ["All", "Equity", "Debt", "Crypto", "Cash"].forEach((label, i) => chip(holdings, label, 24 + i * 68, 260, i === 0));
   text(holdings, "Sorted by asset class", 24, 310, 12, C.secondary, "Regular", 160);
-  holdingRow(holdings, 344, "equity", "HDFC Bank", "Equity · Financial Services", "₹1,82,850", "₹1,64,235", "+₹18,615", "14.6%");
-  holdingRow(holdings, 434, "equity", "Nifty 50 ETF", "Equity · Index Fund", "₹50,665", "₹44,220", "+₹6,445", "4.1%");
-  holdingRow(holdings, 524, "debt", "Sovereign Gold Bond", "Debt · Government Bond", "₹57,110", "₹52,950", "+₹4,160", "4.6%");
-  holdingRow(holdings, 614, "crypto", "Bitcoin", "Crypto · Coin", "₹13,90,400", "₹11,05,000", "+₹2,85,400", "11.1%", "● Manual · 8h ago");
-  holdingRow(holdings, 704, "debt", "Liquid Fund", "Debt · Liquid / Overnight", "₹2,50,250", "₹2,50,000", "+₹250", "2.0%");
+  holdingRow(holdings, 334, "equity", "HDFC Bank", "Equity · Financial Services", "₹1,82,850", "₹1,64,235", "+₹18,615", "14.6%");
+  holdingRow(holdings, 414, "equity", "Nifty 50 ETF", "Equity · Index Fund", "₹50,665", "₹44,220", "+₹6,445", "4.1%");
+  holdingRow(holdings, 494, "debt", "Sovereign Gold Bond", "Debt · Government Bond", "₹57,110", "₹52,950", "+₹4,160", "4.6%");
+  holdingRow(holdings, 574, "crypto", "Bitcoin", "Crypto · Coin", "₹13,90,400", "₹11,05,000", "+₹2,85,400", "11.1%", "● Manual · 8h ago");
+  holdingRow(holdings, 654, "debt", "Liquid Fund", "Debt · Liquid / Overnight", "₹2,50,250", "₹2,50,000", "+₹250", "2.0%");
   nav(holdings, "Holdings");
 
   const addHolding = screen("Add Holding", 872);
-  top(addHolding, "Add Holding", "Opening position • local only", []);
-  svg(addHolding, "home", 24, 72, 20);
+  topBack(addHolding, "Add Holding", "Opening position • local only");
   text(addHolding, "?", 342, 74, 22, C.secondary, "Semi Bold", 24, "CENTER");
   ["Asset", "Classification", "Position", "Review"].forEach((label, i) => {
     const x = 58 + i * 86;
@@ -353,7 +363,7 @@ async function main() {
   nav(cash, "Cash");
 
   const monthly = screen("Monthly Progression", 1720);
-  top(monthly, "Monthly Progression", "May 2026 snapshot", ["eye"]);
+  topBack(monthly, "Monthly Progression", "May 2026 snapshot", "eye");
   text(monthly, "‹  Apr 2026", 24, 128, 13, C.secondary, "Regular", 100);
   text(monthly, "May 2026", 164, 128, 15, C.positive, "Medium", 80, "CENTER");
   text(monthly, "Jun 2026  ›", 286, 128, 13, C.secondary, "Regular", 80, "RIGHT");
@@ -372,21 +382,21 @@ async function main() {
     text(monthly, caption, 78, y + 16, 10, C.secondary, "Regular", 170);
     text(monthly, value, 288, y + 4, 13, value.startsWith("-") ? C.negative : C.text, "Medium", 70, "RIGHT");
   });
-  card(monthly, 24, 484, 345, 118);
+  card(monthly, 24, 484, 345, 100);
   text(monthly, "Progression (last 6 months)", 38, 500, 16, C.text, "Semi Bold", 230);
   line(monthly, 60, 568, 270, C.secondary, 0.75);
-  card(monthly, 24, 620, 345, 128);
-  text(monthly, "Asset class snapshot", 38, 636, 16, C.text, "Semi Bold", 200);
+  card(monthly, 24, 600, 345, 128);
+  text(monthly, "Asset class snapshot", 38, 616, 16, C.text, "Semi Bold", 200);
   [["equity", "Equity", "₹12,45,000", "62.6%"], ["debt", "Debt", "₹3,22,000", "16.2%"], ["crypto", "Crypto", "₹1,20,000", "6.0%"], ["cash", "Cash", "₹3,25,470", "16.3%"]].forEach(([type, label, value, pct], i) => {
-    const y = 674 + i * 26;
+    const y = 654 + i * 26;
     iconCircle(monthly, 38, y - 6, type, 24);
     text(monthly, label, 70, y, 12, C.text, "Medium", 70);
     text(monthly, value, 226, y, 12, C.text, "Regular", 80, "RIGHT");
     text(monthly, pct, 322, y, 12, C.secondary, "Regular", 40, "RIGHT");
   });
-  card(monthly, 24, 764, 345, 52, 12);
-  text(monthly, "May note", 76, 776, 14, C.text, "Medium", 120);
-  text(monthly, "Optional note for future review", 76, 798, 11, C.secondary, "Regular", 180);
+  card(monthly, 24, 742, 345, 40, 12);
+  text(monthly, "May note", 76, 750, 13, C.text, "Medium", 120);
+  text(monthly, "Optional note", 246, 752, 10, C.secondary, "Regular", 90);
   nav(monthly, "Dashboard");
 
   const settings = screen("Settings", 2144);
@@ -398,14 +408,14 @@ async function main() {
     text(settings, title, 92, y + 22, 16, C.text, "Semi Bold", 180);
     lines.forEach(([label, color], i) => text(settings, label, 92, y + 48 + i * 22, 12, color || C.secondary, "Regular", 225));
   }
-  settingCard(128, "Privacy", [["Data stays on this device"], ["●  Local storage: Active", C.positive], ["No account  •  No cloud sync  •  No analytics"]], 126);
-  settingCard(268, "Value masking", [["Hide amounts on screen and in app switcher."], ["Masked preview   ₹••,••,•••"]], 106);
-  settingCard(388, "Quotes", [["Live quote refresh     Every 15 min"], ["Last refresh     3 May 2026, 10:15 AM"], ["Provider status     Available", C.positive]], 126);
-  settingCard(528, "Currency", [["Base currency     INR"], ["Foreign assets converted for summary     On"], ["USD & crypto prices: manual fallback     On"]], 126);
-  settingCard(668, "Display & App info", [["Density     Standard (V1)"], ["Minimal Mode     V2 locked", C.muted], ["App version 1.0.0 · Build preview"]], 126);
-  card(settings, 24, 794, 345, 38, 10, C.bg).strokes = [paint(C.negative, 0.55)];
-  text(settings, "Clear local data", 52, 804, 12, C.negative, "Medium", 150);
-  text(settings, "Deletes all local data", 208, 804, 10, C.muted, "Regular", 130, "RIGHT");
+  settingCard(128, "Privacy", [["Data stays on this device"], ["●  Local storage: Active", C.positive], ["No account • No cloud sync • No analytics"]], 100);
+  settingCard(240, "Value masking", [["Hide amounts on screen and app switcher."], ["Masked preview   ₹••,••,•••"]], 92);
+  settingCard(344, "Quotes", [["Live refresh     Every 15 min"], ["Last refresh     3 May, 10:15 AM"], ["Provider status     Available", C.positive]], 110);
+  settingCard(466, "Currency", [["Base currency     INR"], ["Foreign assets summary     On"], ["USD & crypto fallback     On"]], 110);
+  settingCard(588, "Display & App info", [["Density     Standard (V1)"], ["Minimal Mode     V2 locked", C.muted], ["App version 1.0.0 · preview"]], 110);
+  card(settings, 24, 720, 345, 38, 10, C.bg).strokes = [paint(C.negative, 0.45)];
+  text(settings, "Clear local data", 52, 730, 12, C.negative, "Medium", 150);
+  text(settings, "Deletes local data", 224, 730, 10, C.muted, "Regular", 114, "RIGHT");
   nav(settings, "Settings");
 
   figma.viewport.scrollAndZoomIntoView([dashboard, holdings, addHolding, cash, monthly, settings]);

--- a/docs/design/figma/issue-69-v1-screens/code.js
+++ b/docs/design/figma/issue-69-v1-screens/code.js
@@ -1,5 +1,12 @@
-// CogVest Issue #69 V1 editable Figma screens.
+// CogVest — V1 editable Figma screens
 // Run from Figma Desktop as a development plugin.
+// Improvements: conviction stars, better spacing system,
+// improved hero card, insight card, consistent borders,
+// better typography contrast.
+// Navigation model fixed:
+// Main tabs: Dashboard, Holdings, Progress, Cash, Settings
+// Quick Add: header action button, not middle FAB
+// Secondary screen: Add Holding
 
 async function main() {
   await figma.loadFontAsync({ family: "Inter", style: "Regular" });
@@ -7,53 +14,117 @@ async function main() {
   await figma.loadFontAsync({ family: "Inter", style: "Semi Bold" });
   await figma.loadFontAsync({ family: "Inter", style: "Bold" });
 
+  // ─── COLOUR SYSTEM ───────────────────────────────────────────
   const C = {
-    bg: "#000000",
+    // Backgrounds
+    bg: "#0A0A0B",
     surface: "#1C1C1E",
     elevated: "#2C2C2E",
+    field: "#111113",
+
+    // Text
     text: "#F5F5F7",
     secondary: "#98989D",
     muted: "#636366",
-    green: "#34C759",
+    inverse: "#000000",
+
+    // Brand
+    green: "#2E7D52",
+    greenDim: "#1A4A30",
+    greenText: "#4CAF50",
+
+    // Semantic
     positive: "#34C759",
-    warning: "#F59E0B",
     negative: "#FF453A",
-    border: "#FFFFFF",
+    warning: "#F59E0B",
     blue: "#0A84FF",
+    amber: "#FF9F0A",
     cashBlue: "#64D2FF",
-    amber: "#FF9F0A"
+    purple: "#BF5AF2",
+
+    // Borders
+    border: "#38383A",
+    borderDim: "#28282A",
   };
 
+  // ─── SPACING SYSTEM ──────────────────────────────────────────
+  const S = {
+    screenPad: 20,
+    cardPad: 16,
+    cardGap: 10,
+    rowH: 52,
+    headerH: 32,
+    navH: 74,
+    navY: 778,
+    radius: {
+      sm: 8,
+      md: 14,
+      lg: 18,
+      full: 999,
+    },
+  };
+
+  // ─── PAGE SETUP ──────────────────────────────────────────────
   const PAGE_NAME = "Issue 69 - V1 UI Concepts";
-  let page = figma.root.children.find((item) => item.name === PAGE_NAME);
+  let page = figma.root.children.find((p) => p.name === PAGE_NAME);
   if (!page) {
     page = figma.createPage();
     page.name = PAGE_NAME;
   }
+
   await figma.setCurrentPageAsync(page);
+
   for (const child of [...page.children]) {
     child.remove();
   }
 
+  // ─── PRIMITIVE HELPERS ───────────────────────────────────────
   function rgb(hex) {
     const h = hex.replace("#", "");
     return {
       r: parseInt(h.slice(0, 2), 16) / 255,
       g: parseInt(h.slice(2, 4), 16) / 255,
-      b: parseInt(h.slice(4, 6), 16) / 255
+      b: parseInt(h.slice(4, 6), 16) / 255,
     };
   }
 
   function paint(hex, opacity = 1) {
-    return { type: "SOLID", color: rgb(hex), opacity };
+    return {
+      type: "SOLID",
+      color: rgb(hex),
+      opacity,
+    };
   }
 
-  function text(parent, value, x, y, size, color = C.text, style = "Regular", width = 160, align = "LEFT") {
+  function rect(parent, x, y, w, h, radius = 0, fill = C.surface, strokeColor = null, strokeOpacity = 0.5) {
+    const node = figma.createRectangle();
+    parent.appendChild(node);
+    node.x = x;
+    node.y = y;
+    node.resize(w, h);
+    node.cornerRadius = radius;
+    node.fills = [paint(fill)];
+
+    if (strokeColor) {
+      node.strokes = [paint(strokeColor, strokeOpacity)];
+      node.strokeWeight = 1;
+    } else {
+      node.strokes = [];
+    }
+
+    return node;
+  }
+
+  function card(parent, x, y, w, h, radius = S.radius.lg, fill = C.surface) {
+    return rect(parent, x, y, w, h, radius, fill, C.border, 0.35);
+  }
+
+  function t(parent, value, x, y, size, color = C.text, style = "Regular", width = 160, align = "LEFT") {
     const node = figma.createText();
     parent.appendChild(node);
     node.x = x;
     node.y = y;
-    node.resize(width, Math.max(size + 10, 20));
+    node.resize(width, Math.max(size + 10, 18));
     node.fontName = { family: "Inter", style };
     node.fontSize = size;
     node.fills = [paint(color)];
@@ -63,19 +134,7 @@ async function main() {
     return node;
   }
 
-  function card(parent, x, y, width, height, radius = 18, fill = C.surface) {
-    const node = figma.createRectangle();
-    parent.appendChild(node);
-    node.x = x;
-    node.y = y;
-    node.resize(width, height);
-    node.cornerRadius = radius;
-    node.fills = [paint(fill)];
-    node.strokes = [];
-    return node;
-  }
-
-  function line(parent, x, y, width, color = C.border, opacity = 0.1) {
+  function line(parent, x, y, width, color = C.border, opacity = 0.35) {
     const node = figma.createLine();
     parent.appendChild(node);
     node.x = x;
@@ -86,67 +145,105 @@ async function main() {
     return node;
   }
 
-  function iconSvg(name, color = C.secondary) {
-    const s = color;
-    const icons = {
-      home: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M3 10.8 12 3l9 7.8V21h-6v-6H9v6H3V10.8Z" stroke="${s}" stroke-width="2" stroke-linejoin="round"/></svg>`,
-      pie: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M12 3v9h9A9 9 0 1 1 12 3Z" stroke="${s}" stroke-width="2"/><path d="M14 3.3A9 9 0 0 1 20.7 10H14V3.3Z" stroke="${s}" stroke-width="2"/></svg>`,
-      plus: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M12 5v14M5 12h14" stroke="${s}" stroke-width="2.4" stroke-linecap="round"/></svg>`,
-      wallet: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M4 7h16v12H4z" stroke="${s}" stroke-width="2" stroke-linejoin="round"/><path d="M4 7l11-3 2 3" stroke="${s}" stroke-width="2"/><path d="M15 13h5" stroke="${s}" stroke-width="2"/></svg>`,
-      gear: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z" stroke="${s}" stroke-width="2"/><path d="M4 13v-2l2.1-.6c.2-.6.4-1.1.7-1.6L5.8 6.7 7.2 5.3l2.1 1c.5-.3 1-.5 1.6-.7L11.5 3h2l.6 2.6c.6.2 1.1.4 1.6.7l2.1-1 1.4 1.4-1 2.1c.3.5.5 1 .7 1.6L21 11v2l-2.1.6c-.2.6-.4 1.1-.7 1.6l1 2.1-1.4 1.4-2.1-1c-.5.3-1 .5-1.6.7l-.6 2.6h-2l-.6-2.6c-.6-.2-1.1-.4-1.6-.7l-2.1 1-1.4-1.4 1-2.1c-.3-.5-.5-1-.7-1.6L4 13Z" stroke="${s}" stroke-width="2" stroke-linejoin="round"/></svg>`,
-      trend: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M4 16l5-5 4 4 7-8" stroke="${s}" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"/><path d="M15 7h5v5" stroke="${s}" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
-      shield: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M12 3 20 6v6c0 5-3.4 7.8-8 9-4.6-1.2-8-4-8-9V6l8-3Z" stroke="${s}" stroke-width="2" stroke-linejoin="round"/></svg>`,
-      btc: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M9 4v16M13 4v16M7 7h6.2c2 0 3.3 1 3.3 2.6 0 1.1-.7 2-1.9 2.3 1.5.3 2.4 1.3 2.4 2.8 0 1.8-1.5 3.3-3.8 3.3H7M7 12h6" stroke="${s}" stroke-width="2" stroke-linecap="round"/></svg>`,
-      eye: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z" stroke="${s}" stroke-width="2"/><circle cx="12" cy="12" r="3" stroke="${s}" stroke-width="2"/></svg>`,
-      refresh: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M20 7v5h-5M4 17v-5h5" stroke="${s}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M18 12a6 6 0 0 0-10.2-4.2L4 11m16 2-3.8 3.2A6 6 0 0 1 6 12" stroke="${s}" stroke-width="2" stroke-linecap="round"/></svg>`,
-      search: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><circle cx="11" cy="11" r="7" stroke="${s}" stroke-width="2"/><path d="m16 16 5 5" stroke="${s}" stroke-width="2" stroke-linecap="round"/></svg>`,
-      back: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="m15 6-6 6 6 6" stroke="${s}" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"/></svg>`
-    };
-    return icons[name] || icons.trend;
-  }
-
-  function svg(parent, name, x, y, size = 22, color = C.secondary) {
-    const node = figma.createNodeFromSvg(iconSvg(name, color));
+  function svgNode(parent, svgStr, x, y, w, h) {
+    const node = figma.createNodeFromSvg(svgStr);
     parent.appendChild(node);
     node.x = x;
     node.y = y;
-    node.resize(size, size);
+    node.resize(w, h);
     return node;
   }
 
-  function iconCircle(parent, x, y, type, size = 36) {
-    const config = {
-      equity: [C.green, "trend"],
-      debt: [C.blue, "shield"],
-      crypto: [C.amber, "btc"],
-      cash: [C.cashBlue, "wallet"],
-      neutral: [C.elevated, "trend"]
+  // ─── ICON SYSTEM ─────────────────────────────────────────────
+  function icon(name, color = C.secondary, size = 20) {
+    const s = color;
+
+    const icons = {
+      home: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M3 10.8 12 3l9 7.8V21h-6v-6H9v6H3V10.8Z" stroke="${s}" stroke-width="1.8" stroke-linejoin="round"/></svg>`,
+
+      pie: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M12 3v9h9A9 9 0 1 1 12 3Z" stroke="${s}" stroke-width="1.8"/><path d="M14 3.3A9 9 0 0 1 20.7 10H14V3.3Z" stroke="${s}" stroke-width="1.8"/></svg>`,
+
+      plus: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M12 5v14M5 12h14" stroke="${s}" stroke-width="2.2" stroke-linecap="round"/></svg>`,
+
+      wallet: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M4 7h16v12H4z" stroke="${s}" stroke-width="1.8" stroke-linejoin="round"/><path d="M4 7l11-3 2 3" stroke="${s}" stroke-width="1.8"/><path d="M15 13h5" stroke="${s}" stroke-width="1.8"/><circle cx="17" cy="13" r="1" fill="${s}"/></svg>`,
+
+      gear: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="3.5" stroke="${s}" stroke-width="1.8"/><path d="M12 2v2M12 20v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M2 12h2M20 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/></svg>`,
+
+      trend: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M4 16l5-5 4 4 7-8" stroke="${s}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M15 7h5v5" stroke="${s}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
+
+      shield: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M12 3 20 6v6c0 5-3.4 7.8-8 9-4.6-1.2-8-4-8-9V6l8-3Z" stroke="${s}" stroke-width="1.8" stroke-linejoin="round"/></svg>`,
+
+      btc: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M9 4v16M13 4v16M7 7h6.2c2 0 3.3 1 3.3 2.6 0 1.1-.7 2-1.9 2.3 1.5.3 2.4 1.3 2.4 2.8 0 1.8-1.5 3.3-3.8 3.3H7M7 12h6" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/></svg>`,
+
+      eye: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z" stroke="${s}" stroke-width="1.8"/><circle cx="12" cy="12" r="3" stroke="${s}" stroke-width="1.8"/></svg>`,
+
+      eyeOff: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/><path d="M1 1l22 22" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/></svg>`,
+
+      refresh: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M20 7v5h-5M4 17v-5h5" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/><path d="M18 12a6 6 0 0 0-10.2-4.2L4 11m16 2-3.8 3.2A6 6 0 0 1 6 12" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/></svg>`,
+
+      search: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><circle cx="11" cy="11" r="7" stroke="${s}" stroke-width="1.8"/><path d="m16 16 5 5" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/></svg>`,
+
+      back: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="m15 6-6 6 6 6" stroke="${s}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
+
+      chevron: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M9 18l6-6-6-6" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
+
+      check: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M5 12l5 5L20 7" stroke="${s}" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
+
+      sparkle: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M12 2l2.4 7.2H22l-6.2 4.6 2.4 7.2L12 16.6l-6.2 4.4 2.4-7.2L2 9.2h7.6L12 2Z" stroke="${s}" stroke-width="1.8" stroke-linejoin="round"/></svg>`,
+
+      info: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" stroke="${s}" stroke-width="1.8"/><path d="M12 11v6" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/><circle cx="12" cy="7.5" r="1" fill="${s}"/></svg>`,
+
+      calendar: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><rect x="3" y="4" width="18" height="18" rx="2" stroke="${s}" stroke-width="1.8"/><path d="M3 9h18M8 2v4M16 2v4" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/></svg>`,
     };
-    const [fill, icon] = config[type] || config.neutral;
-    const outer = figma.createEllipse();
-    parent.appendChild(outer);
-    outer.x = x;
-    outer.y = y;
-    outer.resize(size, size);
-    outer.fills = [paint(fill, type === "neutral" ? 0.55 : 0.88)];
-    outer.strokes = [paint(fill, 0.35)];
-    outer.strokeWeight = 1;
-    svg(parent, icon, x + 8, y + 8, size - 16, C.text);
-    return outer;
+
+    return icons[name] || icons.trend;
   }
 
-  function iconGlyph(parent, x, y, type, size = 22) {
-    const config = {
-      equity: [C.positive, "trend"],
-      debt: [C.blue, "shield"],
-      crypto: [C.amber, "btc"],
-      cash: [C.cashBlue, "wallet"],
-      neutral: [C.secondary, "trend"]
-    };
-    const [color, icon] = config[type] || config.neutral;
-    return svg(parent, icon, x, y, size, color);
+  function ico(parent, name, x, y, size = 20, color = C.secondary) {
+    return svgNode(parent, icon(name, color, size), x, y, size, size);
   }
 
+  // ─── ASSET CLASS CONFIG ──────────────────────────────────────
+  const assetClass = {
+    equity: { color: C.positive, icon: "trend", label: "Equity" },
+    debt: { color: C.blue, icon: "shield", label: "Debt" },
+    crypto: { color: C.amber, icon: "btc", label: "Crypto" },
+    cash: { color: C.cashBlue, icon: "wallet", label: "Cash" },
+  };
+
+  function assetDot(parent, x, y, type, dotSize = 8) {
+    const ac = assetClass[type] || assetClass.equity;
+    const dot = figma.createEllipse();
+    parent.appendChild(dot);
+    dot.x = x;
+    dot.y = y;
+    dot.resize(dotSize, dotSize);
+    dot.fills = [paint(ac.color)];
+    dot.strokes = [];
+    return dot;
+  }
+
+  // ─── PILL / BADGE ────────────────────────────────────────────
+  function pill(parent, label, x, y, bgColor, textColor, width = null, height = 24, radius = S.radius.full) {
+    const textW = width ? width - 20 : label.length * 7 + 16;
+    const pillW = width || textW + 20;
+    rect(parent, x, y, pillW, height, radius, bgColor, null);
+    t(parent, label, x, y + (height - 14) / 2, 11, textColor, "Semi Bold", pillW, "CENTER");
+    return pillW;
+  }
+
+  function convictionStars(parent, x, y, filled, outOf = 5) {
+    const starSize = 11;
+    const gap = 2;
+
+    for (let i = 0; i < outOf; i++) {
+      const starX = x + i * (starSize + gap);
+      const isFilled = i < filled;
+      t(parent, "★", starX, y, starSize, isFilled ? C.warning : C.muted, "Semi Bold", starSize + 2);
+    }
+  }
+
+  // ─── SCREEN FRAME ────────────────────────────────────────────
   function screen(name, x) {
     const frame = figma.createFrame();
     page.appendChild(frame);
@@ -154,296 +251,789 @@ async function main() {
     frame.x = x;
     frame.y = 130;
     frame.resize(393, 852);
-    frame.cornerRadius = 34;
+    frame.cornerRadius = 36;
     frame.clipsContent = true;
     frame.fills = [paint(C.bg)];
-    text(frame, "10:42", 24, 22, 12, C.text, "Medium", 60);
-    text(frame, "◢  ▰ 100%", 304, 22, 12, C.text, "Medium", 72, "RIGHT");
+
+    t(frame, "10:42", 24, 20, 12, C.text, "Semi Bold", 60);
+    t(frame, "◢  ▰ 100%", 300, 20, 11, C.text, "Medium", 80, "RIGHT");
+
     return frame;
   }
 
-  function top(frame, title, subtitle, actions = []) {
-    const titleWidth = actions.length > 0 ? 220 : 285;
-    text(frame, title, 24, 70, 28, C.text, "Bold", titleWidth);
-    text(frame, subtitle, 24, 108, 13, C.secondary, "Regular", 255);
+  // ─── HEADER COMPONENTS ───────────────────────────────────────
+  function header(frame, title, subtitle, actions = []) {
+    t(frame, title, S.screenPad, 60, 26, C.text, "Bold", 210);
+
+    if (subtitle) {
+      t(frame, subtitle, S.screenPad, 96, 12, C.secondary, "Regular", 245);
+    }
+
     actions.forEach((action, i) => {
-      const x = 286 + i * 46;
-      card(frame, x, 70, 38, 38, 12, C.elevated);
-      svg(frame, action, x + 9, 77, 20, C.text);
+      const x = 330 - (actions.length - 1 - i) * 42;
+      rect(frame, x, 60, 34, 34, S.radius.sm, C.elevated, C.border, 0.3);
+      ico(frame, action, x + 7, 67, 20, C.secondary);
     });
   }
 
-  function topBack(frame, title, subtitle, action = null) {
-    svg(frame, "back", 24, 74, 20, C.text);
-    text(frame, title, 70, 68, 26, C.text, "Bold", 230);
-    text(frame, subtitle, 70, 104, 13, C.secondary, "Regular", 240);
+  function headerBack(frame, title, subtitle, action = null) {
+    ico(frame, "back", S.screenPad, 66, 20, C.text);
+    t(frame, title, 54, 60, 22, C.text, "Bold", action ? 220 : 280);
+
+    if (subtitle) {
+      t(frame, subtitle, 54, 92, 11, C.secondary, "Regular", 240);
+    }
+
     if (action) {
-      card(frame, 331, 70, 38, 38, 12, C.elevated);
-      svg(frame, action, 340, 77, 20, C.text);
+      rect(frame, 335, 60, 34, 34, S.radius.sm, C.elevated, C.border, 0.3);
+      ico(frame, action, 342, 67, 20, C.secondary);
     }
   }
 
+  // ─── BOTTOM NAVIGATION ───────────────────────────────────────
   function nav(frame, selected) {
-    const navBg = figma.createRectangle();
-    frame.appendChild(navBg);
-    navBg.x = 0;
-    navBg.y = 778;
-    navBg.resize(393, 74);
-    navBg.fills = [paint(C.surface, 0.86)];
-    navBg.strokes = [paint(C.border, 0.08)];
-    navBg.strokeWeight = 1;
+    rect(frame, 0, S.navY, 393, S.navH, 0, C.surface, C.border, 0.5);
+
     const items = [
-      ["Dashboard", "home", 48],
-      ["Holdings", "pie", 122],
-      ["Add", "plus", 196],
-      ["Cash", "wallet", 270],
-      ["Settings", "gear", 344]
+      ["Dashboard", "home", 38],
+      ["Holdings", "pie", 118],
+      ["Progress", "trend", 197],
+      ["Cash", "wallet", 276],
+      ["Settings", "gear", 354],
     ];
-    items.forEach(([label, icon, x]) => {
+
+    items.forEach(([label, iconName, cx]) => {
       const active = label === selected;
-      if (label === "Add") {
-        const circle = figma.createEllipse();
-        frame.appendChild(circle);
-        circle.x = 176;
-        circle.y = 787;
-        circle.resize(40, 40);
-        circle.fills = [paint(C.green)];
-        svg(frame, "plus", 186, 797, 20, C.text);
-      } else {
-        svg(frame, icon, x - 12, 793, 24, active ? C.positive : C.secondary);
-        if (active) card(frame, x - 24, 778, 48, 3, 2, C.green);
+      const iconColor = active ? C.green : C.secondary;
+      const labelColor = active ? C.green : C.secondary;
+
+      if (active) {
+        rect(frame, cx - 18, S.navY, 36, 3, S.radius.full, C.green, null);
       }
-      text(frame, label, x - 34, 829, 11, active ? C.positive : C.secondary, "Regular", 68, "CENTER");
+
+      ico(frame, iconName, cx - 11, S.navY + 14, 22, iconColor);
+
+      t(
+        frame,
+        label,
+        cx - 34,
+        S.navY + 40,
+        10,
+        labelColor,
+        active ? "Medium" : "Regular",
+        68,
+        "CENTER"
+      );
     });
   }
 
-  function metric(frame, label, value, x, y, width = 80, color = C.text) {
-    text(frame, label, x, y, 11, C.secondary, "Regular", width);
-    text(frame, value, x, y + 21, 15, color, "Semi Bold", width);
+  // ─── METRIC HELPERS ──────────────────────────────────────────
+  function metricPair(parent, label, value, x, y, width = 80, valueColor = C.text) {
+    t(parent, label, x, y, 11, C.secondary, "Regular", width);
+    t(parent, value, x, y + 18, 15, valueColor, "Semi Bold", width);
   }
 
-  function summary(frame, y, values) {
-    card(frame, 24, y, 345, 102);
-    values.forEach(([label, value, color], i) => {
-      const x = 38 + i * 84;
-      metric(frame, label, value, x, y + 24, 70, color || C.text);
-      if (i > 0) line(frame, x - 14, y + 24, 56);
+  function metricStrip(frame, x, y, items) {
+    const w = 353;
+    card(frame, x, y, w, 72, S.radius.md);
+
+    const colW = Math.floor(w / items.length);
+
+    items.forEach(([label, value, color], i) => {
+      const colX = x + 14 + i * colW;
+
+      t(frame, label, colX, y + 12, 10, C.secondary, "Regular", colW - 8);
+      t(frame, value, colX, y + 30, 15, color || C.text, "Semi Bold", colW - 8);
+
+      if (i > 0) {
+        line(frame, colX - 10, y + 16, 0, C.border, 0.4);
+      }
     });
   }
 
-  function miniMetricCard(frame, x, y, label, value, width = 78) {
-    card(frame, x, y, width, 72, 10);
-    text(frame, label, x + 10, y + 12, 10, C.secondary, "Regular", width - 20);
-    text(frame, value, x + 10, y + 42, 14, C.text, "Medium", width - 20);
-  }
+  function filterChips(frame, y, labels, activeIndex = 0) {
+    let x = S.screenPad;
 
-  function metricStrip(frame, y, items) {
-    card(frame, 24, y, 345, 76);
-    items.forEach(([label, value], i) => {
-      const x = 38 + i * 84;
-      text(frame, label, x, y + 14, 10, C.secondary, "Regular", 70);
-      text(frame, value, x, y + 43, 15, C.text, "Semi Bold", 70);
-      if (i > 0) line(frame, x - 14, y + 18, 42);
+    labels.forEach((label, i) => {
+      const active = i === activeIndex;
+      const chipW = label.length * 7 + 24;
+
+      rect(frame, x, y, chipW, 30, S.radius.full, active ? C.green : C.elevated, active ? null : C.border, 0.3);
+      t(frame, label, x, y + 8, 12, active ? C.text : C.secondary, active ? "Semi Bold" : "Regular", chipW, "CENTER");
+
+      x += chipW + 8;
     });
   }
 
-  function chip(frame, label, x, y, active = false) {
-    card(frame, x, y, 58, 30, 15, active ? C.green : C.elevated);
-    text(frame, label, x, y + 7, 12, active ? C.text : C.secondary, "Medium", 58, "CENTER");
+  function statusBar(frame, y, message) {
+    rect(frame, S.screenPad, y, 353, 36, S.radius.sm, C.elevated, C.border, 0.2);
+
+    const dot = figma.createEllipse();
+    frame.appendChild(dot);
+    dot.x = S.screenPad + 14;
+    dot.y = y + 13;
+    dot.resize(10, 10);
+    dot.fills = [paint(C.positive)];
+    dot.strokes = [];
+
+    t(frame, message, S.screenPad + 32, y + 11, 11, C.secondary, "Regular", 260);
+    ico(frame, "refresh", 348, y + 8, 18, C.secondary);
   }
 
-  function allocationRows(frame, x, y) {
-    const rows = [
-      ["equity", "Equity", "68%", "₹12,71,300"],
-      ["debt", "Debt", "15%", "₹2,76,000"],
-      ["crypto", "Crypto", "7%", "₹1,29,600"],
-      ["cash", "Cash", "10%", "₹1,65,600"]
+  // ─── DONUT CHART ─────────────────────────────────────────────
+  function donutChart(frame, x, y) {
+    card(frame, x, y, 353, 220, S.radius.lg);
+
+    t(frame, "Allocation", x + S.cardPad, y + 16, 15, C.text, "Semi Bold", 140);
+    t(frame, "View details", x + 263, y + 18, 11, C.green, "Medium", 76, "RIGHT");
+
+    const segments = [
+      { label: "Equity", pct: 68, color: C.positive },
+      { label: "Debt", pct: 15, color: C.blue },
+      { label: "Crypto", pct: 7, color: C.amber },
+      { label: "Cash", pct: 10, color: C.cashBlue },
     ];
-    rows.forEach(([type, label, pct, value], i) => {
-      const yy = y + i * 42;
-      iconGlyph(frame, x + 6, yy + 6, type, 22);
-      text(frame, label, x + 50, yy + 4, 14, C.text, "Medium", 80);
-      text(frame, pct, x + 230, yy + 4, 14, C.text, "Medium", 45, "RIGHT");
-      card(frame, x + 50, yy + 30, 120, 5, 3, "#34313B").strokes = [];
-      const width = Math.max(12, (120 * parseInt(pct, 10)) / 75);
-      const fill = type === "equity" ? C.green : type === "debt" ? C.blue : type === "crypto" ? C.warning : C.cashBlue;
-      card(frame, x + 50, yy + 30, width, 5, 3, fill).strokes = [];
-      text(frame, value, x + 166, yy + 30, 11, C.secondary, "Regular", 90, "RIGHT");
+
+    const cx = 100;
+    const cy = 110;
+    const outerR = 52;
+    const innerR = 34;
+    const gap = 2;
+
+    const toRad = (deg) => ((deg - 90) * Math.PI) / 180;
+    let start = 0;
+
+    const paths = segments
+      .map((seg) => {
+        const sweep = (seg.pct / 100) * 360;
+        const s1 = start + gap;
+        const e1 = start + sweep - gap;
+        const large = sweep > 180 ? 1 : 0;
+
+        const x1 = cx + outerR * Math.cos(toRad(s1));
+        const y1 = cy + outerR * Math.sin(toRad(s1));
+
+        const x2 = cx + outerR * Math.cos(toRad(e1));
+        const y2 = cy + outerR * Math.sin(toRad(e1));
+
+        const x3 = cx + innerR * Math.cos(toRad(e1));
+        const y3 = cy + innerR * Math.sin(toRad(e1));
+
+        const x4 = cx + innerR * Math.cos(toRad(s1));
+        const y4 = cy + innerR * Math.sin(toRad(s1));
+
+        start += sweep;
+
+        return `<path d="M${x1} ${y1} A${outerR} ${outerR} 0 ${large} 1 ${x2} ${y2} L${x3} ${y3} A${innerR} ${innerR} 0 ${large} 0 ${x4} ${y4}Z" fill="${seg.color}"/>`;
+      })
+      .join("");
+
+    const legendRows = segments
+      .map((seg, i) => {
+        const ly = 68 + i * 26;
+
+        return `
+          <circle cx="212" cy="${ly}" r="5" fill="${seg.color}"/>
+          <text x="226" y="${ly + 4}" font-family="Inter" font-size="12" font-weight="500" fill="${C.text}">${seg.label}</text>
+          <text x="339" y="${ly + 4}" font-family="Inter" font-size="12" fill="${C.secondary}" text-anchor="end">${seg.pct}%</text>
+        `;
+      })
+      .join("");
+
+    const donutSvg = `
+      <svg width="353" height="220" viewBox="0 0 353 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+        ${paths}
+        <circle cx="${cx}" cy="${cy}" r="${innerR - 2}" fill="${C.surface}"/>
+        <text x="${cx}" y="${cy - 6}" font-family="Inter" font-size="17" font-weight="700" fill="${C.text}" text-anchor="middle">68%</text>
+        <text x="${cx}" y="${cy + 12}" font-family="Inter" font-size="10" fill="${C.secondary}" text-anchor="middle">Equity</text>
+        ${legendRows}
+        <text x="14" y="208" font-family="Inter" font-size="10" fill="${C.muted}">Equity-heavy allocation · Consider rebalancing at 70%+</text>
+      </svg>
+    `;
+
+    svgNode(frame, donutSvg, x, y, 353, 220);
+  }
+
+  // ─── HOLDINGS TABLE ──────────────────────────────────────────
+  function holdingsTable(frame, x, y) {
+    const W = 353;
+    const HEADER_H = 32;
+    const ROW_H = 58;
+
+    const rows = [
+      {
+        type: "equity",
+        name: "HDFC Bank",
+        meta: "Equity · Financials",
+        current: "₹1.83L",
+        invested: "₹1.64L",
+        pnl: "+₹18.6K",
+        pnlPct: "+11.4%",
+        alloc: "14.6%",
+        conviction: 4,
+      },
+      {
+        type: "equity",
+        name: "Nifty 50 ETF",
+        meta: "Equity · Index",
+        current: "₹50.7K",
+        invested: "₹44.2K",
+        pnl: "+₹6.5K",
+        pnlPct: "+14.7%",
+        alloc: "4.1%",
+        conviction: 3,
+      },
+      {
+        type: "debt",
+        name: "Gold Bond",
+        meta: "Debt · Govt Bond",
+        current: "₹57.1K",
+        invested: "₹53.0K",
+        pnl: "+₹4.1K",
+        pnlPct: "+7.7%",
+        alloc: "4.6%",
+        conviction: 5,
+      },
+      {
+        type: "crypto",
+        name: "Bitcoin",
+        meta: "Crypto · Manual",
+        current: "₹13.9L",
+        invested: "₹11.1L",
+        pnl: "+₹2.85L",
+        pnlPct: "+25.7%",
+        alloc: "11.1%",
+        conviction: 4,
+      },
+      {
+        type: "debt",
+        name: "Liquid Fund",
+        meta: "Debt · Overnight",
+        current: "₹2.50L",
+        invested: "₹2.50L",
+        pnl: "+₹250",
+        pnlPct: "+0.1%",
+        alloc: "2.0%",
+        conviction: null,
+      },
+      {
+        type: "cash",
+        name: "Cash Reserve",
+        meta: "Available cash",
+        current: "₹1.65L",
+        invested: "—",
+        pnl: "+₹70K",
+        pnlPct: "",
+        alloc: "10.0%",
+        conviction: null,
+      },
+    ];
+
+    const tableH = HEADER_H + rows.length * ROW_H;
+
+    card(frame, x, y, W, tableH, S.radius.lg);
+
+    t(frame, "Asset", x + 14, y + 10, 10, C.secondary, "Medium", 110);
+    t(frame, "Current", x + 214, y + 10, 10, C.secondary, "Medium", 68, "RIGHT");
+    t(frame, "P&L", x + 310, y + 10, 10, C.secondary, "Medium", 42, "RIGHT");
+
+    line(frame, x + 14, y + HEADER_H, W - 28, C.border, 0.5);
+
+    rows.forEach((row, i) => {
+      const rowY = y + HEADER_H + i * ROW_H;
+      const pnlColor = row.pnl.startsWith("-") ? C.negative : C.positive;
+      const ac = assetClass[row.type] || assetClass.equity;
+
+      if (i > 0) {
+        line(frame, x + 14, rowY, W - 28, C.border, 0.2);
+      }
+
+      rect(frame, x + 1, rowY + 8, 3, ROW_H - 16, S.radius.full, ac.color, null);
+
+      assetDot(frame, x + 14, rowY + 20, row.type, 8);
+      ico(frame, ac.icon, x + 26, rowY + 14, 16, ac.color);
+
+      t(frame, row.name, x + 50, rowY + 8, 13, C.text, "Semi Bold", 130);
+      t(frame, row.meta, x + 50, rowY + 28, 10, C.secondary, "Regular", 130);
+
+      t(frame, row.current, x + 198, rowY + 8, 13, C.text, "Semi Bold", 84, "RIGHT");
+      t(frame, row.invested, x + 198, rowY + 28, 10, C.secondary, "Regular", 84, "RIGHT");
+
+      t(frame, row.pnl, x + 282, rowY + 8, 13, pnlColor, "Semi Bold", 68, "RIGHT");
+      t(frame, row.pnlPct, x + 282, rowY + 28, 10, C.secondary, "Regular", 68, "RIGHT");
+
+      if (row.conviction) {
+        convictionStars(frame, x + W - 80, rowY + 10, row.conviction);
+      }
     });
   }
 
-  function holdingRow(frame, y, type, name, meta, current, invested, pnl, alloc, note = "") {
-    card(frame, 24, y, 345, 68, 12);
-    iconGlyph(frame, 42, y + 22, type, 22);
-    text(frame, name, 78, y + 12, 14, C.text, "Medium", 150);
-    text(frame, meta, 78, y + 33, 10, C.secondary, "Regular", 178);
-    if (note) text(frame, note, 78, y + 49, 9, C.warning, "Regular", 120);
-    text(frame, current, 265, y + 14, 14, C.text, "Medium", 82, "RIGHT");
-    text(frame, `Invested ${invested}`, 36, y + 50, 9, C.secondary, "Regular", 106);
-    text(frame, `P&L ${pnl}`, 170, y + 50, 9, C.positive, "Regular", 76);
-    text(frame, alloc, 318, y + 50, 9, C.secondary, "Regular", 36, "RIGHT");
+  // ─── PORTFOLIO TREND CHART ───────────────────────────────────
+  function trendChart(frame, x, y, w = 353, h = 140) {
+    card(frame, x, y, w, h, S.radius.md);
+
+    t(frame, "Portfolio trend", x + 14, y + 14, 14, C.text, "Semi Bold", 160);
+    t(frame, "Last 6 months", x + 14, y + 34, 11, C.secondary, "Regular", 140);
+
+    const chartSvg = `
+      <svg width="${w}" height="${h}" viewBox="0 0 ${w} ${h}" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <linearGradient id="areaGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stop-color="${C.positive}" stop-opacity="0.22"/>
+            <stop offset="1" stop-color="${C.positive}" stop-opacity="0"/>
+          </linearGradient>
+        </defs>
+        <line x1="48" y1="56" x2="${w - 20}" y2="56" stroke="${C.border}" stroke-width="0.6" stroke-dasharray="3 5"/>
+        <line x1="48" y1="80" x2="${w - 20}" y2="80" stroke="${C.border}" stroke-width="0.6" stroke-dasharray="3 5"/>
+        <line x1="48" y1="104" x2="${w - 20}" y2="104" stroke="${C.border}" stroke-width="0.6"/>
+        <text x="38" y="60"  font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="end">20L</text>
+        <text x="38" y="84"  font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="end">17L</text>
+        <text x="38" y="108" font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="end">14L</text>
+        <path d="M52 106 L97 96 L142 89 L187 76 L232 65 L277 57 L318 46 L318 104 L52 104Z" fill="url(#areaGrad)"/>
+        <path d="M52 106 L97 96 L142 89 L187 76 L232 65 L277 57 L318 46" stroke="${C.positive}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="318" cy="46" r="5" fill="${C.bg}" stroke="${C.positive}" stroke-width="2.5"/>
+        <text x="52"  y="126" font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="middle">Dec</text>
+        <text x="97"  y="126" font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="middle">Jan</text>
+        <text x="142" y="126" font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="middle">Feb</text>
+        <text x="187" y="126" font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="middle">Mar</text>
+        <text x="232" y="126" font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="middle">Apr</text>
+        <text x="277" y="126" font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="middle">May</text>
+        <text x="318" y="126" font-family="Inter" font-size="9" fill="${C.positive}" text-anchor="middle" font-weight="600">Jun</text>
+      </svg>
+    `;
+
+    svgNode(frame, chartSvg, x, y, w, h);
   }
 
-  text(page, "CogVest V1 UI Concepts - Issue #69", 24, 24, 28, C.text, "Bold", 620);
-  text(page, "Editable Figma frames based on DESIGN.md Private Ledger direction. These replace generated PNGs as the stable design source.", 24, 62, 14, C.secondary, "Regular", 980);
+  // ─── SECTION TITLE ───────────────────────────────────────────
+  function sectionTitle(frame, label, x, y, actionLabel = null, actionColor = C.green) {
+    t(frame, label, x, y, 14, C.text, "Semi Bold", 200);
+    if (actionLabel) {
+      t(frame, actionLabel, 345, y + 1, 12, actionColor, "Medium", 80, "RIGHT");
+    }
+  }
 
-  const dashboard = screen("Dashboard", 24);
-  top(dashboard, "Dashboard", "Local portfolio • 3 May 2026", ["eye", "refresh"]);
-  summary(dashboard, 132, [["Current", "₹18.42L"], ["Invested", "₹15.32L"], ["P&L", "+₹3.10L", C.positive], ["P&L %", "+20.2%", C.positive]]);
-  card(dashboard, 24, 246, 345, 42, 12);
-  text(dashboard, "●  Quotes updated 2m ago  •  Manual fallback ready", 38, 259, 12, C.secondary, "Regular", 250);
-  svg(dashboard, "refresh", 324, 255, 18);
-  card(dashboard, 24, 304, 345, 212);
-  text(dashboard, "Allocation", 38, 320, 16, C.text, "Semi Bold", 150);
-  text(dashboard, "View details", 274, 322, 12, C.positive, "Medium", 80, "RIGHT");
-  allocationRows(dashboard, 38, 356);
-  card(dashboard, 24, 532, 345, 96);
-  text(dashboard, "This month", 38, 548, 16, C.text, "Semi Bold", 130);
-  text(dashboard, "May 2026", 294, 550, 12, C.positive, "Medium", 60, "RIGHT");
-  metric(dashboard, "Invested", "₹1.20L", 42, 586, 92);
-  metric(dashboard, "Savings rate", "42%", 154, 586, 92);
-  metric(dashboard, "Cash change", "+₹70K", 266, 586, 84);
-  card(dashboard, 24, 646, 345, 64);
-  iconGlyph(dashboard, 44, 669, "neutral", 20);
-  text(dashboard, "Conviction data is still building", 82, 660, 14, C.text, "Medium", 230);
-  text(dashboard, "Optional conviction improves context over time.", 82, 682, 11, C.secondary, "Regular", 240);
+  // ──────────────────────────────────────────────────────────────
+  // SCREEN 1 — DASHBOARD
+  // ──────────────────────────────────────────────────────────────
+  const dashboard = screen("1. Dashboard", 24);
+
+  header(dashboard, "Dashboard", "Local portfolio  ·  3 May 2026", ["eye", "refresh", "plus"]);
+
+  const heroY = 124;
+
+  card(dashboard, S.screenPad, heroY, 353, 128, S.radius.lg);
+
+  t(dashboard, "Portfolio value", S.screenPad + 16, heroY + 14, 11, C.secondary, "Medium", 140);
+  t(dashboard, "₹18.42L", S.screenPad + 16, heroY + 34, 34, C.text, "Bold", 180);
+  t(dashboard, "+₹3.10L  (+20.2%)", S.screenPad + 16, heroY + 80, 13, C.positive, "Semi Bold", 170);
+
+  t(dashboard, "Invested", S.screenPad + 226, heroY + 22, 10, C.secondary, "Regular", 90);
+  t(dashboard, "₹15.32L", S.screenPad + 226, heroY + 38, 15, C.text, "Semi Bold", 100);
+
+  t(dashboard, "Today's change", S.screenPad + 226, heroY + 68, 10, C.secondary, "Regular", 110);
+  t(dashboard, "+0.57%", S.screenPad + 226, heroY + 84, 13, C.positive, "Semi Bold", 80);
+
+  statusBar(dashboard, 264, "Quotes updated 2m ago  ·  Manual fallback ready");
+
+  donutChart(dashboard, S.screenPad, 312);
+
+  const insightY = 546;
+
+  rect(dashboard, S.screenPad, insightY, 353, 76, S.radius.md, "#1A1530", C.purple, 0.4);
+  ico(dashboard, "sparkle", S.screenPad + 14, insightY + 14, 18, C.purple);
+  t(dashboard, "INSIGHT", S.screenPad + 40, insightY + 14, 9, C.purple, "Semi Bold", 80);
+  t(dashboard, "Conviction data still building", S.screenPad + 14, insightY + 36, 13, C.text, "Semi Bold", 230);
+  t(dashboard, "Rate your next 3 trades to unlock personalised insights.", S.screenPad + 14, insightY + 54, 11, C.secondary, "Regular", 280);
+  t(dashboard, "×", 353, insightY + 10, 16, C.muted, "Regular", 22, "CENTER");
+
+  const monthY = 638;
+
+  card(dashboard, S.screenPad, monthY, 353, 90, S.radius.md);
+  t(dashboard, "This month", S.screenPad + 14, monthY + 14, 13, C.text, "Semi Bold", 120);
+  t(dashboard, "May 2026", 315, monthY + 16, 11, C.green, "Medium", 60, "RIGHT");
+
+  metricPair(dashboard, "Invested", "₹1.20L", S.screenPad + 14, monthY + 46, 88);
+  metricPair(dashboard, "Savings rate", "42%", S.screenPad + 112, monthY + 46, 88);
+  metricPair(dashboard, "Cash change", "+₹70K", S.screenPad + 214, monthY + 46, 88, C.positive);
+
   nav(dashboard, "Dashboard");
 
-  const holdings = screen("Holdings", 448);
-  top(holdings, "Holdings", "24 positions • local data", ["search", "eye"]);
-  summary(holdings, 128, [["Current", "₹12.48L"], ["Invested", "₹11.05L"], ["P&L", "+₹1.42L", C.positive], ["Drift", "3.2%", C.warning]]);
-  text(holdings, "●  Quotes updated 2m ago  •  1 manual price", 38, 218, 12, C.secondary, "Regular", 230);
-  ["All", "Equity", "Debt", "Crypto", "Cash"].forEach((label, i) => chip(holdings, label, 24 + i * 68, 260, i === 0));
-  text(holdings, "Sorted by asset class", 24, 310, 12, C.secondary, "Regular", 160);
-  holdingRow(holdings, 334, "equity", "HDFC Bank", "Equity · Financial Services", "₹1.83L", "₹1.64L", "+₹18.6K", "14.6%");
-  holdingRow(holdings, 414, "equity", "Nifty 50 ETF", "Equity · Index Fund", "₹50.7K", "₹44.2K", "+₹6.4K", "4.1%");
-  holdingRow(holdings, 494, "debt", "Sovereign Gold Bond", "Debt · Government Bond", "₹57.1K", "₹53.0K", "+₹4.2K", "4.6%");
-  holdingRow(holdings, 574, "crypto", "Bitcoin", "Crypto · Manual price", "₹13.90L", "₹11.05L", "+₹2.85L", "11.1%");
-  holdingRow(holdings, 654, "debt", "Liquid Fund", "Debt · Liquid / Overnight", "₹2.50L", "₹2.50L", "+₹250", "2.0%");
+  // ──────────────────────────────────────────────────────────────
+  // SCREEN 2 — HOLDINGS
+  // ──────────────────────────────────────────────────────────────
+  const holdings = screen("2. Holdings", 448);
+
+  header(holdings, "Holdings", "24 positions  ·  Updated 2m ago", ["search", "plus"]);
+
+  metricStrip(holdings, S.screenPad, 124, [
+    ["Current", "₹12.48L"],
+    ["Invested", "₹11.05L"],
+    ["P&L", "+₹1.42L", C.positive],
+    ["Drift", "3.2%", C.warning],
+  ]);
+
+  statusBar(holdings, 208, "Quotes updated 2m ago  ·  1 manual price");
+
+  filterChips(holdings, 256, ["All", "Equity", "Debt", "Crypto", "Cash"], 0);
+
+  holdingsTable(holdings, S.screenPad, 302);
+
   nav(holdings, "Holdings");
 
-  const addHolding = screen("Add Holding", 872);
-  topBack(addHolding, "Add Holding", "Opening position • local only");
-  text(addHolding, "?", 342, 74, 22, C.secondary, "Semi Bold", 24, "CENTER");
-  ["Asset", "Classification", "Position", "Review"].forEach((label, i) => {
-    const x = 58 + i * 86;
-    iconGlyph(addHolding, x + 5, 147, "neutral", 22);
-    text(addHolding, label, x - 22, 180, 11, i === 2 ? C.positive : C.secondary, "Medium", 76, "CENTER");
-    if (i < 3) line(addHolding, x + 42, 158, 42);
-  });
-  card(addHolding, 24, 222, 345, 58, 12);
-  iconGlyph(addHolding, 44, 242, "neutral", 20);
-  text(addHolding, "Asset", 82, 234, 15, C.text, "Medium", 120);
-  text(addHolding, "HDFC Bank · HDFCBANK · INR", 82, 256, 11, C.secondary, "Regular", 190);
-  text(addHolding, "Edit ›", 310, 242, 13, C.secondary, "Medium", 50);
-  card(addHolding, 24, 292, 345, 58, 12);
-  iconGlyph(addHolding, 44, 312, "equity", 20);
-  text(addHolding, "Classification", 82, 304, 15, C.text, "Medium", 130);
-  text(addHolding, "Equity · Large Cap · Financial Services", 82, 326, 11, C.secondary, "Regular", 220);
-  text(addHolding, "Edit ›", 310, 312, 13, C.secondary, "Medium", 50);
-  card(addHolding, 24, 364, 345, 196, 12);
-  iconGlyph(addHolding, 44, 386, "neutral", 20);
-  text(addHolding, "Position details", 82, 382, 16, C.text, "Semi Bold", 160);
-  metric(addHolding, "Quantity *", "25", 42, 426, 74);
-  metric(addHolding, "Average cost *", "₹1,450.00", 136, 426, 104);
-  metric(addHolding, "Current price *", "₹1,678.25", 252, 426, 110);
-  chip(addHolding, "Live", 42, 486, true);
-  chip(addHolding, "Manual", 112, 486, false);
-  text(addHolding, "Date acquired: 15 Apr 2024", 42, 532, 12, C.secondary, "Regular", 210);
-  card(addHolding, 24, 574, 345, 90, 12);
-  text(addHolding, "Derived preview", 82, 592, 16, C.text, "Semi Bold", 150);
-  ["₹36K", "₹42K", "+₹5.7K", "+2.34%"].forEach((value, i) => metric(addHolding, ["Invested", "Current", "P&L", "Allocation"][i], value, 42 + i * 80, 624, 76, i > 1 ? C.positive : C.text));
-  card(addHolding, 24, 678, 345, 48, 12);
-  text(addHolding, "Conviction optional", 82, 689, 14, C.text, "Medium", 170);
-  text(addHolding, "Add later", 82, 710, 11, C.secondary, "Regular", 100);
-  card(addHolding, 24, 738, 160, 34, 8, C.bg);
-  text(addHolding, "Save and add another", 34, 747, 11, C.text, "Medium", 140, "CENTER");
-  card(addHolding, 202, 738, 166, 34, 8, C.green);
-  text(addHolding, "Save holding", 218, 747, 11, C.text, "Medium", 130, "CENTER");
-  nav(addHolding, "Add");
+  // ──────────────────────────────────────────────────────────────
+  // SCREEN 3 — ADD HOLDING
+  // ──────────────────────────────────────────────────────────────
+  const addTrade = screen("3. Add Holding", 872);
 
-  const cash = screen("Cash", 1296);
-  top(cash, "Cash", "Manual ledger • local only", ["plus", "eye"]);
-  card(cash, 24, 130, 345, 88);
-  iconGlyph(cash, 48, 162, "cash", 24);
-  text(cash, "Cash balance", 92, 146, 13, C.secondary, "Regular", 120);
-  text(cash, "₹1,65,600", 92, 174, 28, C.text, "Semi Bold", 180);
-  text(cash, "₹••,•••", 282, 174, 16, C.secondary, "Medium", 70);
-  metricStrip(cash, 234, [["Added", "₹70K"], ["Invested", "₹45K"], ["Available", "₹1.20L"], ["Savings", "32.8%"]]);
-  card(cash, 24, 328, 345, 178);
-  text(cash, "Add cash entry", 38, 344, 16, C.text, "Semi Bold", 160);
-  chip(cash, "Deposit", 38, 382, true);
-  chip(cash, "Withdrawal", 112, 382, false);
-  card(cash, 200, 382, 132, 30, 15, C.elevated);
-  text(cash, "Investment transfer", 200, 390, 10, C.secondary, "Medium", 132, "CENTER");
-  metric(cash, "Amount (INR) *", "₹0", 38, 434, 110);
-  metric(cash, "Date *", "03 May 2026", 192, 434, 120);
-  text(cash, "Note (optional)  e.g., Salary, SIP transfer", 38, 484, 11, C.muted, "Regular", 260);
-  card(cash, 250, 516, 92, 34, 10, C.green);
-  text(cash, "Save entry", 262, 526, 12, C.bg, "Semi Bold", 70, "CENTER");
-  card(cash, 24, 570, 345, 150);
-  text(cash, "Recent cash ledger", 38, 586, 16, C.text, "Semi Bold", 180);
-  text(cash, "View all", 296, 588, 12, C.positive, "Medium", 60, "RIGHT");
-  [["Salary added", "₹70,000", C.positive], ["SIP transfer – Index Fund", "-₹15,000", C.text], ["Emergency fund top-up", "₹10,000", C.positive], ["SIP transfer – Large Cap", "-₹15,000", C.text]].forEach(([label, value, color], i) => {
-    const y = 622 + i * 24;
-    text(cash, label, 42, y, 11, C.secondary, "Regular", 160);
-    text(cash, value, 286, y, 12, color, "Medium", 70, "RIGHT");
+  headerBack(addTrade, "Add Holding", "Opening position  ·  local only");
+  ico(addTrade, "info", 348, 66, 18, C.secondary);
+
+  const stepperY = 130;
+  const steps = ["Asset", "Class", "Position", "Review"];
+  const stepX = [54, 150, 246, 342];
+
+  steps.forEach((label, i) => {
+    const cx = stepX[i];
+    const done = i < 2;
+    const active = i === 2;
+    const bg = done || active ? C.green : C.elevated;
+
+    const ellipse = figma.createEllipse();
+    addTrade.appendChild(ellipse);
+    ellipse.x = cx - 12;
+    ellipse.y = stepperY;
+    ellipse.resize(24, 24);
+    ellipse.fills = [paint(bg)];
+    ellipse.strokes = [];
+
+    if (done) {
+      ico(addTrade, "check", cx - 7, stepperY + 4, 14, C.text);
+    } else {
+      t(addTrade, String(i + 1), cx - 12, stepperY + 4, 11, C.text, "Semi Bold", 24, "CENTER");
+    }
+
+    t(addTrade, label, cx - 24, stepperY + 30, 10, active ? C.green : C.secondary, active ? "Semi Bold" : "Regular", 48, "CENTER");
+
+    if (i < steps.length - 1) {
+      const lineColor = done ? C.green : C.border;
+      rect(addTrade, cx + 14, stepperY + 11, stepX[i + 1] - cx - 26, 2, S.radius.full, lineColor, null);
+    }
   });
-  text(cash, "Cash is included in total allocation", 38, 740, 11, C.secondary, "Regular", 220);
+
+  const assetSummaryY = 184;
+
+  card(addTrade, S.screenPad, assetSummaryY, 353, 52, S.radius.md);
+  ico(addTrade, "trend", S.screenPad + 12, assetSummaryY + 16, 18, C.positive);
+  t(addTrade, "HDFC Bank", S.screenPad + 38, assetSummaryY + 10, 14, C.text, "Semi Bold", 160);
+  t(addTrade, "HDFCBANK.NS  ·  NSE  ·  INR", S.screenPad + 38, assetSummaryY + 30, 11, C.secondary, "Regular", 190);
+  t(addTrade, "Edit ›", 330, assetSummaryY + 18, 12, C.secondary, "Medium", 48, "RIGHT");
+
+  const classY = 248;
+
+  card(addTrade, S.screenPad, classY, 353, 52, S.radius.md);
+  ico(addTrade, "pie", S.screenPad + 12, classY + 16, 18, C.positive);
+  t(addTrade, "Classification", S.screenPad + 38, classY + 10, 14, C.text, "Semi Bold", 140);
+  t(addTrade, "Equity · Large Cap · Financial Services", S.screenPad + 38, classY + 30, 11, C.secondary, "Regular", 220);
+  t(addTrade, "Edit ›", 330, classY + 18, 12, C.secondary, "Medium", 48, "RIGHT");
+
+  const posY = 312;
+
+  card(addTrade, S.screenPad, posY, 353, 188, S.radius.md);
+  t(addTrade, "Position details", S.screenPad + 14, posY + 14, 15, C.text, "Semi Bold", 180);
+
+  [
+    [S.screenPad + 14, "Quantity *", "25"],
+    [S.screenPad + 118, "Average cost *", "₹1,450.00"],
+    [S.screenPad + 230, "Current price *", "₹1,678.25"],
+  ].forEach(([ix, label, val]) => {
+    t(addTrade, label, ix, posY + 46, 10, C.secondary, "Regular", 90);
+    rect(addTrade, ix, posY + 64, 88, 34, S.radius.sm, C.field, C.border, 0.3);
+    t(addTrade, val, ix + 8, posY + 75, 13, C.text, "Semi Bold", 72);
+  });
+
+  rect(addTrade, S.screenPad + 14, posY + 108, 50, 24, S.radius.full, C.green, null);
+  t(addTrade, "Live", S.screenPad + 14, posY + 115, 11, C.text, "Semi Bold", 50, "CENTER");
+
+  rect(addTrade, S.screenPad + 72, posY + 108, 60, 24, S.radius.full, C.elevated, C.border, 0.3);
+  t(addTrade, "Manual", S.screenPad + 72, posY + 115, 11, C.secondary, "Regular", 60, "CENTER");
+
+  t(addTrade, "Date acquired: 15 Apr 2024", S.screenPad + 14, posY + 146, 11, C.secondary, "Regular", 200);
+
+  const previewY = 512;
+
+  card(addTrade, S.screenPad, previewY, 353, 82, S.radius.md);
+  t(addTrade, "Derived preview", S.screenPad + 14, previewY + 12, 13, C.secondary, "Medium", 160);
+
+  [
+    ["Invested", "₹36K"],
+    ["Current", "₹41.9K"],
+    ["P&L", "+₹5.9K"],
+    ["Alloc", "2.34%"],
+  ].forEach(([label, val], i) => {
+    const vx = S.screenPad + 14 + i * 82;
+    const vColor = label === "P&L" ? C.positive : C.text;
+
+    t(addTrade, label, vx, previewY + 34, 10, C.secondary, "Regular", 76);
+    t(addTrade, val, vx, previewY + 52, 14, vColor, "Semi Bold", 76);
+  });
+
+  const convY = 606;
+
+  rect(addTrade, S.screenPad, convY, 353, 56, S.radius.md, C.elevated, C.border, 0.2);
+  t(addTrade, "Conviction  ", S.screenPad + 14, convY + 10, 12, C.text, "Medium", 100);
+  t(addTrade, "optional", S.screenPad + 100, convY + 11, 11, C.secondary, "Regular", 60);
+
+  [1, 2, 3, 4, 5].forEach((n, i) => {
+    const bx = S.screenPad + 14 + i * 46;
+    const active = n === 4;
+
+    rect(addTrade, bx, convY + 30, 38, 22, S.radius.sm, active ? C.greenDim : C.elevated, active ? C.green : C.border, 0.4);
+    t(addTrade, String(n), bx, convY + 36, 12, active ? C.green : C.secondary, "Semi Bold", 38, "CENTER");
+  });
+
+  rect(addTrade, S.screenPad, 676, 353, 48, S.radius.md, C.green, null);
+  t(addTrade, "Save holding", S.screenPad, 692, 14, C.text, "Bold", 353, "CENTER");
+  t(addTrade, "Save and add another", S.screenPad, 734, 11, C.secondary, "Medium", 353, "CENTER");
+
+  nav(addTrade, "Holdings");
+
+  // ──────────────────────────────────────────────────────────────
+  // SCREEN 4 — CASH
+  // ──────────────────────────────────────────────────────────────
+  const cash = screen("4. Cash", 1296);
+
+  header(cash, "Cash", "Manual ledger  ·  local only", ["plus", "eye"]);
+
+  card(cash, S.screenPad, 124, 353, 92, S.radius.lg);
+  ico(cash, "wallet", S.screenPad + 16, 156, 24, C.cashBlue);
+  t(cash, "Cash balance", S.screenPad + 50, 136, 11, C.secondary, "Regular", 130);
+  t(cash, "₹1,65,600", S.screenPad + 50, 158, 28, C.text, "Bold", 180);
+  t(cash, "₹•• •••", 294, 162, 14, C.secondary, "Medium", 60, "RIGHT");
+  t(cash, "+₹70K this month", S.screenPad + 50, 194, 12, C.positive, "Medium", 160);
+
+  metricStrip(cash, S.screenPad, 228, [
+    ["Added", "₹70K", C.positive],
+    ["Invested", "₹45K"],
+    ["Available", "₹1.20L"],
+    ["Savings", "32.8%", C.green],
+  ]);
+
+  const addCashY = 312;
+
+  card(cash, S.screenPad, addCashY, 353, 218, S.radius.lg);
+  t(cash, "Add cash entry", S.screenPad + 14, addCashY + 14, 15, C.text, "Semi Bold", 160);
+
+  [
+    ["Deposit", true],
+    ["Withdraw", false],
+    ["Transfer", false],
+  ].forEach(([label, active], i) => {
+    const cx = S.screenPad + 14 + i * 98;
+    const cw = 86;
+
+    rect(cash, cx, addCashY + 44, cw, 28, S.radius.full, active ? C.green : C.elevated, active ? null : C.border, 0.3);
+    t(cash, label, cx, addCashY + 52, 12, active ? C.text : C.secondary, active ? "Semi Bold" : "Regular", cw, "CENTER");
+  });
+
+  t(cash, "Amount (INR) *", S.screenPad + 14, addCashY + 86, 10, C.secondary, "Regular", 120);
+  rect(cash, S.screenPad + 14, addCashY + 104, 148, 36, S.radius.sm, C.field, C.border, 0.3);
+  t(cash, "₹0", S.screenPad + 28, addCashY + 116, 13, C.muted, "Regular", 100);
+
+  t(cash, "Date *", S.screenPad + 178, addCashY + 86, 10, C.secondary, "Regular", 80);
+  rect(cash, S.screenPad + 178, addCashY + 104, 148, 36, S.radius.sm, C.field, C.border, 0.3);
+  t(cash, "03 May 2026", S.screenPad + 192, addCashY + 116, 13, C.text, "Regular", 120);
+  ico(cash, "calendar", S.screenPad + 298, addCashY + 112, 16, C.secondary);
+
+  t(cash, "Note", S.screenPad + 14, addCashY + 152, 10, C.secondary, "Regular", 60);
+  rect(cash, S.screenPad + 50, addCashY + 148, 276, 28, S.radius.sm, C.field, C.border, 0.25);
+  t(cash, "Salary, SIP transfer…", S.screenPad + 62, addCashY + 156, 11, C.muted, "Regular", 230);
+
+  rect(cash, S.screenPad + 14, addCashY + 188, 325, 22, S.radius.full, C.green, null);
+  t(cash, "Save entry", S.screenPad + 14, addCashY + 193, 11, C.text, "Bold", 325, "CENTER");
+
+  sectionTitle(cash, "Recent ledger", S.screenPad, 546, "View all");
+
+  const ledgerRows = [
+    ["Salary added", "+₹70,000", C.positive],
+    ["SIP — Index Fund", "-₹15,000", C.secondary],
+    ["Emergency fund top-up", "+₹10,000", C.positive],
+    ["SIP — Large Cap", "-₹15,000", C.secondary],
+  ];
+
+  card(cash, S.screenPad, 568, 353, ledgerRows.length * 40 + 8, S.radius.md);
+
+  ledgerRows.forEach(([label, value, color], i) => {
+    const ly = 576 + i * 40;
+
+    if (i > 0) {
+      line(cash, S.screenPad + 14, ly, 325, C.border, 0.2);
+    }
+
+    t(cash, label, S.screenPad + 14, ly + 14, 12, C.secondary, "Regular", 180);
+    t(cash, value, 350, ly + 12, 13, color, "Semi Bold", 60, "RIGHT");
+  });
+
   nav(cash, "Cash");
 
-  const monthly = screen("Monthly Progression", 1720);
-  topBack(monthly, "Monthly Progression", "May 2026 snapshot", "eye");
-  text(monthly, "‹  Apr 2026", 24, 128, 13, C.secondary, "Regular", 100);
-  text(monthly, "May 2026", 164, 128, 15, C.positive, "Medium", 80, "CENTER");
-  text(monthly, "Jun 2026  ›", 286, 128, 13, C.secondary, "Regular", 80, "RIGHT");
-  metricStrip(monthly, 170, [["Portfolio", "₹19.87L"], ["Invested", "₹1.40L"], ["Cash", "₹3.25L"], ["Savings", "34%"]]);
-  card(monthly, 24, 264, 345, 196);
-  text(monthly, "What changed this month?", 38, 280, 16, C.text, "Semi Bold", 210);
-  [["equity", "Equity", "Market value and contributions", "+₹58,000"], ["debt", "Debt", "Stable allocation", "+₹12,000"], ["crypto", "Crypto", "Manual price movement", "-₹8,500"], ["cash", "Cash", "Net cash change", "+₹70,000"]].forEach(([type, label, caption, value], i) => {
-    const y = 326 + i * 34;
-    iconGlyph(monthly, 41, y, type, 20);
-    text(monthly, label, 78, y, 13, C.text, "Medium", 80);
-    text(monthly, caption, 78, y + 16, 10, C.secondary, "Regular", 170);
-    text(monthly, value, 288, y + 4, 13, value.startsWith("-") ? C.negative : C.text, "Medium", 70, "RIGHT");
-  });
-  card(monthly, 24, 484, 345, 100);
-  text(monthly, "Progression (last 6 months)", 38, 500, 16, C.text, "Semi Bold", 230);
-  line(monthly, 60, 568, 270, C.secondary, 0.75);
-  card(monthly, 24, 596, 345, 138);
-  text(monthly, "Asset class snapshot", 38, 612, 16, C.text, "Semi Bold", 200);
-  [["equity", "Equity", "₹12,45,000", "62.6%"], ["debt", "Debt", "₹3,22,000", "16.2%"], ["crypto", "Crypto", "₹1,20,000", "6.0%"], ["cash", "Cash", "₹3,25,470", "16.3%"]].forEach(([type, label, value, pct], i) => {
-    const y = 644 + i * 25;
-    iconGlyph(monthly, 40, y - 1, type, 18);
-    text(monthly, label, 70, y, 12, C.text, "Medium", 70);
-    text(monthly, value, 226, y, 12, C.text, "Regular", 80, "RIGHT");
-    text(monthly, pct, 322, y, 12, C.secondary, "Regular", 40, "RIGHT");
-  });
-  nav(monthly, "Dashboard");
+  // ──────────────────────────────────────────────────────────────
+  // SCREEN 5 — MONTHLY PROGRESS
+  // ──────────────────────────────────────────────────────────────
+  const progress = screen("5. Progress", 1720);
 
-  const settings = screen("Settings", 2144);
-  top(settings, "Settings", "Local-first controls", []);
-  text(settings, "ⓘ", 342, 76, 20, C.secondary, "Regular", 24, "CENTER");
-  function settingCard(y, title, lines, height = 106) {
-    card(settings, 24, y, 345, height);
-    iconGlyph(settings, 48, y + 28, "neutral", 20);
-    text(settings, title, 84, y + 22, 16, C.text, "Semi Bold", 180);
-    lines.forEach(([label, color], i) => text(settings, label, 84, y + 48 + i * 22, 12, color || C.secondary, "Regular", 235));
+  headerBack(progress, "Progress", "May 2026 snapshot", "calendar");
+
+  t(progress, "‹  Apr 2026", S.screenPad, 122, 12, C.secondary, "Regular", 100);
+  t(progress, "May 2026", 164, 122, 14, C.green, "Semi Bold", 80, "CENTER");
+  t(progress, "Jun 2026  ›", 294, 122, 12, C.secondary, "Regular", 80, "RIGHT");
+
+  metricStrip(progress, S.screenPad, 148, [
+    ["Portfolio", "₹19.87L"],
+    ["Invested", "₹1.40L"],
+    ["Cash", "₹3.25L"],
+    ["Savings", "34%", C.green],
+  ]);
+
+  const changedY = 232;
+
+  card(progress, S.screenPad, changedY, 353, 212, S.radius.lg);
+  t(progress, "What changed this month?", S.screenPad + 14, changedY + 14, 15, C.text, "Semi Bold", 220);
+
+  [
+    ["equity", "Equity", "Market value and contributions", "+₹58,000"],
+    ["debt", "Debt", "Stable allocation", "+₹12,000"],
+    ["crypto", "Crypto", "Manual price movement", "-₹8,500"],
+    ["cash", "Cash", "Net cash change", "+₹70,000"],
+  ].forEach(([type, label, caption, value], i) => {
+    const ac = assetClass[type];
+    const wy = changedY + 52 + i * 38;
+    const isNeg = value.startsWith("-");
+
+    assetDot(progress, S.screenPad + 14, wy + 8, type, 8);
+    ico(progress, ac.icon, S.screenPad + 26, wy + 2, 16, ac.color);
+
+    t(progress, label, S.screenPad + 52, wy, 13, C.text, "Semi Bold", 110);
+    t(progress, caption, S.screenPad + 52, wy + 17, 10, C.secondary, "Regular", 180);
+    t(progress, value, 310, wy + 2, 13, isNeg ? C.negative : C.text, "Semi Bold", 62, "RIGHT");
+  });
+
+  trendChart(progress, S.screenPad, 456, 353, 140);
+
+  const snapY = 610;
+
+  card(progress, S.screenPad, snapY, 353, 118, S.radius.md);
+  t(progress, "Asset class snapshot", S.screenPad + 14, snapY + 12, 14, C.text, "Semi Bold", 200);
+
+  [
+    ["equity", "Equity", "₹12,45,000", "62.6%"],
+    ["debt", "Debt", "₹3,22,000", "16.2%"],
+    ["crypto", "Crypto", "₹1,20,000", "6.0%"],
+    ["cash", "Cash", "₹3,25,470", "16.3%"],
+  ].forEach(([type, label, value, pct], i) => {
+    const sy = snapY + 42 + i * 18;
+
+    assetDot(progress, S.screenPad + 14, sy + 5, type, 7);
+    t(progress, label, S.screenPad + 28, sy, 12, C.text, "Medium", 70);
+    t(progress, value, 250, sy, 12, C.text, "Regular", 80, "RIGHT");
+    t(progress, pct, 340, sy, 12, C.secondary, "Regular", 36, "RIGHT");
+  });
+
+  nav(progress, "Progress");
+
+  // ──────────────────────────────────────────────────────────────
+  // SCREEN 6 — SETTINGS
+  // ──────────────────────────────────────────────────────────────
+  const settings = screen("6. Settings", 2144);
+
+  header(settings, "Settings", "Local-first controls");
+  ico(settings, "info", 350, 66, 18, C.secondary);
+
+  let sy = 128;
+
+  function settingsSection(title, rows) {
+    t(settings, title, S.screenPad, sy, 13, C.secondary, "Semi Bold", 160);
+    sy += 24;
+
+    const sH = rows.length * 48;
+
+    card(settings, S.screenPad, sy, 353, sH, S.radius.lg);
+
+    rows.forEach(([label, value, valueColor, iconName], i) => {
+      const ry = sy + i * 48;
+
+      if (i > 0) {
+        line(settings, S.screenPad + 14, ry, 325, C.border, 0.25);
+      }
+
+      if (iconName) {
+        ico(settings, iconName, S.screenPad + 14, ry + 14, 18, C.secondary);
+        t(settings, label, S.screenPad + 42, ry + 15, 13, C.text, "Medium", 160);
+      } else {
+        t(settings, label, S.screenPad + 14, ry + 15, 13, C.text, "Medium", 190);
+      }
+
+      if (value) {
+        t(settings, value, 340, ry + 15, 12, valueColor || C.secondary, "Regular", 90, "RIGHT");
+        ico(settings, "chevron", 346, ry + 14, 16, C.muted);
+      }
+    });
+
+    sy += sH + 18;
   }
-  settingCard(128, "Privacy", [["Data stays on this device"], ["●  Local storage: Active", C.positive], ["No account • No cloud • No analytics"]], 104);
-  settingCard(246, "Value masking", [["Hide amounts on screen"], ["Masked preview   ₹••,••,•••"]], 88);
-  settingCard(348, "Quotes", [["Live refresh     Every 15 min"], ["Last refresh     3 May, 10:15 AM"], ["Provider status     Available", C.positive]], 104);
-  settingCard(466, "Currency", [["Base currency     INR"], ["Foreign assets summary     On"], ["USD & crypto fallback     On"]], 104);
-  settingCard(584, "Display & App info", [["Density     Standard (V1)"], ["Minimal Mode     V2 locked", C.muted], ["App version 1.0.0 · preview"]], 104);
-  card(settings, 24, 704, 345, 38, 10, C.bg).strokes = [paint(C.negative, 0.45)];
-  text(settings, "Clear local data", 52, 714, 12, C.negative, "Medium", 150);
-  text(settings, "Deletes local data", 224, 714, 10, C.muted, "Regular", 114, "RIGHT");
+
+  settingsSection("PRIVACY", [
+    ["Local storage", "Active", C.positive, "shield"],
+    ["Account", "None", C.secondary, null],
+    ["Analytics", "Off", C.secondary, null],
+  ]);
+
+  settingsSection("DISPLAY", [
+    ["Value masking", "Off", C.secondary, "eye"],
+    ["Display mode", "Standard", C.green, null],
+    ["Base currency", "INR  ₹", C.secondary, null],
+  ]);
+
+  settingsSection("QUOTES", [
+    ["Live quotes", "15 min", C.secondary, "refresh"],
+    ["Manual fallback", "Enabled", C.positive, null],
+    ["Last updated", "2m ago", C.secondary, null],
+  ]);
+
+  settingsSection("APP", [
+    ["Density", "Standard", C.secondary, null],
+    ["Version", "1.0.0", C.secondary, null],
+  ]);
+
+  rect(settings, S.screenPad, sy, 353, 44, S.radius.md, C.bg, C.negative, 0.4);
+  t(settings, "Clear local data", S.screenPad + 14, sy + 14, 13, C.negative, "Medium", 180);
+  t(settings, "Permanently deletes all holdings", 304, sy + 14, 11, C.muted, "Regular", 154, "RIGHT");
+
   nav(settings, "Settings");
 
-  figma.viewport.scrollAndZoomIntoView([dashboard, holdings, addHolding, cash, monthly, settings]);
-  figma.closePlugin("Created CogVest issue #69 V1 editable screens.");
+  // ─── PAGE TITLE ──────────────────────────────────────────────
+  t(page, "CogVest — V1 UI Concepts", 24, 24, 28, C.text, "Bold", 900);
+  t(
+    page,
+    "6 screens · Dashboard · Holdings · Add Holding · Cash · Progress · Settings · Quick actions moved to header · Bottom nav is navigation only",
+    24,
+    62,
+    13,
+    C.secondary,
+    "Regular",
+    1300
+  );
+
+  // ─── VIEWPORT ────────────────────────────────────────────────
+  figma.viewport.scrollAndZoomIntoView([
+    dashboard,
+    holdings,
+    addTrade,
+    cash,
+    progress,
+    settings,
+  ]);
+
+  figma.closePlugin("✓ CogVest V1 screens generated — quick actions moved to header.");
 }
 
-main().catch((error) => {
-  figma.closePlugin(`CogVest screen generation failed: ${error.message}`);
-});
+main().catch((err) => figma.closePlugin(`Failed: ${err.message}`));

--- a/docs/design/figma/issue-69-v1-screens/code.js
+++ b/docs/design/figma/issue-69-v1-screens/code.js
@@ -8,20 +8,20 @@ async function main() {
   await figma.loadFontAsync({ family: "Inter", style: "Bold" });
 
   const C = {
-    bg: "#1C1B1F",
-    surface: "#242329",
-    elevated: "#2B2930",
-    text: "#E6E1E5",
-    secondary: "#CAC4D0",
-    muted: "#938F99",
-    green: "#2E7D52",
-    positive: "#22C55E",
+    bg: "#000000",
+    surface: "#1C1C1E",
+    elevated: "#2C2C2E",
+    text: "#F5F5F7",
+    secondary: "#98989D",
+    muted: "#636366",
+    green: "#34C759",
+    positive: "#34C759",
     warning: "#F59E0B",
-    negative: "#EF4444",
-    border: "#3A3740",
-    blue: "#3D5FA8",
-    cashBlue: "#2E5F9E",
-    amber: "#B7791F"
+    negative: "#FF453A",
+    border: "#FFFFFF",
+    blue: "#0A84FF",
+    cashBlue: "#64D2FF",
+    amber: "#FF9F0A"
   };
 
   const PAGE_NAME = "Issue 69 - V1 UI Concepts";
@@ -63,7 +63,7 @@ async function main() {
     return node;
   }
 
-  function card(parent, x, y, width, height, radius = 14, fill = C.surface) {
+  function card(parent, x, y, width, height, radius = 18, fill = C.surface) {
     const node = figma.createRectangle();
     parent.appendChild(node);
     node.x = x;
@@ -71,12 +71,11 @@ async function main() {
     node.resize(width, height);
     node.cornerRadius = radius;
     node.fills = [paint(fill)];
-    node.strokes = [paint(C.border)];
-    node.strokeWeight = 1;
+    node.strokes = [];
     return node;
   }
 
-  function line(parent, x, y, width, color = C.border, opacity = 0.65) {
+  function line(parent, x, y, width, color = C.border, opacity = 0.1) {
     const node = figma.createLine();
     parent.appendChild(node);
     node.x = x;
@@ -136,6 +135,18 @@ async function main() {
     return outer;
   }
 
+  function iconGlyph(parent, x, y, type, size = 22) {
+    const config = {
+      equity: [C.positive, "trend"],
+      debt: [C.blue, "shield"],
+      crypto: [C.amber, "btc"],
+      cash: [C.cashBlue, "wallet"],
+      neutral: [C.secondary, "trend"]
+    };
+    const [color, icon] = config[type] || config.neutral;
+    return svg(parent, icon, x, y, size, color);
+  }
+
   function screen(name, x) {
     const frame = figma.createFrame();
     page.appendChild(frame);
@@ -153,27 +164,34 @@ async function main() {
 
   function top(frame, title, subtitle, actions = []) {
     const titleWidth = actions.length > 0 ? 220 : 285;
-    text(frame, title, 24, 72, 23, C.text, "Semi Bold", titleWidth);
-    text(frame, subtitle, 24, 104, 13, C.secondary, "Regular", 255);
+    text(frame, title, 24, 70, 28, C.text, "Bold", titleWidth);
+    text(frame, subtitle, 24, 108, 13, C.secondary, "Regular", 255);
     actions.forEach((action, i) => {
       const x = 286 + i * 46;
-      card(frame, x, 68, 38, 38, 10);
+      card(frame, x, 70, 38, 38, 12, C.elevated);
       svg(frame, action, x + 9, 77, 20, C.text);
     });
   }
 
   function topBack(frame, title, subtitle, action = null) {
     svg(frame, "back", 24, 74, 20, C.text);
-    text(frame, title, 70, 70, 22, C.text, "Semi Bold", 230);
-    text(frame, subtitle, 70, 102, 13, C.secondary, "Regular", 240);
+    text(frame, title, 70, 68, 26, C.text, "Bold", 230);
+    text(frame, subtitle, 70, 104, 13, C.secondary, "Regular", 240);
     if (action) {
-      card(frame, 331, 68, 38, 38, 10);
+      card(frame, 331, 70, 38, 38, 12, C.elevated);
       svg(frame, action, 340, 77, 20, C.text);
     }
   }
 
   function nav(frame, selected) {
-    card(frame, 0, 778, 393, 74, 0, "#202026").strokes = [];
+    const navBg = figma.createRectangle();
+    frame.appendChild(navBg);
+    navBg.x = 0;
+    navBg.y = 778;
+    navBg.resize(393, 74);
+    navBg.fills = [paint(C.surface, 0.86)];
+    navBg.strokes = [paint(C.border, 0.08)];
+    navBg.strokeWeight = 1;
     const items = [
       ["Dashboard", "home", 48],
       ["Holdings", "pie", 122],
@@ -189,11 +207,11 @@ async function main() {
         circle.x = 176;
         circle.y = 787;
         circle.resize(40, 40);
-        circle.fills = [paint(C.green, 0.86)];
+        circle.fills = [paint(C.green)];
         svg(frame, "plus", 186, 797, 20, C.text);
       } else {
         svg(frame, icon, x - 12, 793, 24, active ? C.positive : C.secondary);
-        if (active) card(frame, x - 24, 778, 48, 3, 2, C.green).strokes = [];
+        if (active) card(frame, x - 24, 778, 48, 3, 2, C.green);
       }
       text(frame, label, x - 34, 829, 11, active ? C.positive : C.secondary, "Regular", 68, "CENTER");
     });
@@ -201,7 +219,7 @@ async function main() {
 
   function metric(frame, label, value, x, y, width = 80, color = C.text) {
     text(frame, label, x, y, 11, C.secondary, "Regular", width);
-    text(frame, value, x, y + 21, 14, color, "Medium", width);
+    text(frame, value, x, y + 21, 15, color, "Semi Bold", width);
   }
 
   function summary(frame, y, values) {
@@ -219,8 +237,18 @@ async function main() {
     text(frame, value, x + 10, y + 42, 14, C.text, "Medium", width - 20);
   }
 
+  function metricStrip(frame, y, items) {
+    card(frame, 24, y, 345, 76);
+    items.forEach(([label, value], i) => {
+      const x = 38 + i * 84;
+      text(frame, label, x, y + 14, 10, C.secondary, "Regular", 70);
+      text(frame, value, x, y + 43, 15, C.text, "Semi Bold", 70);
+      if (i > 0) line(frame, x - 14, y + 18, 42);
+    });
+  }
+
   function chip(frame, label, x, y, active = false) {
-    card(frame, x, y, 58, 30, 15, active ? C.green : C.bg);
+    card(frame, x, y, 58, 30, 15, active ? C.green : C.elevated);
     text(frame, label, x, y + 7, 12, active ? C.text : C.secondary, "Medium", 58, "CENTER");
   }
 
@@ -233,7 +261,7 @@ async function main() {
     ];
     rows.forEach(([type, label, pct, value], i) => {
       const yy = y + i * 42;
-      iconCircle(frame, x, yy, type, 34);
+      iconGlyph(frame, x + 6, yy + 6, type, 22);
       text(frame, label, x + 50, yy + 4, 14, C.text, "Medium", 80);
       text(frame, pct, x + 230, yy + 4, 14, C.text, "Medium", 45, "RIGHT");
       card(frame, x + 50, yy + 30, 120, 5, 3, "#34313B").strokes = [];
@@ -246,7 +274,7 @@ async function main() {
 
   function holdingRow(frame, y, type, name, meta, current, invested, pnl, alloc, note = "") {
     card(frame, 24, y, 345, 68, 12);
-    iconCircle(frame, 36, y + 14, type, 32);
+    iconGlyph(frame, 42, y + 22, type, 22);
     text(frame, name, 78, y + 12, 14, C.text, "Medium", 150);
     text(frame, meta, 78, y + 33, 10, C.secondary, "Regular", 178);
     if (note) text(frame, note, 78, y + 49, 9, C.warning, "Regular", 120);
@@ -276,7 +304,7 @@ async function main() {
   metric(dashboard, "Savings rate", "42%", 154, 586, 92);
   metric(dashboard, "Cash change", "+₹70K", 266, 586, 84);
   card(dashboard, 24, 646, 345, 64);
-  iconCircle(dashboard, 38, 661, "neutral", 32);
+  iconGlyph(dashboard, 44, 669, "neutral", 20);
   text(dashboard, "Conviction data is still building", 82, 660, 14, C.text, "Medium", 230);
   text(dashboard, "Optional conviction improves context over time.", 82, 682, 11, C.secondary, "Regular", 240);
   nav(dashboard, "Dashboard");
@@ -299,22 +327,22 @@ async function main() {
   text(addHolding, "?", 342, 74, 22, C.secondary, "Semi Bold", 24, "CENTER");
   ["Asset", "Classification", "Position", "Review"].forEach((label, i) => {
     const x = 58 + i * 86;
-    iconCircle(addHolding, x, 142, "neutral", 32);
+    iconGlyph(addHolding, x + 5, 147, "neutral", 22);
     text(addHolding, label, x - 22, 180, 11, i === 2 ? C.positive : C.secondary, "Medium", 76, "CENTER");
     if (i < 3) line(addHolding, x + 42, 158, 42);
   });
   card(addHolding, 24, 222, 345, 58, 12);
-  iconCircle(addHolding, 38, 234, "neutral", 32);
+  iconGlyph(addHolding, 44, 242, "neutral", 20);
   text(addHolding, "Asset", 82, 234, 15, C.text, "Medium", 120);
   text(addHolding, "HDFC Bank · HDFCBANK · INR", 82, 256, 11, C.secondary, "Regular", 190);
   text(addHolding, "Edit ›", 310, 242, 13, C.secondary, "Medium", 50);
   card(addHolding, 24, 292, 345, 58, 12);
-  iconCircle(addHolding, 38, 304, "equity", 32);
+  iconGlyph(addHolding, 44, 312, "equity", 20);
   text(addHolding, "Classification", 82, 304, 15, C.text, "Medium", 130);
   text(addHolding, "Equity · Large Cap · Financial Services", 82, 326, 11, C.secondary, "Regular", 220);
   text(addHolding, "Edit ›", 310, 312, 13, C.secondary, "Medium", 50);
   card(addHolding, 24, 364, 345, 196, 12);
-  iconCircle(addHolding, 38, 378, "neutral", 32);
+  iconGlyph(addHolding, 44, 386, "neutral", 20);
   text(addHolding, "Position details", 82, 382, 16, C.text, "Semi Bold", 160);
   metric(addHolding, "Quantity *", "25", 42, 426, 74);
   metric(addHolding, "Average cost *", "₹1,450.00", 136, 426, 104);
@@ -337,34 +365,31 @@ async function main() {
   const cash = screen("Cash", 1296);
   top(cash, "Cash", "Manual ledger • local only", ["plus", "eye"]);
   card(cash, 24, 130, 345, 88);
-  iconCircle(cash, 38, 152, "cash", 38);
+  iconGlyph(cash, 48, 162, "cash", 24);
   text(cash, "Cash balance", 92, 146, 13, C.secondary, "Regular", 120);
   text(cash, "₹1,65,600", 92, 174, 28, C.text, "Semi Bold", 180);
   text(cash, "₹••,•••", 282, 174, 16, C.secondary, "Medium", 70);
-  [["Added", "₹70K"], ["Invested", "₹45K"], ["Available", "₹1.20L"], ["Savings", "32.8%"]].forEach(([label, value], i) => {
-    const x = 24 + i * 86;
-    miniMetricCard(cash, x, 234, label, value);
-  });
-  card(cash, 24, 332, 345, 178);
-  text(cash, "Add cash entry", 38, 348, 16, C.text, "Semi Bold", 160);
-  chip(cash, "Deposit", 38, 386, true);
-  chip(cash, "Withdrawal", 112, 386, false);
-  card(cash, 200, 386, 132, 30, 15, C.bg);
-  text(cash, "Investment transfer", 200, 394, 10, C.secondary, "Medium", 132, "CENTER");
-  metric(cash, "Amount (INR) *", "₹0", 38, 438, 110);
-  metric(cash, "Date *", "03 May 2026", 192, 438, 120);
-  text(cash, "Note (optional)  e.g., Salary, SIP transfer", 38, 488, 11, C.muted, "Regular", 260);
-  card(cash, 250, 520, 92, 34, 8, C.green);
-  text(cash, "Save entry", 262, 530, 12, C.text, "Medium", 70, "CENTER");
-  card(cash, 24, 574, 345, 150);
-  text(cash, "Recent cash ledger", 38, 590, 16, C.text, "Semi Bold", 180);
-  text(cash, "View all", 296, 592, 12, C.positive, "Medium", 60, "RIGHT");
+  metricStrip(cash, 234, [["Added", "₹70K"], ["Invested", "₹45K"], ["Available", "₹1.20L"], ["Savings", "32.8%"]]);
+  card(cash, 24, 328, 345, 178);
+  text(cash, "Add cash entry", 38, 344, 16, C.text, "Semi Bold", 160);
+  chip(cash, "Deposit", 38, 382, true);
+  chip(cash, "Withdrawal", 112, 382, false);
+  card(cash, 200, 382, 132, 30, 15, C.elevated);
+  text(cash, "Investment transfer", 200, 390, 10, C.secondary, "Medium", 132, "CENTER");
+  metric(cash, "Amount (INR) *", "₹0", 38, 434, 110);
+  metric(cash, "Date *", "03 May 2026", 192, 434, 120);
+  text(cash, "Note (optional)  e.g., Salary, SIP transfer", 38, 484, 11, C.muted, "Regular", 260);
+  card(cash, 250, 516, 92, 34, 10, C.green);
+  text(cash, "Save entry", 262, 526, 12, C.bg, "Semi Bold", 70, "CENTER");
+  card(cash, 24, 570, 345, 150);
+  text(cash, "Recent cash ledger", 38, 586, 16, C.text, "Semi Bold", 180);
+  text(cash, "View all", 296, 588, 12, C.positive, "Medium", 60, "RIGHT");
   [["Salary added", "₹70,000", C.positive], ["SIP transfer – Index Fund", "-₹15,000", C.text], ["Emergency fund top-up", "₹10,000", C.positive], ["SIP transfer – Large Cap", "-₹15,000", C.text]].forEach(([label, value, color], i) => {
-    const y = 626 + i * 24;
+    const y = 622 + i * 24;
     text(cash, label, 42, y, 11, C.secondary, "Regular", 160);
     text(cash, value, 286, y, 12, color, "Medium", 70, "RIGHT");
   });
-  text(cash, "Cash is included in total allocation", 38, 744, 11, C.secondary, "Regular", 220);
+  text(cash, "Cash is included in total allocation", 38, 740, 11, C.secondary, "Regular", 220);
   nav(cash, "Cash");
 
   const monthly = screen("Monthly Progression", 1720);
@@ -372,15 +397,12 @@ async function main() {
   text(monthly, "‹  Apr 2026", 24, 128, 13, C.secondary, "Regular", 100);
   text(monthly, "May 2026", 164, 128, 15, C.positive, "Medium", 80, "CENTER");
   text(monthly, "Jun 2026  ›", 286, 128, 13, C.secondary, "Regular", 80, "RIGHT");
-  [["Portfolio", "₹19.87L"], ["Invested", "₹1.40L"], ["Cash", "₹3.25L"], ["Savings", "34%"]].forEach(([label, value], i) => {
-    const x = 24 + i * 86;
-    miniMetricCard(monthly, x, 170, label, value);
-  });
-  card(monthly, 24, 270, 345, 196);
-  text(monthly, "What changed this month?", 38, 286, 16, C.text, "Semi Bold", 210);
+  metricStrip(monthly, 170, [["Portfolio", "₹19.87L"], ["Invested", "₹1.40L"], ["Cash", "₹3.25L"], ["Savings", "34%"]]);
+  card(monthly, 24, 264, 345, 196);
+  text(monthly, "What changed this month?", 38, 280, 16, C.text, "Semi Bold", 210);
   [["equity", "Equity", "Market value and contributions", "+₹58,000"], ["debt", "Debt", "Stable allocation", "+₹12,000"], ["crypto", "Crypto", "Manual price movement", "-₹8,500"], ["cash", "Cash", "Net cash change", "+₹70,000"]].forEach(([type, label, caption, value], i) => {
     const y = 326 + i * 34;
-    iconCircle(monthly, 38, y - 5, type, 28);
+    iconGlyph(monthly, 41, y, type, 20);
     text(monthly, label, 78, y, 13, C.text, "Medium", 80);
     text(monthly, caption, 78, y + 16, 10, C.secondary, "Regular", 170);
     text(monthly, value, 288, y + 4, 13, value.startsWith("-") ? C.negative : C.text, "Medium", 70, "RIGHT");
@@ -392,7 +414,7 @@ async function main() {
   text(monthly, "Asset class snapshot", 38, 612, 16, C.text, "Semi Bold", 200);
   [["equity", "Equity", "₹12,45,000", "62.6%"], ["debt", "Debt", "₹3,22,000", "16.2%"], ["crypto", "Crypto", "₹1,20,000", "6.0%"], ["cash", "Cash", "₹3,25,470", "16.3%"]].forEach(([type, label, value, pct], i) => {
     const y = 644 + i * 25;
-    iconCircle(monthly, 38, y - 6, type, 24);
+    iconGlyph(monthly, 40, y - 1, type, 18);
     text(monthly, label, 70, y, 12, C.text, "Medium", 70);
     text(monthly, value, 226, y, 12, C.text, "Regular", 80, "RIGHT");
     text(monthly, pct, 322, y, 12, C.secondary, "Regular", 40, "RIGHT");
@@ -404,9 +426,9 @@ async function main() {
   text(settings, "ⓘ", 342, 76, 20, C.secondary, "Regular", 24, "CENTER");
   function settingCard(y, title, lines, height = 106) {
     card(settings, 24, y, 345, height);
-    iconCircle(settings, 40, y + 20, "neutral", 34);
-    text(settings, title, 92, y + 22, 16, C.text, "Semi Bold", 180);
-    lines.forEach(([label, color], i) => text(settings, label, 92, y + 48 + i * 22, 12, color || C.secondary, "Regular", 225));
+    iconGlyph(settings, 48, y + 28, "neutral", 20);
+    text(settings, title, 84, y + 22, 16, C.text, "Semi Bold", 180);
+    lines.forEach(([label, color], i) => text(settings, label, 84, y + 48 + i * 22, 12, color || C.secondary, "Regular", 235));
   }
   settingCard(128, "Privacy", [["Data stays on this device"], ["●  Local storage: Active", C.positive], ["No account • No cloud • No analytics"]], 104);
   settingCard(246, "Value masking", [["Hide amounts on screen"], ["Masked preview   ₹••,••,•••"]], 88);

--- a/docs/design/figma/issue-69-v1-screens/code.js
+++ b/docs/design/figma/issue-69-v1-screens/code.js
@@ -100,7 +100,8 @@ async function main() {
       btc: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M9 4v16M13 4v16M7 7h6.2c2 0 3.3 1 3.3 2.6 0 1.1-.7 2-1.9 2.3 1.5.3 2.4 1.3 2.4 2.8 0 1.8-1.5 3.3-3.8 3.3H7M7 12h6" stroke="${s}" stroke-width="2" stroke-linecap="round"/></svg>`,
       eye: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z" stroke="${s}" stroke-width="2"/><circle cx="12" cy="12" r="3" stroke="${s}" stroke-width="2"/></svg>`,
       refresh: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M20 7v5h-5M4 17v-5h5" stroke="${s}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M18 12a6 6 0 0 0-10.2-4.2L4 11m16 2-3.8 3.2A6 6 0 0 1 6 12" stroke="${s}" stroke-width="2" stroke-linecap="round"/></svg>`,
-      search: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><circle cx="11" cy="11" r="7" stroke="${s}" stroke-width="2"/><path d="m16 16 5 5" stroke="${s}" stroke-width="2" stroke-linecap="round"/></svg>`
+      search: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><circle cx="11" cy="11" r="7" stroke="${s}" stroke-width="2"/><path d="m16 16 5 5" stroke="${s}" stroke-width="2" stroke-linecap="round"/></svg>`,
+      back: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="m15 6-6 6 6 6" stroke="${s}" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"/></svg>`
     };
     return icons[name] || icons.trend;
   }
@@ -162,7 +163,7 @@ async function main() {
   }
 
   function topBack(frame, title, subtitle, action = null) {
-    svg(frame, "home", 24, 74, 20);
+    svg(frame, "back", 24, 74, 20, C.text);
     text(frame, title, 70, 70, 22, C.text, "Semi Bold", 230);
     text(frame, subtitle, 70, 102, 13, C.secondary, "Regular", 240);
     if (action) {
@@ -199,17 +200,23 @@ async function main() {
   }
 
   function metric(frame, label, value, x, y, width = 80, color = C.text) {
-    text(frame, label, x, y, 12, C.secondary, "Regular", width);
-    text(frame, value, x, y + 22, 15, color, "Medium", width);
+    text(frame, label, x, y, 11, C.secondary, "Regular", width);
+    text(frame, value, x, y + 21, 14, color, "Medium", width);
   }
 
   function summary(frame, y, values) {
-    card(frame, 24, y, 345, 112);
+    card(frame, 24, y, 345, 102);
     values.forEach(([label, value, color], i) => {
       const x = 38 + i * 84;
-      metric(frame, label, value, x, y + 26, 78, color || C.text);
-      if (i > 0) line(frame, x - 14, y + 26, 64);
+      metric(frame, label, value, x, y + 24, 70, color || C.text);
+      if (i > 0) line(frame, x - 14, y + 24, 56);
     });
+  }
+
+  function miniMetricCard(frame, x, y, label, value, width = 78) {
+    card(frame, x, y, width, 72, 10);
+    text(frame, label, x + 10, y + 12, 10, C.secondary, "Regular", width - 20);
+    text(frame, value, x + 10, y + 42, 14, C.text, "Medium", width - 20);
   }
 
   function chip(frame, label, x, y, active = false) {
@@ -254,37 +261,37 @@ async function main() {
 
   const dashboard = screen("Dashboard", 24);
   top(dashboard, "Dashboard", "Local portfolio • 3 May 2026", ["eye", "refresh"]);
-  summary(dashboard, 132, [["Current value", "₹18,42,500"], ["Invested", "₹15,32,000"], ["P&L", "+₹3,10,500", C.positive], ["P&L %", "+20.26%", C.positive]]);
-  card(dashboard, 24, 258, 345, 44, 12);
-  text(dashboard, "●  Quotes updated 2m ago  •  Manual fallback ready", 38, 272, 12, C.secondary, "Regular", 250);
-  svg(dashboard, "refresh", 324, 268, 18);
-  card(dashboard, 24, 318, 345, 230);
-  text(dashboard, "Allocation", 38, 334, 16, C.text, "Semi Bold", 150);
-  text(dashboard, "View details", 274, 336, 12, C.positive, "Medium", 80, "RIGHT");
-  allocationRows(dashboard, 38, 378);
-  card(dashboard, 24, 562, 345, 98);
-  text(dashboard, "This month", 38, 578, 16, C.text, "Semi Bold", 130);
-  text(dashboard, "May 2026", 294, 580, 12, C.positive, "Medium", 60, "RIGHT");
-  metric(dashboard, "Invested", "₹1,20,000", 42, 616, 92);
-  metric(dashboard, "Savings rate", "42%", 154, 616, 92);
-  metric(dashboard, "Cash change", "+₹70,000", 266, 616, 84);
-  card(dashboard, 24, 674, 345, 64);
-  iconCircle(dashboard, 38, 689, "neutral", 32);
-  text(dashboard, "Conviction data is still building", 82, 688, 14, C.text, "Medium", 230);
-  text(dashboard, "Optional conviction improves context over time.", 82, 710, 11, C.secondary, "Regular", 240);
+  summary(dashboard, 132, [["Current", "₹18.42L"], ["Invested", "₹15.32L"], ["P&L", "+₹3.10L", C.positive], ["P&L %", "+20.2%", C.positive]]);
+  card(dashboard, 24, 246, 345, 42, 12);
+  text(dashboard, "●  Quotes updated 2m ago  •  Manual fallback ready", 38, 259, 12, C.secondary, "Regular", 250);
+  svg(dashboard, "refresh", 324, 255, 18);
+  card(dashboard, 24, 304, 345, 230);
+  text(dashboard, "Allocation", 38, 320, 16, C.text, "Semi Bold", 150);
+  text(dashboard, "View details", 274, 322, 12, C.positive, "Medium", 80, "RIGHT");
+  allocationRows(dashboard, 38, 364);
+  card(dashboard, 24, 552, 345, 100);
+  text(dashboard, "This month", 38, 568, 16, C.text, "Semi Bold", 130);
+  text(dashboard, "May 2026", 294, 570, 12, C.positive, "Medium", 60, "RIGHT");
+  metric(dashboard, "Invested", "₹1.20L", 42, 606, 92);
+  metric(dashboard, "Savings rate", "42%", 154, 606, 92);
+  metric(dashboard, "Cash change", "+₹70K", 266, 606, 84);
+  card(dashboard, 24, 668, 345, 64);
+  iconCircle(dashboard, 38, 683, "neutral", 32);
+  text(dashboard, "Conviction data is still building", 82, 682, 14, C.text, "Medium", 230);
+  text(dashboard, "Optional conviction improves context over time.", 82, 704, 11, C.secondary, "Regular", 240);
   nav(dashboard, "Dashboard");
 
   const holdings = screen("Holdings", 448);
   top(holdings, "Holdings", "24 positions • local data", ["search", "eye"]);
-  summary(holdings, 128, [["Current value", "₹12,48,212"], ["Invested", "₹11,05,823"], ["P&L", "+₹1,42,389", C.positive], ["Drift", "3.2%", C.warning]]);
+  summary(holdings, 128, [["Current", "₹12.48L"], ["Invested", "₹11.05L"], ["P&L", "+₹1.42L", C.positive], ["Drift", "3.2%", C.warning]]);
   text(holdings, "●  Quotes updated 2m ago  •  1 manual price", 38, 218, 12, C.secondary, "Regular", 230);
   ["All", "Equity", "Debt", "Crypto", "Cash"].forEach((label, i) => chip(holdings, label, 24 + i * 68, 260, i === 0));
   text(holdings, "Sorted by asset class", 24, 310, 12, C.secondary, "Regular", 160);
-  holdingRow(holdings, 334, "equity", "HDFC Bank", "Equity · Financial Services", "₹1,82,850", "₹1,64,235", "+₹18,615", "14.6%");
-  holdingRow(holdings, 414, "equity", "Nifty 50 ETF", "Equity · Index Fund", "₹50,665", "₹44,220", "+₹6,445", "4.1%");
-  holdingRow(holdings, 494, "debt", "Sovereign Gold Bond", "Debt · Government Bond", "₹57,110", "₹52,950", "+₹4,160", "4.6%");
-  holdingRow(holdings, 574, "crypto", "Bitcoin", "Crypto · Coin", "₹13,90,400", "₹11,05,000", "+₹2,85,400", "11.1%", "● Manual · 8h ago");
-  holdingRow(holdings, 654, "debt", "Liquid Fund", "Debt · Liquid / Overnight", "₹2,50,250", "₹2,50,000", "+₹250", "2.0%");
+  holdingRow(holdings, 334, "equity", "HDFC Bank", "Equity · Financial Services", "₹1.83L", "₹1.64L", "+₹18.6K", "14.6%");
+  holdingRow(holdings, 414, "equity", "Nifty 50 ETF", "Equity · Index Fund", "₹50.7K", "₹44.2K", "+₹6.4K", "4.1%");
+  holdingRow(holdings, 494, "debt", "Sovereign Gold Bond", "Debt · Government Bond", "₹57.1K", "₹53.0K", "+₹4.2K", "4.6%");
+  holdingRow(holdings, 574, "crypto", "Bitcoin", "Crypto · Coin", "₹13.90L", "₹11.05L", "+₹2.85L", "11.1%", "● Manual · 8h ago");
+  holdingRow(holdings, 654, "debt", "Liquid Fund", "Debt · Liquid / Overnight", "₹2.50L", "₹2.50L", "+₹250", "2.0%");
   nav(holdings, "Holdings");
 
   const addHolding = screen("Add Holding", 872);
@@ -334,11 +341,9 @@ async function main() {
   text(cash, "Cash balance", 92, 146, 13, C.secondary, "Regular", 120);
   text(cash, "₹1,65,600", 92, 174, 28, C.text, "Semi Bold", 180);
   text(cash, "₹••,•••", 282, 174, 16, C.secondary, "Medium", 70);
-  [["May added", "₹70,000"], ["May invested", "₹45,000"], ["Available", "₹1,20,600"], ["Savings rate", "32.8%"]].forEach(([label, value], i) => {
+  [["Added", "₹70K"], ["Invested", "₹45K"], ["Available", "₹1.20L"], ["Savings", "32.8%"]].forEach(([label, value], i) => {
     const x = 24 + i * 86;
-    card(cash, x, 234, 78, 82, 10);
-    text(cash, label, x + 10, 248, 10, C.secondary, "Regular", 60);
-    text(cash, value, x + 10, 286, 15, C.text, "Medium", 62);
+    miniMetricCard(cash, x, 234, label, value);
   });
   card(cash, 24, 332, 345, 178);
   text(cash, "Add cash entry", 38, 348, 16, C.text, "Semi Bold", 160);
@@ -370,11 +375,9 @@ async function main() {
   text(monthly, "‹  Apr 2026", 24, 128, 13, C.secondary, "Regular", 100);
   text(monthly, "May 2026", 164, 128, 15, C.positive, "Medium", 80, "CENTER");
   text(monthly, "Jun 2026  ›", 286, 128, 13, C.secondary, "Regular", 80, "RIGHT");
-  [["Portfolio value", "₹19,87,450"], ["Monthly investment", "₹1,40,000"], ["Cash balance", "₹3,25,470"], ["Savings rate", "34%"]].forEach(([label, value], i) => {
+  [["Portfolio", "₹19.87L"], ["Invested", "₹1.40L"], ["Cash", "₹3.25L"], ["Savings", "34%"]].forEach(([label, value], i) => {
     const x = 24 + i * 86;
-    card(monthly, x, 170, 78, 82, 10);
-    text(monthly, label, x + 10, 184, 10, C.secondary, "Regular", 58);
-    text(monthly, value, x + 10, 222, 14, C.text, "Medium", 60);
+    miniMetricCard(monthly, x, 170, label, value);
   });
   card(monthly, 24, 270, 345, 196);
   text(monthly, "What changed this month?", 38, 286, 16, C.text, "Semi Bold", 210);

--- a/docs/design/figma/issue-69-v1-screens/code.js
+++ b/docs/design/figma/issue-69-v1-screens/code.js
@@ -1,0 +1,417 @@
+// CogVest Issue #69 V1 editable Figma screens.
+// Run from Figma Desktop as a development plugin.
+
+async function main() {
+  await figma.loadFontAsync({ family: "Inter", style: "Regular" });
+  await figma.loadFontAsync({ family: "Inter", style: "Medium" });
+  await figma.loadFontAsync({ family: "Inter", style: "Semi Bold" });
+  await figma.loadFontAsync({ family: "Inter", style: "Bold" });
+
+  const C = {
+    bg: "#1C1B1F",
+    surface: "#242329",
+    elevated: "#2B2930",
+    text: "#E6E1E5",
+    secondary: "#CAC4D0",
+    muted: "#938F99",
+    green: "#2E7D52",
+    positive: "#22C55E",
+    warning: "#F59E0B",
+    negative: "#EF4444",
+    border: "#3A3740",
+    blue: "#3D5FA8",
+    cashBlue: "#2E5F9E",
+    amber: "#B7791F"
+  };
+
+  const PAGE_NAME = "Issue 69 - V1 UI Concepts";
+  const existing = figma.root.children.find((page) => page.name === PAGE_NAME);
+  if (existing) existing.remove();
+
+  const page = figma.createPage();
+  page.name = PAGE_NAME;
+  await figma.setCurrentPageAsync(page);
+
+  function rgb(hex) {
+    const h = hex.replace("#", "");
+    return {
+      r: parseInt(h.slice(0, 2), 16) / 255,
+      g: parseInt(h.slice(2, 4), 16) / 255,
+      b: parseInt(h.slice(4, 6), 16) / 255
+    };
+  }
+
+  function paint(hex, opacity = 1) {
+    return { type: "SOLID", color: rgb(hex), opacity };
+  }
+
+  function text(parent, value, x, y, size, color = C.text, style = "Regular", width = 160, align = "LEFT") {
+    const node = figma.createText();
+    parent.appendChild(node);
+    node.x = x;
+    node.y = y;
+    node.resize(width, Math.max(size + 10, 20));
+    node.fontName = { family: "Inter", style };
+    node.fontSize = size;
+    node.fills = [paint(color)];
+    node.textAlignHorizontal = align;
+    node.textAutoResize = "HEIGHT";
+    node.characters = value;
+    return node;
+  }
+
+  function card(parent, x, y, width, height, radius = 14, fill = C.surface) {
+    const node = figma.createRectangle();
+    parent.appendChild(node);
+    node.x = x;
+    node.y = y;
+    node.resize(width, height);
+    node.cornerRadius = radius;
+    node.fills = [paint(fill)];
+    node.strokes = [paint(C.border)];
+    node.strokeWeight = 1;
+    return node;
+  }
+
+  function line(parent, x, y, width, color = C.border, opacity = 0.65) {
+    const node = figma.createLine();
+    parent.appendChild(node);
+    node.x = x;
+    node.y = y;
+    node.resize(width, 0);
+    node.strokes = [paint(color, opacity)];
+    node.strokeWeight = 1;
+    return node;
+  }
+
+  function iconSvg(name, color = C.secondary) {
+    const s = color;
+    const icons = {
+      home: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M3 10.8 12 3l9 7.8V21h-6v-6H9v6H3V10.8Z" stroke="${s}" stroke-width="2" stroke-linejoin="round"/></svg>`,
+      pie: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M12 3v9h9A9 9 0 1 1 12 3Z" stroke="${s}" stroke-width="2"/><path d="M14 3.3A9 9 0 0 1 20.7 10H14V3.3Z" stroke="${s}" stroke-width="2"/></svg>`,
+      plus: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M12 5v14M5 12h14" stroke="${s}" stroke-width="2.4" stroke-linecap="round"/></svg>`,
+      wallet: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M4 7h16v12H4z" stroke="${s}" stroke-width="2" stroke-linejoin="round"/><path d="M4 7l11-3 2 3" stroke="${s}" stroke-width="2"/><path d="M15 13h5" stroke="${s}" stroke-width="2"/></svg>`,
+      gear: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z" stroke="${s}" stroke-width="2"/><path d="M4 13v-2l2.1-.6c.2-.6.4-1.1.7-1.6L5.8 6.7 7.2 5.3l2.1 1c.5-.3 1-.5 1.6-.7L11.5 3h2l.6 2.6c.6.2 1.1.4 1.6.7l2.1-1 1.4 1.4-1 2.1c.3.5.5 1 .7 1.6L21 11v2l-2.1.6c-.2.6-.4 1.1-.7 1.6l1 2.1-1.4 1.4-2.1-1c-.5.3-1 .5-1.6.7l-.6 2.6h-2l-.6-2.6c-.6-.2-1.1-.4-1.6-.7l-2.1 1-1.4-1.4 1-2.1c-.3-.5-.5-1-.7-1.6L4 13Z" stroke="${s}" stroke-width="2" stroke-linejoin="round"/></svg>`,
+      trend: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M4 16l5-5 4 4 7-8" stroke="${s}" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"/><path d="M15 7h5v5" stroke="${s}" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
+      shield: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M12 3 20 6v6c0 5-3.4 7.8-8 9-4.6-1.2-8-4-8-9V6l8-3Z" stroke="${s}" stroke-width="2" stroke-linejoin="round"/></svg>`,
+      btc: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M9 4v16M13 4v16M7 7h6.2c2 0 3.3 1 3.3 2.6 0 1.1-.7 2-1.9 2.3 1.5.3 2.4 1.3 2.4 2.8 0 1.8-1.5 3.3-3.8 3.3H7M7 12h6" stroke="${s}" stroke-width="2" stroke-linecap="round"/></svg>`,
+      eye: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z" stroke="${s}" stroke-width="2"/><circle cx="12" cy="12" r="3" stroke="${s}" stroke-width="2"/></svg>`,
+      refresh: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M20 7v5h-5M4 17v-5h5" stroke="${s}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M18 12a6 6 0 0 0-10.2-4.2L4 11m16 2-3.8 3.2A6 6 0 0 1 6 12" stroke="${s}" stroke-width="2" stroke-linecap="round"/></svg>`,
+      search: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><circle cx="11" cy="11" r="7" stroke="${s}" stroke-width="2"/><path d="m16 16 5 5" stroke="${s}" stroke-width="2" stroke-linecap="round"/></svg>`
+    };
+    return icons[name] || icons.trend;
+  }
+
+  function svg(parent, name, x, y, size = 22, color = C.secondary) {
+    const node = figma.createNodeFromSvg(iconSvg(name, color));
+    parent.appendChild(node);
+    node.x = x;
+    node.y = y;
+    node.resize(size, size);
+    return node;
+  }
+
+  function iconCircle(parent, x, y, type, size = 36) {
+    const config = {
+      equity: [C.green, "trend"],
+      debt: [C.blue, "shield"],
+      crypto: [C.amber, "btc"],
+      cash: [C.cashBlue, "wallet"],
+      neutral: [C.elevated, "trend"]
+    };
+    const [fill, icon] = config[type] || config.neutral;
+    const outer = figma.createEllipse();
+    parent.appendChild(outer);
+    outer.x = x;
+    outer.y = y;
+    outer.resize(size, size);
+    outer.fills = [paint(fill, type === "neutral" ? 0.55 : 0.88)];
+    outer.strokes = [paint(fill, 0.35)];
+    outer.strokeWeight = 1;
+    svg(parent, icon, x + 8, y + 8, size - 16, C.text);
+    return outer;
+  }
+
+  function screen(name, x) {
+    const frame = figma.createFrame();
+    page.appendChild(frame);
+    frame.name = name;
+    frame.x = x;
+    frame.y = 130;
+    frame.resize(393, 852);
+    frame.cornerRadius = 34;
+    frame.clipsContent = true;
+    frame.fills = [paint(C.bg)];
+    text(frame, "10:42", 24, 22, 12, C.text, "Medium", 60);
+    text(frame, "◢  ▰ 100%", 304, 22, 12, C.text, "Medium", 72, "RIGHT");
+    return frame;
+  }
+
+  function top(frame, title, subtitle, actions = []) {
+    text(frame, title, 24, 72, 24, C.text, "Semi Bold", 230);
+    text(frame, subtitle, 24, 104, 14, C.secondary, "Regular", 250);
+    actions.forEach((action, i) => {
+      const x = 286 + i * 46;
+      card(frame, x, 68, 38, 38, 10);
+      svg(frame, action, x + 9, 77, 20, C.text);
+    });
+  }
+
+  function nav(frame, selected) {
+    card(frame, 0, 778, 393, 74, 0, "#202026").strokes = [];
+    const items = [
+      ["Dashboard", "home", 48],
+      ["Holdings", "pie", 122],
+      ["Add", "plus", 196],
+      ["Cash", "wallet", 270],
+      ["Settings", "gear", 344]
+    ];
+    items.forEach(([label, icon, x]) => {
+      const active = label === selected;
+      if (label === "Add") {
+        const circle = figma.createEllipse();
+        frame.appendChild(circle);
+        circle.x = 176;
+        circle.y = 787;
+        circle.resize(40, 40);
+        circle.fills = [paint(C.green, 0.86)];
+        svg(frame, "plus", 186, 797, 20, C.text);
+      } else {
+        svg(frame, icon, x - 12, 793, 24, active ? C.positive : C.secondary);
+        if (active) card(frame, x - 24, 778, 48, 3, 2, C.green).strokes = [];
+      }
+      text(frame, label, x - 34, 829, 11, active ? C.positive : C.secondary, "Regular", 68, "CENTER");
+    });
+  }
+
+  function metric(frame, label, value, x, y, width = 80, color = C.text) {
+    text(frame, label, x, y, 12, C.secondary, "Regular", width);
+    text(frame, value, x, y + 22, 15, color, "Medium", width);
+  }
+
+  function summary(frame, y, values) {
+    card(frame, 24, y, 345, 112);
+    values.forEach(([label, value, color], i) => {
+      const x = 38 + i * 84;
+      metric(frame, label, value, x, y + 26, 78, color || C.text);
+      if (i > 0) line(frame, x - 14, y + 26, 64);
+    });
+  }
+
+  function chip(frame, label, x, y, active = false) {
+    card(frame, x, y, 58, 30, 15, active ? C.green : C.bg);
+    text(frame, label, x, y + 7, 12, active ? C.text : C.secondary, "Medium", 58, "CENTER");
+  }
+
+  function allocationRows(frame, x, y) {
+    const rows = [
+      ["equity", "Equity", "68%", "₹12,71,300"],
+      ["debt", "Debt", "15%", "₹2,76,000"],
+      ["crypto", "Crypto", "7%", "₹1,29,600"],
+      ["cash", "Cash", "10%", "₹1,65,600"]
+    ];
+    rows.forEach(([type, label, pct, value], i) => {
+      const yy = y + i * 56;
+      iconCircle(frame, x, yy, type, 34);
+      text(frame, label, x + 50, yy + 4, 14, C.text, "Medium", 80);
+      text(frame, pct, x + 230, yy + 4, 14, C.text, "Medium", 45, "RIGHT");
+      card(frame, x + 50, yy + 30, 120, 5, 3, "#34313B").strokes = [];
+      const width = Math.max(12, (120 * parseInt(pct, 10)) / 75);
+      const fill = type === "equity" ? C.green : type === "debt" ? C.blue : type === "crypto" ? C.warning : C.cashBlue;
+      card(frame, x + 50, yy + 30, width, 5, 3, fill).strokes = [];
+      text(frame, value, x + 166, yy + 30, 11, C.secondary, "Regular", 90, "RIGHT");
+    });
+  }
+
+  function holdingRow(frame, y, type, name, meta, current, invested, pnl, alloc, note = "") {
+    card(frame, 24, y, 345, 80, 12);
+    iconCircle(frame, 36, y + 16, type, 34);
+    text(frame, name, 82, y + 16, 15, C.text, "Medium", 150);
+    text(frame, meta, 82, y + 39, 11, C.secondary, "Regular", 178);
+    if (note) text(frame, note, 82, y + 57, 10, C.warning, "Regular", 130);
+    text(frame, current, 265, y + 18, 15, C.text, "Medium", 82, "RIGHT");
+    text(frame, `Invested  ${invested}`, 36, y + 56, 10, C.secondary, "Regular", 105);
+    text(frame, `P&L  ${pnl}`, 160, y + 56, 10, C.positive, "Regular", 86);
+    text(frame, `Allocation  ${alloc}`, 260, y + 56, 10, C.secondary, "Regular", 84, "RIGHT");
+  }
+
+  text(page, "CogVest V1 UI Concepts - Issue #69", 24, 24, 28, C.text, "Bold", 620);
+  text(page, "Editable Figma frames based on DESIGN.md Private Ledger direction. These replace generated PNGs as the stable design source.", 24, 62, 14, C.secondary, "Regular", 980);
+
+  const dashboard = screen("Dashboard", 24);
+  top(dashboard, "Dashboard", "Local portfolio • 3 May 2026", ["eye", "refresh"]);
+  summary(dashboard, 132, [["Current value", "₹18,42,500"], ["Invested", "₹15,32,000"], ["P&L", "+₹3,10,500", C.positive], ["P&L %", "+20.26%", C.positive]]);
+  card(dashboard, 24, 258, 345, 44, 12);
+  text(dashboard, "●  Quotes updated 2m ago  •  Manual fallback ready", 38, 272, 12, C.secondary, "Regular", 250);
+  svg(dashboard, "refresh", 324, 268, 18);
+  card(dashboard, 24, 318, 164, 260);
+  text(dashboard, "Allocation", 38, 334, 16, C.text, "Semi Bold", 120);
+  text(dashboard, "View details", 95, 334, 12, C.positive, "Medium", 80, "RIGHT");
+  allocationRows(dashboard, 38, 382);
+  card(dashboard, 204, 318, 165, 260);
+  text(dashboard, "This month", 220, 334, 16, C.text, "Semi Bold", 120);
+  text(dashboard, "May 2026", 292, 336, 12, C.positive, "Medium", 60, "RIGHT");
+  metric(dashboard, "Invested", "₹1,20,000", 248, 390, 90);
+  metric(dashboard, "Savings rate", "42%", 248, 462, 90);
+  metric(dashboard, "Cash change", "+₹70,000", 248, 534, 90);
+  card(dashboard, 24, 596, 345, 72);
+  iconCircle(dashboard, 38, 613, "neutral", 34);
+  text(dashboard, "Conviction data is still building", 86, 614, 15, C.text, "Medium", 230);
+  text(dashboard, "Optional conviction improves context over time.", 86, 638, 12, C.secondary, "Regular", 240);
+  nav(dashboard, "Dashboard");
+
+  const holdings = screen("Holdings", 448);
+  top(holdings, "Holdings", "24 positions • local data", ["search", "eye"]);
+  summary(holdings, 128, [["Current value", "₹12,48,212"], ["Invested", "₹11,05,823"], ["P&L", "+₹1,42,389", C.positive], ["Drift", "3.2%", C.warning]]);
+  text(holdings, "●  Quotes updated 2m ago  •  1 manual price", 38, 218, 12, C.secondary, "Regular", 230);
+  ["All", "Equity", "Debt", "Crypto", "Cash"].forEach((label, i) => chip(holdings, label, 24 + i * 68, 260, i === 0));
+  text(holdings, "Sorted by asset class", 24, 310, 12, C.secondary, "Regular", 160);
+  holdingRow(holdings, 344, "equity", "HDFC Bank", "Equity · Financial Services", "₹1,82,850", "₹1,64,235", "+₹18,615", "14.6%");
+  holdingRow(holdings, 434, "equity", "Nifty 50 ETF", "Equity · Index Fund", "₹50,665", "₹44,220", "+₹6,445", "4.1%");
+  holdingRow(holdings, 524, "debt", "Sovereign Gold Bond", "Debt · Government Bond", "₹57,110", "₹52,950", "+₹4,160", "4.6%");
+  holdingRow(holdings, 614, "crypto", "Bitcoin", "Crypto · Coin", "₹13,90,400", "₹11,05,000", "+₹2,85,400", "11.1%", "● Manual · 8h ago");
+  holdingRow(holdings, 704, "debt", "Liquid Fund", "Debt · Liquid / Overnight", "₹2,50,250", "₹2,50,000", "+₹250", "2.0%");
+  nav(holdings, "Holdings");
+
+  const addHolding = screen("Add Holding", 872);
+  top(addHolding, "Add Holding", "Opening position • local only", []);
+  svg(addHolding, "home", 24, 72, 20);
+  text(addHolding, "?", 342, 74, 22, C.secondary, "Semi Bold", 24, "CENTER");
+  ["Asset", "Classification", "Position", "Review"].forEach((label, i) => {
+    const x = 58 + i * 86;
+    iconCircle(addHolding, x, 142, "neutral", 32);
+    text(addHolding, label, x - 22, 180, 11, i === 2 ? C.positive : C.secondary, "Medium", 76, "CENTER");
+    if (i < 3) line(addHolding, x + 42, 158, 42);
+  });
+  card(addHolding, 24, 222, 345, 58, 12);
+  iconCircle(addHolding, 38, 234, "neutral", 32);
+  text(addHolding, "Asset", 82, 234, 15, C.text, "Medium", 120);
+  text(addHolding, "HDFC Bank · HDFCBANK · INR", 82, 256, 11, C.secondary, "Regular", 190);
+  text(addHolding, "Edit ›", 310, 242, 13, C.secondary, "Medium", 50);
+  card(addHolding, 24, 292, 345, 58, 12);
+  iconCircle(addHolding, 38, 304, "equity", 32);
+  text(addHolding, "Classification", 82, 304, 15, C.text, "Medium", 130);
+  text(addHolding, "Equity · Large Cap · Financial Services", 82, 326, 11, C.secondary, "Regular", 220);
+  text(addHolding, "Edit ›", 310, 312, 13, C.secondary, "Medium", 50);
+  card(addHolding, 24, 364, 345, 196, 12);
+  iconCircle(addHolding, 38, 378, "neutral", 32);
+  text(addHolding, "Position details", 82, 382, 16, C.text, "Semi Bold", 160);
+  metric(addHolding, "Quantity *", "25", 42, 426, 74);
+  metric(addHolding, "Average cost *", "₹1,450.00", 136, 426, 104);
+  metric(addHolding, "Current price *", "₹1,678.25", 252, 426, 110);
+  chip(addHolding, "Live", 42, 486, true);
+  chip(addHolding, "Manual", 112, 486, false);
+  text(addHolding, "Date acquired: 15 Apr 2024", 42, 532, 12, C.secondary, "Regular", 210);
+  card(addHolding, 24, 574, 345, 96, 12);
+  text(addHolding, "Derived preview", 82, 592, 16, C.text, "Semi Bold", 150);
+  ["₹36,250", "₹41,956", "+₹5,706", "+2.34%"].forEach((value, i) => metric(addHolding, ["Invested", "Current", "P&L", "Allocation"][i], value, 42 + i * 80, 626, 76, i > 1 ? C.positive : C.text));
+  card(addHolding, 24, 684, 345, 52, 12);
+  text(addHolding, "Conviction optional", 82, 697, 14, C.text, "Medium", 170);
+  text(addHolding, "Add later", 82, 718, 11, C.secondary, "Regular", 100);
+  card(addHolding, 24, 750, 160, 40, 8, C.bg);
+  text(addHolding, "Save and add another", 34, 761, 12, C.text, "Medium", 140, "CENTER");
+  card(addHolding, 202, 750, 166, 40, 8, C.green);
+  text(addHolding, "Save holding", 218, 761, 12, C.text, "Medium", 130, "CENTER");
+  nav(addHolding, "Add");
+
+  const cash = screen("Cash", 1296);
+  top(cash, "Cash", "Manual ledger • local only", ["plus", "eye"]);
+  card(cash, 24, 130, 345, 88);
+  iconCircle(cash, 38, 152, "cash", 38);
+  text(cash, "Cash balance", 92, 146, 13, C.secondary, "Regular", 120);
+  text(cash, "₹1,65,600", 92, 174, 28, C.text, "Semi Bold", 180);
+  text(cash, "₹••,•••", 282, 174, 16, C.secondary, "Medium", 70);
+  [["May added", "₹70,000"], ["May invested", "₹45,000"], ["Available", "₹1,20,600"], ["Savings rate", "32.8%"]].forEach(([label, value], i) => {
+    const x = 24 + i * 86;
+    card(cash, x, 234, 78, 82, 10);
+    text(cash, label, x + 10, 248, 10, C.secondary, "Regular", 60);
+    text(cash, value, x + 10, 286, 15, C.text, "Medium", 62);
+  });
+  card(cash, 24, 332, 345, 178);
+  text(cash, "Add cash entry", 38, 348, 16, C.text, "Semi Bold", 160);
+  chip(cash, "Deposit", 38, 386, true);
+  chip(cash, "Withdrawal", 112, 386, false);
+  card(cash, 200, 386, 132, 30, 15, C.bg);
+  text(cash, "Investment transfer", 200, 394, 10, C.secondary, "Medium", 132, "CENTER");
+  metric(cash, "Amount (INR) *", "₹0", 38, 438, 110);
+  metric(cash, "Date *", "03 May 2026", 192, 438, 120);
+  text(cash, "Note (optional)  e.g., Salary, SIP transfer", 38, 488, 11, C.muted, "Regular", 260);
+  card(cash, 250, 520, 92, 34, 8, C.green);
+  text(cash, "Save entry", 262, 530, 12, C.text, "Medium", 70, "CENTER");
+  card(cash, 24, 574, 345, 150);
+  text(cash, "Recent cash ledger", 38, 590, 16, C.text, "Semi Bold", 180);
+  text(cash, "View all", 296, 592, 12, C.positive, "Medium", 60, "RIGHT");
+  [["Salary added", "₹70,000", C.positive], ["SIP transfer – Index Fund", "-₹15,000", C.text], ["Emergency fund top-up", "₹10,000", C.positive], ["SIP transfer – Large Cap", "-₹15,000", C.text]].forEach(([label, value, color], i) => {
+    const y = 626 + i * 24;
+    text(cash, label, 42, y, 11, C.secondary, "Regular", 160);
+    text(cash, value, 286, y, 12, color, "Medium", 70, "RIGHT");
+  });
+  card(cash, 24, 738, 345, 48, 12);
+  iconCircle(cash, 38, 745, "cash", 28);
+  text(cash, "Cash is included in total allocation", 78, 748, 12, C.text, "Medium", 200);
+  text(cash, "Last updated 03 May 2026, 9:40 AM", 78, 768, 10, C.secondary, "Regular", 200);
+  nav(cash, "Cash");
+
+  const monthly = screen("Monthly Progression", 1720);
+  top(monthly, "Monthly Progression", "May 2026 snapshot", ["eye"]);
+  text(monthly, "‹  Apr 2026", 24, 128, 13, C.secondary, "Regular", 100);
+  text(monthly, "May 2026", 164, 128, 15, C.positive, "Medium", 80, "CENTER");
+  text(monthly, "Jun 2026  ›", 286, 128, 13, C.secondary, "Regular", 80, "RIGHT");
+  [["Portfolio value", "₹19,87,450"], ["Monthly investment", "₹1,40,000"], ["Cash balance", "₹3,25,470"], ["Savings rate", "34%"]].forEach(([label, value], i) => {
+    const x = 24 + i * 86;
+    card(monthly, x, 170, 78, 82, 10);
+    text(monthly, label, x + 10, 184, 10, C.secondary, "Regular", 58);
+    text(monthly, value, x + 10, 222, 14, C.text, "Medium", 60);
+  });
+  card(monthly, 24, 270, 345, 196);
+  text(monthly, "What changed this month?", 38, 286, 16, C.text, "Semi Bold", 210);
+  [["equity", "Equity", "Market value and contributions", "+₹58,000"], ["debt", "Debt", "Stable allocation", "+₹12,000"], ["crypto", "Crypto", "Manual price movement", "-₹8,500"], ["cash", "Cash", "Net cash change", "+₹70,000"]].forEach(([type, label, caption, value], i) => {
+    const y = 326 + i * 34;
+    iconCircle(monthly, 38, y - 5, type, 28);
+    text(monthly, label, 78, y, 13, C.text, "Medium", 80);
+    text(monthly, caption, 78, y + 16, 10, C.secondary, "Regular", 170);
+    text(monthly, value, 288, y + 4, 13, value.startsWith("-") ? C.negative : C.text, "Medium", 70, "RIGHT");
+  });
+  card(monthly, 24, 484, 345, 118);
+  text(monthly, "Progression (last 6 months)", 38, 500, 16, C.text, "Semi Bold", 230);
+  line(monthly, 60, 568, 270, C.secondary, 0.75);
+  card(monthly, 24, 620, 345, 128);
+  text(monthly, "Asset class snapshot", 38, 636, 16, C.text, "Semi Bold", 200);
+  [["equity", "Equity", "₹12,45,000", "62.6%"], ["debt", "Debt", "₹3,22,000", "16.2%"], ["crypto", "Crypto", "₹1,20,000", "6.0%"], ["cash", "Cash", "₹3,25,470", "16.3%"]].forEach(([type, label, value, pct], i) => {
+    const y = 674 + i * 26;
+    iconCircle(monthly, 38, y - 6, type, 24);
+    text(monthly, label, 70, y, 12, C.text, "Medium", 70);
+    text(monthly, value, 226, y, 12, C.text, "Regular", 80, "RIGHT");
+    text(monthly, pct, 322, y, 12, C.secondary, "Regular", 40, "RIGHT");
+  });
+  card(monthly, 24, 764, 345, 52, 12);
+  text(monthly, "May note", 76, 776, 14, C.text, "Medium", 120);
+  text(monthly, "Optional note for future review", 76, 798, 11, C.secondary, "Regular", 180);
+  nav(monthly, "Dashboard");
+
+  const settings = screen("Settings", 2144);
+  top(settings, "Settings", "Local-first controls", []);
+  text(settings, "ⓘ", 342, 76, 20, C.secondary, "Regular", 24, "CENTER");
+  function settingCard(y, title, lines, height = 106) {
+    card(settings, 24, y, 345, height);
+    iconCircle(settings, 40, y + 20, "neutral", 34);
+    text(settings, title, 92, y + 22, 16, C.text, "Semi Bold", 180);
+    lines.forEach(([label, color], i) => text(settings, label, 92, y + 48 + i * 22, 12, color || C.secondary, "Regular", 225));
+  }
+  settingCard(128, "Privacy", [["Data stays on this device"], ["●  Local storage: Active", C.positive], ["No account  •  No cloud sync  •  No analytics"]], 126);
+  settingCard(268, "Value masking", [["Hide amounts on screen and in app switcher."], ["Masked preview   ₹••,••,•••"]], 106);
+  settingCard(388, "Quotes", [["Live quote refresh     Every 15 min"], ["Last refresh     3 May 2026, 10:15 AM"], ["Provider status     Available", C.positive]], 126);
+  settingCard(528, "Currency", [["Base currency     INR"], ["Foreign assets converted for summary     On"], ["USD & crypto prices: manual fallback     On"]], 126);
+  settingCard(668, "Display & App info", [["Density     Standard (V1)"], ["Minimal Mode     V2 locked", C.muted], ["App version 1.0.0 · Build preview"]], 126);
+  card(settings, 24, 794, 345, 38, 10, C.bg).strokes = [paint(C.negative, 0.55)];
+  text(settings, "Clear local data", 52, 804, 12, C.negative, "Medium", 150);
+  text(settings, "Deletes all local data", 208, 804, 10, C.muted, "Regular", 130, "RIGHT");
+  nav(settings, "Settings");
+
+  figma.viewport.scrollAndZoomIntoView([dashboard, holdings, addHolding, cash, monthly, settings]);
+  figma.closePlugin("Created CogVest issue #69 V1 editable screens.");
+}
+
+main().catch((error) => {
+  figma.closePlugin(`CogVest screen generation failed: ${error.message}`);
+});

--- a/docs/design/figma/issue-69-v1-screens/code.js
+++ b/docs/design/figma/issue-69-v1-screens/code.js
@@ -25,12 +25,15 @@ async function main() {
   };
 
   const PAGE_NAME = "Issue 69 - V1 UI Concepts";
-  const existing = figma.root.children.find((page) => page.name === PAGE_NAME);
-  if (existing) existing.remove();
-
-  const page = figma.createPage();
-  page.name = PAGE_NAME;
+  let page = figma.root.children.find((item) => item.name === PAGE_NAME);
+  if (!page) {
+    page = figma.createPage();
+    page.name = PAGE_NAME;
+  }
   await figma.setCurrentPageAsync(page);
+  for (const child of [...page.children]) {
+    child.remove();
+  }
 
   function rgb(hex) {
     const h = hex.replace("#", "");

--- a/docs/design/figma/issue-69-v1-screens/manifest.json
+++ b/docs/design/figma/issue-69-v1-screens/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "CogVest Issue 69 V1 Screens",
+  "id": "cogvest-issue-69-v1-screens",
+  "api": "1.0.0",
+  "main": "code.js",
+  "editorType": ["figma"]
+}

--- a/docs/design/issue-69-ui-screens/README.md
+++ b/docs/design/issue-69-ui-screens/README.md
@@ -22,5 +22,7 @@ long-term investing.
 - Review these images one screen at a time before moving approved designs into
   Figma.
 - Treat the images as visual direction, not implementation-ready specs.
+- Prefer the editable Figma plugin in
+  `docs/design/figma/issue-69-v1-screens/` for stable future iteration.
 - Preserve the V1 non-goals: no spreadsheet grid UI, no Minimal Mode, no LTCG
   UI, no import/export, no cloud sync, and no trading-terminal patterns.

--- a/e2e/add-trade.yaml
+++ b/e2e/add-trade.yaml
@@ -2,8 +2,7 @@ appId: com.abdulshaikh.cogvest
 ---
 - launchApp:
     clearState: true
-- tapOn:
-    id: "tab-add"
+- openLink: "cogvest:///add-holding"
 - assertVisible:
     id: "add-holding-screen"
 - tapOn:

--- a/e2e/add-trade.yaml
+++ b/e2e/add-trade.yaml
@@ -3,9 +3,9 @@ appId: com.abdulshaikh.cogvest
 - launchApp:
     clearState: true
 - tapOn:
-    id: "add-trade-tab"
+    id: "tab-add"
 - assertVisible:
-    id: "add-trade-screen"
+    id: "add-holding-screen"
 - tapOn:
     id: "asset-input"
 - inputText: "Reliance Industries"
@@ -26,11 +26,11 @@ appId: com.abdulshaikh.cogvest
     id: "conviction-4"
 - tapOn:
     id: "review-trade-button"
-- assertVisible: "Review buy"
+- assertVisible: "Derived preview"
 - scrollUntilVisible:
     element:
       id: "save-trade-button"
     direction: DOWN
 - tapOn:
     id: "save-trade-button"
-- assertVisible: "Trade logged."
+- assertVisible: "Holding saved."

--- a/e2e/cash.yaml
+++ b/e2e/cash.yaml
@@ -3,7 +3,7 @@ appId: com.abdulshaikh.cogvest
 - launchApp:
     clearState: true
 - tapOn:
-    id: "cash-tab"
+    id: "tab-cash"
 - assertVisible:
     id: "cash-screen"
 - tapOn:

--- a/e2e/holdings.yaml
+++ b/e2e/holdings.yaml
@@ -2,8 +2,7 @@ appId: com.abdulshaikh.cogvest
 ---
 - launchApp:
     clearState: true
-- tapOn:
-    id: "tab-add"
+- openLink: "cogvest:///add-holding"
 - tapOn:
     id: "asset-input"
 - inputText: "Reliance Industries"

--- a/e2e/holdings.yaml
+++ b/e2e/holdings.yaml
@@ -3,7 +3,7 @@ appId: com.abdulshaikh.cogvest
 - launchApp:
     clearState: true
 - tapOn:
-    id: "add-trade-tab"
+    id: "tab-add"
 - tapOn:
     id: "asset-input"
 - inputText: "Reliance Industries"
@@ -26,7 +26,7 @@ appId: com.abdulshaikh.cogvest
     direction: DOWN
 - tapOn:
     id: "review-trade-button"
-- assertVisible: "Review buy"
+- assertVisible: "Derived preview"
 - scrollUntilVisible:
     element:
       id: "save-trade-button"
@@ -34,7 +34,7 @@ appId: com.abdulshaikh.cogvest
 - tapOn:
     id: "save-trade-button"
 - tapOn:
-    id: "holdings-tab"
+    id: "tab-holdings"
 - assertVisible:
     id: "holdings-screen"
 - assertVisible: "Reliance Industries"

--- a/e2e/navigation.yaml
+++ b/e2e/navigation.yaml
@@ -8,11 +8,9 @@ appId: com.abdulshaikh.cogvest
 - assertVisible:
     id: "holdings-screen"
 - tapOn:
-    id: "tab-add"
+    id: "tab-progress"
 - assertVisible:
-    id: "add-trade-screen"
-- assertVisible:
-    id: "add-holding-screen"
+    id: "progress-screen"
 - tapOn:
     id: "tab-cash"
 - assertVisible:
@@ -21,3 +19,8 @@ appId: com.abdulshaikh.cogvest
     id: "tab-settings"
 - assertVisible:
     id: "settings-screen"
+- openLink: "cogvest:///add-holding"
+- assertVisible:
+    id: "add-trade-screen"
+- assertVisible:
+    id: "add-holding-screen"

--- a/e2e/navigation.yaml
+++ b/e2e/navigation.yaml
@@ -1,0 +1,23 @@
+appId: com.abdulshaikh.cogvest
+---
+- launchApp
+- assertVisible:
+    id: "dashboard-screen"
+- tapOn:
+    id: "tab-holdings"
+- assertVisible:
+    id: "holdings-screen"
+- tapOn:
+    id: "tab-add"
+- assertVisible:
+    id: "add-trade-screen"
+- assertVisible:
+    id: "add-holding-screen"
+- tapOn:
+    id: "tab-cash"
+- assertVisible:
+    id: "cash-screen"
+- tapOn:
+    id: "tab-settings"
+- assertVisible:
+    id: "settings-screen"

--- a/e2e/persistence.yaml
+++ b/e2e/persistence.yaml
@@ -3,7 +3,7 @@ appId: com.abdulshaikh.cogvest
 - launchApp:
     clearState: true
 - tapOn:
-    id: "cash-tab"
+    id: "tab-cash"
 - tapOn:
     id: "cash-amount-input"
 - inputText: "1000"
@@ -20,5 +20,5 @@ appId: com.abdulshaikh.cogvest
 - stopApp
 - launchApp
 - tapOn:
-    id: "cash-tab"
+    id: "tab-cash"
 - assertVisible: "Broker cash"

--- a/e2e/smoke-launch.yaml
+++ b/e2e/smoke-launch.yaml
@@ -6,5 +6,5 @@ appId: com.abdulshaikh.cogvest
     id: "dashboard-screen"
 - assertVisible: "Dashboard"
 - assertVisible: "Holdings"
-- assertVisible: "Add"
+- assertVisible: "Progress"
 - assertNotVisible: "Unmatched Route"

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,11 @@
 import "@testing-library/jest-native/extend-expect";
+
+jest.mock("@expo/vector-icons", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
+
+  return {
+    Ionicons: ({ name }: { name: string }) =>
+      React.createElement(Text, { accessibilityElementsHidden: true }, name),
+  };
+});

--- a/scripts/maestro-run.mjs
+++ b/scripts/maestro-run.mjs
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 const defaultFlows = [
   "e2e/smoke-launch.yaml",
+  "e2e/navigation.yaml",
   "e2e/add-trade.yaml",
   "e2e/holdings.yaml",
   "e2e/cash.yaml",

--- a/src/components/cards/CashEntryRow.tsx
+++ b/src/components/cards/CashEntryRow.tsx
@@ -1,8 +1,8 @@
 import { StyleSheet, View } from "react-native";
 
-import { AppText, MaskedValue } from "@/src/components/common";
+import { AppText, MaskedValue, PremiumCard } from "@/src/components/common";
 import { formatDate, formatINR } from "@/src/domain/formatters";
-import { colors, radii, shadows, spacing } from "@/src/theme";
+import { colors, spacing } from "@/src/theme";
 import type { CashEntry } from "@/src/types";
 
 type CashEntryRowProps = {
@@ -20,7 +20,7 @@ export function CashEntryRow({ entry, masked = false }: CashEntryRowProps) {
   const isAddition = entry.type === "addition";
 
   return (
-    <View style={styles.row}>
+    <PremiumCard style={styles.row}>
       <View style={styles.details}>
         <AppText weight="bold">{entry.label}</AppText>
         <AppText color="secondary" variant="caption">
@@ -38,7 +38,7 @@ export function CashEntryRow({ entry, masked = false }: CashEntryRowProps) {
         value={formatCashAmount(entry)}
         weight="bold"
       />
-    </View>
+    </PremiumCard>
   );
 }
 
@@ -51,12 +51,7 @@ const styles = StyleSheet.create({
     gap: spacing.xs,
   },
   row: {
-    ...shadows.none,
     alignItems: "center",
-    backgroundColor: colors.surface.card,
-    borderColor: colors.border.subtle,
-    borderRadius: radii.card,
-    borderWidth: 1,
     flexDirection: "row",
     gap: spacing.cardInner,
     justifyContent: "space-between",

--- a/src/components/cards/HoldingCard.tsx
+++ b/src/components/cards/HoldingCard.tsx
@@ -1,12 +1,14 @@
 import { StyleSheet, View } from "react-native";
 
+import { CategoryIcon, PremiumCard, assetClassLabel } from "@/src/components/common";
 import { formatDate, formatINR, formatPercentage } from "@/src/domain/formatters";
-import { colors, radii, shadows, spacing } from "@/src/theme";
+import { colors, spacing } from "@/src/theme";
 import type { Holding } from "@/src/types";
 
 import { AppText, MaskedValue } from "../common";
 
 type HoldingCardProps = {
+  allocationPct?: number;
   holding: Holding;
   masked?: boolean;
 };
@@ -21,17 +23,27 @@ function formatPnLAmount(holding: Holding) {
   return `${holding.unrealisedPnL > 0 ? "+" : ""}${amount}`;
 }
 
-export function HoldingCard({ holding, masked = false }: HoldingCardProps) {
+export function HoldingCard({
+  allocationPct,
+  holding,
+  masked = false,
+}: HoldingCardProps) {
   const isProfit = holding.unrealisedPnL >= 0;
 
   return (
-    <View style={styles.card}>
+    <PremiumCard style={styles.card}>
       <View style={styles.header}>
+        <CategoryIcon assetClass={holding.asset.assetClass} />
         <View style={styles.identity}>
-          <AppText variant="title" weight="bold">
+          <AppText weight="bold">
             {holding.asset.name}
           </AppText>
-          <AppText color="secondary">{holding.asset.symbol}</AppText>
+          <AppText color="secondary" variant="caption">
+            {holding.asset.symbol}
+          </AppText>
+          <AppText color="secondary" variant="caption">
+            {assetClassLabel(holding.asset.assetClass)}
+          </AppText>
         </View>
         <View style={styles.valueBlock}>
           <MaskedValue
@@ -66,6 +78,11 @@ export function HoldingCard({ holding, masked = false }: HoldingCardProps) {
         <AppText color="secondary">
           Current {formatINR(holding.currentPrice)}
         </AppText>
+        {allocationPct !== undefined ? (
+          <AppText color="secondary">
+            Allocation {formatPercentage(allocationPct).replace("+", "")}
+          </AppText>
+        ) : null}
       </View>
 
       <AppText color="muted" variant="caption">
@@ -73,21 +90,16 @@ export function HoldingCard({ holding, masked = false }: HoldingCardProps) {
           ? `Updated ${formatDate(holding.lastUpdated)}`
           : "Quote not refreshed yet"}
       </AppText>
-    </View>
+    </PremiumCard>
   );
 }
 
 const styles = StyleSheet.create({
   card: {
-    ...shadows.none,
-    backgroundColor: colors.surface.card,
-    borderColor: colors.border.subtle,
-    borderRadius: radii.card,
-    borderWidth: 1,
     gap: spacing.cardInner,
-    padding: spacing.md,
   },
   header: {
+    alignItems: "flex-start",
     flexDirection: "row",
     gap: spacing.cardInner,
     justifyContent: "space-between",

--- a/src/components/common/AppButton.tsx
+++ b/src/components/common/AppButton.tsx
@@ -91,7 +91,5 @@ const styles = StyleSheet.create({
   },
   secondary: {
     backgroundColor: colors.surface.elevated,
-    borderColor: colors.border.subtle,
-    borderWidth: 1,
   },
 });

--- a/src/components/common/AppText.tsx
+++ b/src/components/common/AppText.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, Text } from "react-native";
 
 import { colors, typography } from "@/src/theme";
 
-type TextVariant = "caption" | "body" | "title" | "hero";
+type TextVariant = "caption" | "body" | "title" | "largeTitle" | "hero";
 type TextColor = keyof typeof colors.text | "primary";
 
 export type AppTextProps = TextProps & {
@@ -57,7 +57,11 @@ const styles = StyleSheet.create({
   },
   hero: {
     fontSize: typography.sizes.hero,
-    lineHeight: 40,
+    lineHeight: 50,
+  },
+  largeTitle: {
+    fontSize: typography.sizes.largeTitle,
+    lineHeight: 38,
   },
   title: {
     fontSize: typography.sizes.title,

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, View } from "react-native";
 
-import { colors, radii, shadows, spacing } from "@/src/theme";
+import { colors, radii, spacing } from "@/src/theme";
 
 import { AppButton } from "./AppButton";
 import { AppText } from "./AppText";
@@ -37,12 +37,9 @@ export function EmptyState({
 
 const styles = StyleSheet.create({
   card: {
-    ...shadows.none,
     alignItems: "center",
     backgroundColor: colors.surface.card,
-    borderColor: colors.border.subtle,
     borderRadius: radii.card,
-    borderWidth: 1,
     gap: spacing.cardInner,
     padding: spacing.md,
   },

--- a/src/components/common/Premium.tsx
+++ b/src/components/common/Premium.tsx
@@ -1,0 +1,354 @@
+import { Ionicons } from "@expo/vector-icons";
+import type { ReactNode } from "react";
+import {
+  Pressable,
+  StyleSheet,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native";
+
+import { colors, interaction, radii, spacing } from "@/src/theme";
+import type { AssetClass } from "@/src/types";
+
+import { AppText } from "./AppText";
+import { MaskedValue } from "./MaskedValue";
+
+type PremiumCardProps = {
+  children: ReactNode;
+  elevated?: boolean;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+};
+
+type ScreenHeaderProps = {
+  action?: ReactNode;
+  subtitle: string;
+  title: string;
+};
+
+type Metric = {
+  color?: "primary" | "secondary";
+  label: string;
+  masked?: boolean;
+  value: string;
+};
+
+type MetricGroupProps = {
+  metrics: Metric[];
+  testID?: string;
+};
+
+type GroupedListRowProps = {
+  destructive?: boolean;
+  icon?: keyof typeof Ionicons.glyphMap;
+  meta?: string;
+  onPress?: () => void;
+  testID?: string;
+  title: string;
+  value?: string;
+};
+
+const assetClassConfig: Record<
+  AssetClass | "neutral",
+  { color: string; icon: keyof typeof Ionicons.glyphMap; label: string }
+> = {
+  cash: { color: colors.cashBlue, icon: "wallet-outline", label: "Cash" },
+  crypto: { color: colors.cryptoAmber, icon: "logo-bitcoin", label: "Crypto" },
+  etf: { color: colors.blue, icon: "shield-outline", label: "Debt" },
+  neutral: { color: colors.text.secondary, icon: "analytics-outline", label: "Info" },
+  stock: { color: colors.primary, icon: "trending-up-outline", label: "Equity" },
+};
+
+export function PremiumCard({
+  children,
+  elevated = false,
+  style,
+  testID,
+}: PremiumCardProps) {
+  return (
+    <View
+      style={[styles.card, elevated && styles.elevatedCard, style]}
+      testID={testID}
+    >
+      {children}
+    </View>
+  );
+}
+
+export function ScreenHeader({ action, subtitle, title }: ScreenHeaderProps) {
+  return (
+    <View style={styles.header}>
+      <View style={styles.headerCopy}>
+        <AppText variant="largeTitle" weight="bold">
+          {title}
+        </AppText>
+        <AppText color="secondary">{subtitle}</AppText>
+      </View>
+      {action ? <View style={styles.headerAction}>{action}</View> : null}
+    </View>
+  );
+}
+
+export function IconButton({
+  accessibilityLabel,
+  icon,
+  onPress,
+  testID,
+}: {
+  accessibilityLabel: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  onPress?: () => void;
+  testID?: string;
+}) {
+  return (
+    <Pressable
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      onPress={onPress}
+      style={({ pressed }) => [styles.iconButton, pressed && styles.pressed]}
+      testID={testID}
+    >
+      <Ionicons color={colors.text.primary} name={icon} size={20} />
+    </Pressable>
+  );
+}
+
+export function HeroMetric({
+  label,
+  masked,
+  subValue,
+  subValueTone = "positive",
+  value,
+}: {
+  label: string;
+  masked?: boolean;
+  subValue?: string;
+  subValueTone?: "positive" | "negative" | "secondary";
+  value: string;
+}) {
+  const toneStyle =
+    subValueTone === "positive"
+      ? styles.positiveText
+      : subValueTone === "negative"
+        ? styles.negativeText
+        : styles.secondaryText;
+
+  return (
+    <PremiumCard elevated style={styles.heroCard}>
+      <AppText color="secondary">{label}</AppText>
+      <MaskedValue masked={masked} value={value} variant="hero" weight="bold" />
+      {subValue ? (
+        <View style={styles.metricPill}>
+          <AppText style={toneStyle} variant="caption" weight="bold">
+            {subValue}
+          </AppText>
+        </View>
+      ) : null}
+    </PremiumCard>
+  );
+}
+
+export function MetricGroup({ metrics, testID }: MetricGroupProps) {
+  return (
+    <PremiumCard style={styles.metricGroup} testID={testID}>
+      {metrics.map((metric, index) => (
+        <View key={metric.label} style={styles.metricCell}>
+          <AppText color="secondary" variant="caption">
+            {metric.label}
+          </AppText>
+          <MaskedValue
+            color={metric.color ?? "primary"}
+            masked={metric.masked}
+            value={metric.value}
+            weight="bold"
+          />
+          {index < metrics.length - 1 ? <View style={styles.metricDivider} /> : null}
+        </View>
+      ))}
+    </PremiumCard>
+  );
+}
+
+export function SectionHeader({
+  actionLabel,
+  title,
+}: {
+  actionLabel?: string;
+  title: string;
+}) {
+  return (
+    <View style={styles.sectionHeader}>
+      <AppText variant="title" weight="bold">
+        {title}
+      </AppText>
+      {actionLabel ? (
+        <AppText style={styles.brandText} variant="caption" weight="bold">
+          {actionLabel}
+        </AppText>
+      ) : null}
+    </View>
+  );
+}
+
+export function CategoryIcon({
+  assetClass = "neutral",
+  size = 22,
+}: {
+  assetClass?: AssetClass | "neutral";
+  size?: number;
+}) {
+  const config = assetClassConfig[assetClass];
+
+  return <Ionicons color={config.color} name={config.icon} size={size} />;
+}
+
+export function assetClassLabel(assetClass: AssetClass) {
+  return assetClassConfig[assetClass].label;
+}
+
+export function GroupedListRow({
+  destructive = false,
+  icon,
+  meta,
+  onPress,
+  testID,
+  title,
+  value,
+}: GroupedListRowProps) {
+  const content = (
+    <>
+      {icon ? (
+        <Ionicons
+          color={destructive ? colors.loss : colors.text.secondary}
+          name={icon}
+          size={20}
+        />
+      ) : null}
+      <View style={styles.groupedCopy}>
+        <AppText style={destructive && styles.negativeText} weight="bold">
+          {title}
+        </AppText>
+        {meta ? (
+          <AppText color="secondary" variant="caption">
+            {meta}
+          </AppText>
+        ) : null}
+      </View>
+      {value ? (
+        <AppText color="secondary" variant="caption" weight="medium">
+          {value}
+        </AppText>
+      ) : null}
+    </>
+  );
+
+  if (onPress) {
+    return (
+      <Pressable
+        accessibilityRole="button"
+        onPress={onPress}
+        style={({ pressed }) => [styles.groupedRow, pressed && styles.pressed]}
+        testID={testID}
+      >
+        {content}
+      </Pressable>
+    );
+  }
+
+  return (
+    <View style={styles.groupedRow} testID={testID}>
+      {content}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  brandText: {
+    color: colors.primary,
+  },
+  card: {
+    backgroundColor: colors.surface.card,
+    borderRadius: radii.card,
+    gap: spacing.cardInner,
+    padding: spacing.md,
+  },
+  elevatedCard: {
+    backgroundColor: colors.surface.elevated,
+  },
+  groupedCopy: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  groupedRow: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: spacing.cardInner,
+    minHeight: 64,
+  },
+  header: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: spacing.md,
+    justifyContent: "space-between",
+  },
+  headerAction: {
+    flexDirection: "row",
+    gap: spacing.sm,
+  },
+  headerCopy: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  heroCard: {
+    gap: spacing.sm,
+  },
+  iconButton: {
+    alignItems: "center",
+    backgroundColor: colors.surface.elevated,
+    borderRadius: 14,
+    height: 42,
+    justifyContent: "center",
+    width: 42,
+  },
+  metricCell: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  metricDivider: {
+    backgroundColor: colors.border.subtle,
+    bottom: spacing.xs,
+    position: "absolute",
+    right: spacing.xs * -1,
+    top: spacing.xs,
+    width: StyleSheet.hairlineWidth,
+  },
+  metricGroup: {
+    flexDirection: "row",
+    gap: spacing.md,
+  },
+  metricPill: {
+    alignSelf: "flex-start",
+    backgroundColor: "rgba(52,199,89,0.12)",
+    borderRadius: radii.pill,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+  },
+  negativeText: {
+    color: colors.loss,
+  },
+  positiveText: {
+    color: colors.profit,
+  },
+  pressed: {
+    opacity: interaction.pressedOpacity,
+  },
+  secondaryText: {
+    color: colors.text.secondary,
+  },
+  sectionHeader: {
+    alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+});

--- a/src/components/common/ScreenContainer.tsx
+++ b/src/components/common/ScreenContainer.tsx
@@ -58,6 +58,7 @@ const styles = StyleSheet.create({
   },
   scrollContent: {
     flexGrow: 1,
+    paddingBottom: spacing.xl,
     paddingHorizontal: spacing.screenHorizontal,
   },
 });

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -3,5 +3,16 @@ export { AppButton } from "./AppButton";
 export { AppText } from "./AppText";
 export { EmptyState } from "./EmptyState";
 export { MASKED_INR_VALUE, MaskedValue } from "./MaskedValue";
+export {
+  assetClassLabel,
+  CategoryIcon,
+  GroupedListRow,
+  HeroMetric,
+  IconButton,
+  MetricGroup,
+  PremiumCard,
+  ScreenHeader,
+  SectionHeader,
+} from "./Premium";
 export { PlaceholderScreen } from "./PlaceholderScreen";
 export { ScreenContainer } from "./ScreenContainer";

--- a/src/components/forms/FormTextField.tsx
+++ b/src/components/forms/FormTextField.tsx
@@ -56,9 +56,7 @@ const styles = StyleSheet.create({
   },
   input: {
     backgroundColor: colors.surface.elevated,
-    borderColor: colors.border.subtle,
     borderRadius: radii.card,
-    borderWidth: 1,
     color: colors.text.primary,
     minHeight: 48,
     paddingHorizontal: spacing.cardInner,

--- a/src/features/cash/CashScreen.tsx
+++ b/src/features/cash/CashScreen.tsx
@@ -7,8 +7,13 @@ import {
   AppButton,
   AppText,
   EmptyState,
+  HeroMetric,
+  MetricGroup,
   MaskedValue,
+  PremiumCard,
   ScreenContainer,
+  ScreenHeader,
+  SectionHeader,
 } from "@/src/components/common";
 import { FormTextField } from "@/src/components/forms";
 import { formatINR } from "@/src/domain/formatters";
@@ -101,16 +106,33 @@ export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
   return (
     <ScreenContainer scroll testID="cash-screen">
       <View style={styles.content}>
-        <View style={styles.heroCard}>
-          <AppText color="secondary">Cash balance</AppText>
-          <MaskedValue
-            masked={maskWealthValues}
-            selectable
-            value={formatINR(balance)}
-            variant="hero"
-            weight="bold"
-          />
-        </View>
+        <ScreenHeader title="Cash Ledger" subtitle="Manual ledger • local only" />
+
+        <HeroMetric
+          label="Cash balance"
+          masked={maskWealthValues}
+          value={formatINR(balance)}
+          subValue="Included in total allocation"
+          subValueTone="secondary"
+        />
+
+        <MetricGroup
+          metrics={[
+            {
+              label: "Entries",
+              value: entries.length.toString(),
+            },
+            {
+              label: "Available",
+              masked: maskWealthValues,
+              value: formatINR(balance),
+            },
+            {
+              label: "Savings",
+              value: "Not enough data",
+            },
+          ]}
+        />
 
         <View style={styles.segmentedControl}>
           {(["addition", "withdrawal"] as const).map((entryType) => (
@@ -131,16 +153,14 @@ export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
                 color={type === entryType ? "inverse" : "secondary"}
                 weight="bold"
               >
-                {entryType === "addition" ? "Add Cash" : "Withdraw"}
+                {entryType === "addition" ? "Deposit" : "Withdraw"}
               </AppText>
             </Pressable>
           ))}
         </View>
 
-        <View style={styles.card}>
-          <AppText variant="body" weight="bold">
-            Cash entry
-          </AppText>
+        <PremiumCard>
+          <SectionHeader title="Add cash entry" />
           <FormTextField
             error={errors.amount}
             keyboardType="decimal-pad"
@@ -178,7 +198,7 @@ export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
             testID="save-cash-entry-button"
             onPress={submit}
           />
-        </View>
+        </PremiumCard>
 
         {entries.length === 0 ? (
           <EmptyState
@@ -187,9 +207,7 @@ export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
           />
         ) : (
           <View style={styles.history}>
-            <AppText variant="title" weight="bold">
-              Cash history
-            </AppText>
+            <SectionHeader title="Recent cash ledger" />
             {entries.map((entry) => (
               <CashEntryRow
                 entry={entry}
@@ -205,26 +223,10 @@ export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
 }
 
 const styles = StyleSheet.create({
-  card: {
-    backgroundColor: colors.surface.card,
-    borderColor: colors.border.subtle,
-    borderRadius: radii.card,
-    borderWidth: 1,
-    gap: spacing.cardInner,
-    padding: spacing.md,
-  },
   content: {
     gap: spacing.cardGap,
     paddingBottom: spacing.lg,
     paddingTop: spacing.md,
-  },
-  heroCard: {
-    backgroundColor: colors.surface.elevated,
-    borderColor: colors.border.subtle,
-    borderRadius: radii.card,
-    borderWidth: 1,
-    gap: spacing.cardInner,
-    padding: spacing.md,
   },
   history: {
     gap: spacing.cardGap,
@@ -243,9 +245,7 @@ const styles = StyleSheet.create({
   },
   segmentedControl: {
     backgroundColor: colors.surface.card,
-    borderColor: colors.border.subtle,
     borderRadius: radii.pill,
-    borderWidth: 1,
     flexDirection: "row",
     padding: spacing.xs,
   },

--- a/src/features/cash/__tests__/CashScreen.test.tsx
+++ b/src/features/cash/__tests__/CashScreen.test.tsx
@@ -9,21 +9,21 @@ describe("CashScreen", () => {
   it("shows an empty cash state with zero balance", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
 
-    const { getByTestId, getByText } = render(<CashScreen store={store} />);
+    const { getAllByText, getByTestId, getByText } = render(<CashScreen store={store} />);
 
     expect(getByTestId("cash-screen")).toBeTruthy();
     expect(getByTestId("cash-amount-input")).toBeTruthy();
     expect(getByTestId("cash-label-input")).toBeTruthy();
     expect(getByTestId("cash-date-input")).toBeTruthy();
     expect(getByTestId("save-cash-entry-button")).toBeTruthy();
-    expect(getByText("₹0.00")).toBeTruthy();
+    expect(getAllByText("₹0.00").length).toBeGreaterThan(0);
     expect(getByText("No cash entries yet")).toBeTruthy();
     expect(getByText("Add available broker or bank cash to include it in portfolio value.")).toBeTruthy();
   });
 
   it("adds and withdraws cash and shows history rows", async () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
-    const { getByLabelText, getByText } = render(<CashScreen store={store} />);
+    const { getAllByText, getByLabelText, getByText } = render(<CashScreen store={store} />);
 
     fireEvent.changeText(getByLabelText("Amount"), "1000");
     fireEvent.changeText(getByLabelText("Label"), "Broker cash");
@@ -31,7 +31,7 @@ describe("CashScreen", () => {
     fireEvent.press(getByText("Save Cash Entry"));
 
     await waitFor(() => {
-      expect(getByText("₹1,000.00")).toBeTruthy();
+      expect(getAllByText("₹1,000.00").length).toBeGreaterThan(0);
       expect(getByText("Broker cash")).toBeTruthy();
       expect(getByText("+₹1,000.00")).toBeTruthy();
     });
@@ -43,7 +43,7 @@ describe("CashScreen", () => {
     fireEvent.press(getByText("Save Cash Entry"));
 
     await waitFor(() => {
-      expect(getByText("₹750.00")).toBeTruthy();
+      expect(getAllByText("₹750.00").length).toBeGreaterThan(0);
       expect(getByText("Emergency withdrawal")).toBeTruthy();
       expect(getByText("-₹250.00")).toBeTruthy();
     });

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -5,13 +5,20 @@ import {
   AppButton,
   AppText,
   EmptyState,
+  HeroMetric,
+  IconButton,
+  MetricGroup,
   MaskedValue,
+  PremiumCard,
   ScreenContainer,
+  ScreenHeader,
+  SectionHeader,
+  assetClassLabel,
+  CategoryIcon,
 } from "@/src/components/common";
 import { formatDate, formatINR, formatPercentage } from "@/src/domain/formatters";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
-import { colors, radii, shadows, spacing } from "@/src/theme";
-import type { AssetClass } from "@/src/types";
+import { spacing } from "@/src/theme";
 
 import { useDashboard } from "./useDashboard";
 
@@ -20,17 +27,14 @@ type DashboardScreenProps = {
   store?: StoreApi<PortfolioStoreState>;
 };
 
-const assetClassLabels: Record<AssetClass, string> = {
-  cash: "Cash",
-  crypto: "Crypto",
-  etf: "ETF",
-  stock: "Stock",
-};
-
 function formatSignedINR(value: number) {
   const amount = formatINR(value);
 
   return value > 0 ? `+${amount}` : amount;
+}
+
+function formatUnsignedPercentage(value: number) {
+  return formatPercentage(value).replace("+", "");
 }
 
 export function DashboardScreen({
@@ -40,59 +44,93 @@ export function DashboardScreen({
   const dashboard = useDashboard({ store });
   const hasAllocation = dashboard.allocation.length > 0;
   const dayChangeAmount = formatSignedINR(dashboard.dayChange.absolute);
+  const totalInvested = dashboard.holdings.reduce(
+    (total, holding) => total + holding.totalInvested,
+    0,
+  );
+  const totalPnL = dashboard.holdings.reduce(
+    (total, holding) => total + holding.unrealisedPnL,
+    0,
+  );
+  const totalPnLPct = totalInvested === 0 ? 0 : (totalPnL / totalInvested) * 100;
 
   return (
     <ScreenContainer scroll testID="dashboard-screen">
       <View style={styles.content}>
-        <View style={styles.heroCard}>
-          <AppText color="secondary">Portfolio value</AppText>
-          <MaskedValue
-            masked={dashboard.maskWealthValues}
-            value={formatINR(dashboard.totalValue)}
-            variant="hero"
-            weight="bold"
+        <ScreenHeader
+          title="Dashboard"
+          subtitle="Local portfolio • latest snapshot"
+          action={
+            <>
+              <IconButton accessibilityLabel="Toggle value visibility" icon="eye-outline" />
+              <IconButton accessibilityLabel="Refresh quotes" icon="refresh-outline" />
+            </>
+          }
+        />
+
+        <HeroMetric
+          label="Portfolio Value"
+          masked={dashboard.maskWealthValues}
+          value={formatINR(dashboard.totalValue)}
+          subValue={`${dayChangeAmount} (${formatPercentage(
+            dashboard.dayChange.percentage,
+          )}) today`}
+          subValueTone={dashboard.dayChange.absolute >= 0 ? "positive" : "negative"}
+        />
+
+        <MetricGroup
+          metrics={[
+            {
+              label: "Invested",
+              masked: dashboard.maskWealthValues,
+              value: formatINR(totalInvested),
+            },
+            {
+              color: totalPnL >= 0 ? "primary" : "primary",
+              label: "P&L",
+              masked: dashboard.maskWealthValues,
+              value: formatSignedINR(totalPnL),
+            },
+            {
+              label: "P&L %",
+              value: formatPercentage(totalPnLPct),
+            },
+          ]}
+        />
+
+        {onAddTrade && hasAllocation ? (
+          <AppButton
+            title="Add Trade"
+            testID="add-trade-button"
+            onPress={onAddTrade}
           />
-          <View style={styles.dayChangeLine}>
-            <MaskedValue
-              masked={dashboard.maskWealthValues}
-              style={dashboard.dayChange.absolute >= 0 ? styles.profit : styles.loss}
-              value={dayChangeAmount}
-            />
-            <AppText
-              color="primary"
-              style={dashboard.dayChange.absolute >= 0 ? styles.profit : styles.loss}
-            >
-              ({formatPercentage(dashboard.dayChange.percentage)}) today
-            </AppText>
-          </View>
-          {onAddTrade && hasAllocation ? (
-            <AppButton
-              title="Add Trade"
-              testID="add-trade-button"
-              onPress={onAddTrade}
-            />
-          ) : null}
-        </View>
+        ) : null}
 
         {hasAllocation ? (
-          <View style={styles.card}>
-            <AppText variant="title" weight="bold">
-              Allocation
-            </AppText>
+          <PremiumCard>
+            <SectionHeader title="Allocation" actionLabel="View details" />
             {dashboard.allocation.map((item) => (
               <View key={item.assetClass} style={styles.allocationRow}>
-                <View style={styles.allocationLabel}>
-                  <AppText>{assetClassLabels[item.assetClass]}</AppText>
-                  <MaskedValue
-                    color="secondary"
-                    masked={dashboard.maskWealthValues}
-                    value={formatINR(item.value)}
-                  />
+                <View style={styles.allocationIdentity}>
+                  <CategoryIcon assetClass={item.assetClass} />
+                  <View style={styles.allocationCopy}>
+                    <AppText weight="bold">
+                      {assetClassLabel(item.assetClass)}
+                    </AppText>
+                    <MaskedValue
+                      color="secondary"
+                      masked={dashboard.maskWealthValues}
+                      value={formatINR(item.value)}
+                      variant="caption"
+                    />
+                  </View>
                 </View>
-                <AppText weight="bold">{formatPercentage(item.percentage).replace("+", "")}</AppText>
+                <AppText weight="bold">
+                  {formatUnsignedPercentage(item.percentage)}
+                </AppText>
               </View>
             ))}
-          </View>
+          </PremiumCard>
         ) : (
           <EmptyState
             actionLabel={onAddTrade ? "Add Trade" : undefined}
@@ -103,77 +141,76 @@ export function DashboardScreen({
           />
         )}
 
-        <View style={styles.card}>
-          <AppText variant="title" weight="bold">
-            Quote freshness
-          </AppText>
+        <PremiumCard>
+          <SectionHeader title="This Month" />
+          <MetricGroup
+            metrics={[
+              {
+                label: "Invested",
+                masked: dashboard.maskWealthValues,
+                value: formatINR(totalInvested),
+              },
+              {
+                label: "Cash balance",
+                masked: dashboard.maskWealthValues,
+                value: formatINR(dashboard.cashBalance),
+              },
+              {
+                label: "Holdings",
+                value: dashboard.holdings.length.toString(),
+              },
+            ]}
+          />
+        </PremiumCard>
+
+        <PremiumCard>
+          <SectionHeader title="Quote Status" />
           <AppText color="secondary">
             {dashboard.latestQuoteAsOf
               ? `Quotes updated ${formatDate(dashboard.latestQuoteAsOf)}`
               : "Quotes will appear after your first priced holding."}
           </AppText>
-        </View>
+        </PremiumCard>
 
-        <View style={styles.card}>
-          <AppText variant="title" weight="bold">
-            {dashboard.convictionReadiness.isReady
-              ? "Conviction data ready"
-              : "Conviction data needs more trades"}
-          </AppText>
+        <PremiumCard>
+          <SectionHeader
+            title={
+              dashboard.convictionReadiness.isReady
+                ? "Conviction data ready"
+                : "Conviction data needs more trades"
+            }
+          />
           <AppText color="secondary">
             {dashboard.convictionReadiness.ratedTradeCount} of{" "}
             {dashboard.convictionReadiness.requiredTradeCount} trades rated. Keep
             conviction optional, but useful.
           </AppText>
-        </View>
+        </PremiumCard>
+
       </View>
     </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
-  allocationLabel: {
+  allocationCopy: {
     flex: 1,
     gap: spacing.xs,
+  },
+  allocationIdentity: {
+    alignItems: "center",
+    flex: 1,
+    flexDirection: "row",
+    gap: spacing.cardInner,
   },
   allocationRow: {
     alignItems: "center",
     flexDirection: "row",
-    gap: spacing.cardInner,
     justifyContent: "space-between",
-  },
-  card: {
-    ...shadows.none,
-    backgroundColor: colors.surface.card,
-    borderColor: colors.border.subtle,
-    borderRadius: radii.card,
-    borderWidth: 1,
-    gap: spacing.cardInner,
-    padding: spacing.md,
   },
   content: {
     gap: spacing.cardGap,
     paddingBottom: spacing.lg,
     paddingTop: spacing.md,
-  },
-  dayChangeLine: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: spacing.xs,
-  },
-  heroCard: {
-    ...shadows.none,
-    backgroundColor: colors.surface.elevated,
-    borderColor: colors.border.subtle,
-    borderRadius: radii.card,
-    borderWidth: 1,
-    gap: spacing.cardInner,
-    padding: spacing.md,
-  },
-  loss: {
-    color: colors.loss,
-  },
-  profit: {
-    color: colors.profit,
   },
 });

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -100,7 +100,7 @@ export function DashboardScreen({
 
         {onAddTrade && hasAllocation ? (
           <AppButton
-            title="Add Trade"
+            title="Add Holding"
             testID="add-trade-button"
             onPress={onAddTrade}
           />
@@ -133,9 +133,9 @@ export function DashboardScreen({
           </PremiumCard>
         ) : (
           <EmptyState
-            actionLabel={onAddTrade ? "Add Trade" : undefined}
+            actionLabel={onAddTrade ? "Add Holding" : undefined}
             actionTestID="add-trade-button"
-            message="Add your first trade to build holdings automatically."
+            message="Add your first portfolio entry to build holdings automatically."
             title="No allocation yet"
             onAction={onAddTrade}
           />

--- a/src/features/dashboard/__tests__/DashboardScreen.test.tsx
+++ b/src/features/dashboard/__tests__/DashboardScreen.test.tsx
@@ -71,9 +71,8 @@ describe("DashboardScreen", () => {
     const { getByText, queryByText } = render(<DashboardScreen store={store} />);
 
     expect(getByText("₹350.00")).toBeTruthy();
-    expect(getByText("+₹27.27")).toBeTruthy();
-    expect(getByText("(+10.00%) today")).toBeTruthy();
-    expect(getByText("Stock")).toBeTruthy();
+    expect(getByText("+₹27.27 (+10.00%) today")).toBeTruthy();
+    expect(getByText("Equity")).toBeTruthy();
     expect(getByText("85.71%")).toBeTruthy();
     expect(getByText("Cash")).toBeTruthy();
     expect(getByText("14.29%")).toBeTruthy();

--- a/src/features/dashboard/__tests__/DashboardScreen.test.tsx
+++ b/src/features/dashboard/__tests__/DashboardScreen.test.tsx
@@ -27,7 +27,7 @@ const buyTrade: Trade = {
 };
 
 describe("DashboardScreen", () => {
-  it("shows the empty dashboard with a zero total and Add Trade action", () => {
+  it("shows the empty dashboard with a zero total and Add Holding action", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     const onAddTrade = jest.fn();
 
@@ -40,10 +40,10 @@ describe("DashboardScreen", () => {
     expect(getAllByText("₹0.00").length).toBeGreaterThan(0);
     expect(getByText("No allocation yet")).toBeTruthy();
     expect(
-      getByText("Add your first trade to build holdings automatically."),
+      getByText("Add your first portfolio entry to build holdings automatically."),
     ).toBeTruthy();
 
-    fireEvent.press(getByText("Add Trade"));
+    fireEvent.press(getByText("Add Holding"));
 
     expect(onAddTrade).toHaveBeenCalledTimes(1);
   });

--- a/src/features/holdings/HoldingsScreen.tsx
+++ b/src/features/holdings/HoldingsScreen.tsx
@@ -2,7 +2,17 @@ import { RefreshControl, StyleSheet, View } from "react-native";
 import type { StoreApi } from "zustand/vanilla";
 
 import { HoldingCard } from "@/src/components/cards";
-import { AppButton, AppText, EmptyState, ScreenContainer } from "@/src/components/common";
+import {
+  AppButton,
+  AppText,
+  EmptyState,
+  IconButton,
+  MetricGroup,
+  PremiumCard,
+  ScreenContainer,
+  ScreenHeader,
+} from "@/src/components/common";
+import { formatINR } from "@/src/domain/formatters";
 import type { RefreshQuotesInput, QuoteRefreshResult } from "@/src/services/quotes";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
 import { colors, spacing } from "@/src/theme";
@@ -28,6 +38,14 @@ export function HoldingsScreen({
     refreshQuotes,
     store,
   });
+  const totalCurrentValue = holdings.reduce(
+    (total, holding) => total + holding.currentValue,
+    0,
+  );
+  const totalInvested = holdings.reduce(
+    (total, holding) => total + holding.totalInvested,
+    0,
+  );
 
   return (
     <ScreenContainer
@@ -46,13 +64,40 @@ export function HoldingsScreen({
       testID="holdings-screen"
     >
       <View style={styles.content}>
-        <View style={styles.header}>
-          <View>
-            <AppText color="secondary">Portfolio</AppText>
-            <AppText variant="hero" weight="bold">
-              Holdings
-            </AppText>
-          </View>
+        <ScreenHeader
+          title="Holdings"
+          subtitle={`${holdings.length} positions • local data`}
+          action={
+            <>
+              <IconButton accessibilityLabel="Search holdings" icon="search-outline" />
+              <IconButton accessibilityLabel="Toggle value visibility" icon="eye-outline" />
+            </>
+          }
+        />
+
+        {holdings.length > 0 ? (
+          <MetricGroup
+            metrics={[
+              {
+                label: "Current",
+                masked: maskWealthValues,
+                value: formatINR(totalCurrentValue),
+              },
+              {
+                label: "Invested",
+                masked: maskWealthValues,
+                value: formatINR(totalInvested),
+              },
+              {
+                label: "P&L",
+                masked: maskWealthValues,
+                value: formatINR(totalCurrentValue - totalInvested),
+              },
+            ]}
+          />
+        ) : null}
+
+        <View style={styles.actionRow}>
           {holdings.length > 0 ? (
             <AppButton
               title="Refresh Quotes"
@@ -64,6 +109,20 @@ export function HoldingsScreen({
           ) : null}
         </View>
 
+        <View style={styles.filters}>
+          {["All", "Equity", "Debt", "Crypto", "Cash"].map((label, index) => (
+            <View key={label} style={[styles.filterChip, index === 0 && styles.filterChipActive]}>
+              <AppText
+                color={index === 0 ? "inverse" : "secondary"}
+                variant="caption"
+                weight="bold"
+              >
+                {label}
+              </AppText>
+            </View>
+          ))}
+        </View>
+
         {holdings.length === 0 ? (
           <EmptyState
             actionLabel={onAddTrade ? "Add Trade" : undefined}
@@ -73,18 +132,20 @@ export function HoldingsScreen({
             onAction={onAddTrade}
           />
         ) : (
-          <View
-            style={styles.list}
-            testID="holdings-list"
-          >
+          <PremiumCard style={styles.list} testID="holdings-list">
             {holdings.map((holding) => (
               <HoldingCard
                 key={holding.asset.id}
+                allocationPct={
+                  totalCurrentValue === 0
+                    ? 0
+                    : (holding.currentValue / totalCurrentValue) * 100
+                }
                 holding={holding}
                 masked={maskWealthValues}
               />
             ))}
-          </View>
+          </PremiumCard>
         )}
 
         {failures.length > 0 ? (
@@ -103,13 +164,25 @@ const styles = StyleSheet.create({
     paddingBottom: spacing.lg,
     paddingTop: spacing.md,
   },
-  header: {
-    alignItems: "flex-start",
+  actionRow: {
     flexDirection: "row",
-    gap: spacing.cardInner,
-    justifyContent: "space-between",
+  },
+  filters: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.sm,
+  },
+  filterChip: {
+    backgroundColor: colors.surface.elevated,
+    borderRadius: 999,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  filterChipActive: {
+    backgroundColor: colors.primary,
   },
   list: {
-    gap: spacing.cardGap,
+    gap: spacing.sm,
+    padding: spacing.sm,
   },
 });

--- a/src/features/holdings/HoldingsScreen.tsx
+++ b/src/features/holdings/HoldingsScreen.tsx
@@ -125,9 +125,9 @@ export function HoldingsScreen({
 
         {holdings.length === 0 ? (
           <EmptyState
-            actionLabel={onAddTrade ? "Add Trade" : undefined}
+            actionLabel={onAddTrade ? "Add Holding" : undefined}
             actionTestID="add-trade-button"
-            message="Holdings are created automatically from your trades."
+            message="Holdings are created automatically from your portfolio entries."
             title="No holdings yet"
             onAction={onAddTrade}
           />

--- a/src/features/holdings/__tests__/HoldingsScreen.test.tsx
+++ b/src/features/holdings/__tests__/HoldingsScreen.test.tsx
@@ -28,7 +28,7 @@ const buyTrade: Trade = {
 };
 
 describe("HoldingsScreen", () => {
-  it("shows an empty state with an Add Trade action", () => {
+  it("shows an empty state with an Add Holding action", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     const onAddTrade = jest.fn();
 
@@ -40,10 +40,10 @@ describe("HoldingsScreen", () => {
     expect(getByTestId("add-trade-button")).toBeTruthy();
     expect(getByText("No holdings yet")).toBeTruthy();
     expect(
-      getByText("Holdings are created automatically from your trades."),
+      getByText("Holdings are created automatically from your portfolio entries."),
     ).toBeTruthy();
 
-    fireEvent.press(getByText("Add Trade"));
+    fireEvent.press(getByText("Add Holding"));
 
     expect(onAddTrade).toHaveBeenCalledTimes(1);
   });

--- a/src/features/holdings/__tests__/HoldingsScreen.test.tsx
+++ b/src/features/holdings/__tests__/HoldingsScreen.test.tsx
@@ -60,13 +60,13 @@ describe("HoldingsScreen", () => {
       source: "yahoo",
     });
 
-    const { getByText, queryByText } = render(<HoldingsScreen store={store} />);
+    const { getAllByText, getByText, queryByText } = render(<HoldingsScreen store={store} />);
 
     expect(getByText("Reliance Industries")).toBeTruthy();
     expect(getByText("RELIANCE")).toBeTruthy();
     expect(getByText("Qty 2")).toBeTruthy();
     expect(getByText("Avg ₹100.00")).toBeTruthy();
-    expect(getByText("₹250.00")).toBeTruthy();
+    expect(getAllByText("₹250.00").length).toBeGreaterThan(0);
     expect(getByText("+₹50.00")).toBeTruthy();
     expect(getByText("+25.00%")).toBeTruthy();
     expect(getByText("Updated 20 Apr 2026")).toBeTruthy();
@@ -99,14 +99,14 @@ describe("HoldingsScreen", () => {
         },
       });
 
-    const { getByText } = render(
+    const { getAllByText, getByText } = render(
       <HoldingsScreen store={store} refreshQuotes={refreshQuotes} />,
     );
 
     fireEvent.press(getByText("Refresh Quotes"));
 
     await waitFor(() => {
-      expect(getByText("₹300.00")).toBeTruthy();
+      expect(getAllByText("₹300.00").length).toBeGreaterThan(0);
       expect(getByText("Updated 21 Apr 2026")).toBeTruthy();
     });
   });

--- a/src/features/progress/ProgressScreen.tsx
+++ b/src/features/progress/ProgressScreen.tsx
@@ -1,0 +1,187 @@
+import { useSyncExternalStore } from "react";
+import { StyleSheet, View } from "react-native";
+import type { StoreApi } from "zustand/vanilla";
+
+import {
+  AppText,
+  CategoryIcon,
+  EmptyState,
+  MetricGroup,
+  PremiumCard,
+  ScreenContainer,
+  ScreenHeader,
+  SectionHeader,
+  assetClassLabel,
+} from "@/src/components/common";
+import {
+  calculateAllocation,
+  calculateCashBalance,
+  calculateHoldings,
+  calculatePortfolioTotal,
+} from "@/src/domain/calculations";
+import { formatINR, formatPercentage } from "@/src/domain/formatters";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import { colors, spacing } from "@/src/theme";
+
+type ProgressScreenProps = {
+  store?: StoreApi<PortfolioStoreState>;
+};
+
+function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
+  return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+}
+
+function getMonthLabel(date = new Date()) {
+  return new Intl.DateTimeFormat("en-IN", {
+    month: "long",
+    year: "numeric",
+  }).format(date);
+}
+
+function isCurrentMonth(isoDate: string, now = new Date()) {
+  const date = new Date(isoDate);
+
+  return (
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth()
+  );
+}
+
+export function ProgressScreen({
+  store = getPortfolioStore(),
+}: ProgressScreenProps) {
+  const snapshot = usePortfolioSnapshot(store);
+  const holdings = calculateHoldings({
+    assets: snapshot.assets,
+    quoteCache: snapshot.quoteCache,
+    trades: snapshot.trades,
+  });
+  const cashBalance = calculateCashBalance(snapshot.cashEntries);
+  const portfolioValue = calculatePortfolioTotal(holdings, snapshot.cashEntries);
+  const totalInvested = holdings.reduce(
+    (total, holding) => total + holding.totalInvested,
+    0,
+  );
+  const monthlyInvestment = snapshot.trades
+    .filter((trade) => trade.type === "buy" && isCurrentMonth(trade.date))
+    .reduce((total, trade) => total + trade.totalValue, 0);
+  const monthlyCashAdded = snapshot.cashEntries
+    .filter((entry) => entry.type === "addition" && isCurrentMonth(entry.date))
+    .reduce((total, entry) => total + entry.amount, 0);
+  const savingsRate =
+    monthlyCashAdded === 0 ? 0 : (monthlyInvestment / monthlyCashAdded) * 100;
+  const allocation = calculateAllocation({ cashBalance, holdings });
+  const hasData = holdings.length > 0 || snapshot.cashEntries.length > 0;
+
+  return (
+    <ScreenContainer scroll testID="progress-screen">
+      <View style={styles.content}>
+        <ScreenHeader title="Monthly Progress" subtitle={getMonthLabel()} />
+
+        {hasData ? (
+          <>
+            <MetricGroup
+              metrics={[
+                {
+                  label: "Portfolio",
+                  masked: snapshot.preferences.maskWealthValues,
+                  value: formatINR(portfolioValue),
+                },
+                {
+                  label: "Invested",
+                  masked: snapshot.preferences.maskWealthValues,
+                  value: formatINR(totalInvested),
+                },
+                {
+                  label: "Cash",
+                  masked: snapshot.preferences.maskWealthValues,
+                  value: formatINR(cashBalance),
+                },
+                {
+                  label: "Savings",
+                  value: monthlyCashAdded === 0 ? "Not enough data" : formatPercentage(savingsRate),
+                },
+              ]}
+            />
+
+            <PremiumCard>
+              <SectionHeader title="What changed this month?" />
+              <AppText color="secondary">
+                Monthly investment: {formatINR(monthlyInvestment)}
+              </AppText>
+              <AppText color="secondary">
+                Cash added: {formatINR(monthlyCashAdded)}
+              </AppText>
+              <AppText color="secondary">
+                Expense rate needs explicit expense tracking and is not shown in V1.
+              </AppText>
+            </PremiumCard>
+
+            <PremiumCard>
+              <SectionHeader title="Progression (last 6 months)" />
+              <View style={styles.chartPlaceholder}>
+                <AppText color="secondary" align="center">
+                  Historical chart appears after monthly snapshots are recorded.
+                </AppText>
+              </View>
+            </PremiumCard>
+
+            <PremiumCard>
+              <SectionHeader title="Asset class snapshot" />
+              {allocation.map((item) => (
+                <View key={item.assetClass} style={styles.assetRow}>
+                  <View style={styles.assetIdentity}>
+                    <CategoryIcon assetClass={item.assetClass} />
+                    <AppText weight="bold">{assetClassLabel(item.assetClass)}</AppText>
+                  </View>
+                  <View style={styles.assetValue}>
+                    <AppText>{formatINR(item.value)}</AppText>
+                    <AppText color="secondary" variant="caption">
+                      {formatPercentage(item.percentage).replace("+", "")}
+                    </AppText>
+                  </View>
+                </View>
+              ))}
+            </PremiumCard>
+          </>
+        ) : (
+          <EmptyState
+            title="No monthly progress yet"
+            message="Add holdings and cash entries to build a monthly snapshot without opening Excel."
+          />
+        )}
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  assetIdentity: {
+    alignItems: "center",
+    flex: 1,
+    flexDirection: "row",
+    gap: spacing.cardInner,
+  },
+  assetRow: {
+    alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  assetValue: {
+    alignItems: "flex-end",
+    gap: spacing.xs,
+  },
+  chartPlaceholder: {
+    alignItems: "center",
+    backgroundColor: colors.surface.elevated,
+    borderRadius: 18,
+    justifyContent: "center",
+    minHeight: 120,
+    padding: spacing.md,
+  },
+  content: {
+    gap: spacing.cardGap,
+    paddingBottom: spacing.lg,
+    paddingTop: spacing.md,
+  },
+});

--- a/src/features/progress/ProgressScreen.tsx
+++ b/src/features/progress/ProgressScreen.tsx
@@ -118,10 +118,10 @@ export function ProgressScreen({
             </PremiumCard>
 
             <PremiumCard>
-              <SectionHeader title="Progression (last 6 months)" />
+              <SectionHeader title="Progress trend" />
               <View style={styles.chartPlaceholder}>
                 <AppText color="secondary" align="center">
-                  Historical chart appears after monthly snapshots are recorded.
+                  Trend appears after monthly records are available.
                 </AppText>
               </View>
             </PremiumCard>
@@ -147,7 +147,7 @@ export function ProgressScreen({
         ) : (
           <EmptyState
             title="No monthly progress yet"
-            message="Add holdings and cash entries to build a monthly snapshot without opening Excel."
+            message="Add holdings and cash entries to build monthly progress context without opening Excel."
           />
         )}
       </View>

--- a/src/features/progress/index.ts
+++ b/src/features/progress/index.ts
@@ -1,0 +1,1 @@
+export { ProgressScreen } from "./ProgressScreen";

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -109,7 +109,6 @@ export function SettingsScreen({
         <PremiumCard>
           <SectionHeader title="Display & App Info" />
           <GroupedListRow title="Density" value="Standard (V1)" />
-          <GroupedListRow title="Minimal Mode" value="V2 locked" />
           <GroupedListRow title="App version 1.0.0" value="Preview" />
         </PremiumCard>
 

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -2,9 +2,16 @@ import * as Haptics from "expo-haptics";
 import { Pressable, StyleSheet, View } from "react-native";
 import type { StoreApi } from "zustand/vanilla";
 
-import { AppText, ScreenContainer } from "@/src/components/common";
+import {
+  AppText,
+  GroupedListRow,
+  PremiumCard,
+  ScreenContainer,
+  ScreenHeader,
+  SectionHeader,
+} from "@/src/components/common";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
-import { colors, interaction, radii, shadows, spacing } from "@/src/theme";
+import { colors, interaction, radii, spacing } from "@/src/theme";
 
 import { useSettings } from "./useSettings";
 
@@ -25,12 +32,7 @@ export function SettingsScreen({
   return (
     <ScreenContainer scroll testID="settings-screen">
       <View style={styles.content}>
-        <View style={styles.header}>
-          <AppText color="secondary">Privacy and app controls</AppText>
-          <AppText variant="hero" weight="bold">
-            Settings
-          </AppText>
-        </View>
+        <ScreenHeader title="Settings" subtitle="Local-first controls" />
 
         <Pressable
           accessibilityLabel="Toggle value masking"
@@ -47,7 +49,7 @@ export function SettingsScreen({
           testID="value-mask-toggle"
         >
           <View style={styles.toggleCopy}>
-            <AppText variant="title" weight="bold">
+            <AppText weight="bold">
               Value masking
             </AppText>
             <AppText color="secondary">
@@ -67,38 +69,59 @@ export function SettingsScreen({
           </View>
         </Pressable>
 
-        <View style={styles.card}>
-          <AppText weight="bold">
-            {maskWealthValues ? "Values masked" : "Values visible"}
-          </AppText>
-          <AppText color="secondary">
-            This preference is stored locally on this device.
-          </AppText>
-        </View>
+        <PremiumCard>
+          <SectionHeader title="Privacy" />
+          <GroupedListRow
+            icon="lock-closed-outline"
+            title="Local-first privacy"
+            meta="No backend, auth, analytics, or cloud sync is enabled in V1."
+            value="Active"
+          />
+          <GroupedListRow
+            icon="phone-portrait-outline"
+            title={maskWealthValues ? "Values masked" : "Values visible"}
+            meta="This preference is stored locally on this device."
+          />
+        </PremiumCard>
 
-        <View style={styles.card}>
-          <AppText variant="title" weight="bold">
-            Local-first privacy
-          </AppText>
-          <AppText color="secondary">
-            CogVest keeps portfolio data on-device. No backend, auth, analytics,
-            or cloud sync is enabled in V1.
-          </AppText>
-        </View>
+        <PremiumCard>
+          <SectionHeader title="Quotes" />
+          <GroupedListRow
+            icon="refresh-outline"
+            title="Quote refresh"
+            meta="Dashboard and Holdings refresh current quotes on demand."
+            value="Manual fallback"
+          />
+          <GroupedListRow
+            icon="cloud-offline-outline"
+            title="Provider fallback"
+            meta="Manual prices remain available when quote APIs fail."
+          />
+        </PremiumCard>
 
-        <View style={styles.card}>
-          <AppText variant="title" weight="bold">
-            Quote refresh
-          </AppText>
-          <AppText color="secondary">
-            Dashboard and Holdings refresh current quotes on demand. Manual
-            prices remain available when quote APIs fail.
-          </AppText>
-        </View>
+        <PremiumCard>
+          <SectionHeader title="Currency" />
+          <GroupedListRow title="Base currency" value="INR" />
+          <GroupedListRow title="Foreign asset summary" value="On" />
+          <GroupedListRow title="USD & crypto fallback" value="On" />
+        </PremiumCard>
 
-        <View style={styles.card}>
-          <AppText color="secondary">App version 1.0.0</AppText>
-        </View>
+        <PremiumCard>
+          <SectionHeader title="Display & App Info" />
+          <GroupedListRow title="Density" value="Standard (V1)" />
+          <GroupedListRow title="Minimal Mode" value="V2 locked" />
+          <GroupedListRow title="App version 1.0.0" value="Preview" />
+        </PremiumCard>
+
+        <PremiumCard>
+          <SectionHeader title="Data" />
+          <GroupedListRow
+            destructive
+            icon="trash-outline"
+            title="Clear local data"
+            meta="Destructive action. Keep disabled until implemented."
+          />
+        </PremiumCard>
       </View>
     </ScreenContainer>
   );
@@ -106,11 +129,8 @@ export function SettingsScreen({
 
 const styles = StyleSheet.create({
   card: {
-    ...shadows.none,
     backgroundColor: colors.surface.card,
-    borderColor: colors.border.subtle,
     borderRadius: radii.card,
-    borderWidth: 1,
     gap: spacing.cardInner,
     padding: spacing.md,
   },
@@ -118,9 +138,6 @@ const styles = StyleSheet.create({
     gap: spacing.cardGap,
     paddingBottom: spacing.lg,
     paddingTop: spacing.md,
-  },
-  header: {
-    gap: spacing.xs,
   },
   pressed: {
     opacity: interaction.pressedOpacity,
@@ -139,9 +156,7 @@ const styles = StyleSheet.create({
   },
   switchTrack: {
     backgroundColor: colors.surface.elevated,
-    borderColor: colors.border.subtle,
     borderRadius: radii.pill,
-    borderWidth: 1,
     justifyContent: "center",
     padding: 3,
     width: 48,

--- a/src/features/settings/__tests__/SettingsScreen.test.tsx
+++ b/src/features/settings/__tests__/SettingsScreen.test.tsx
@@ -14,9 +14,9 @@ describe("SettingsScreen", () => {
     jest.clearAllMocks();
   });
 
-  it("shows privacy settings and toggles value masking", () => {
+  it("shows privacy settings without V2 settings leaks and toggles value masking", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
-    const { getByLabelText, getByTestId, getByText } = render(
+    const { getByLabelText, getByTestId, getByText, queryByText } = render(
       <SettingsScreen store={store} />,
     );
 
@@ -26,6 +26,7 @@ describe("SettingsScreen", () => {
     expect(getByText("Values visible")).toBeTruthy();
     expect(getByText("Local-first privacy")).toBeTruthy();
     expect(getByText("App version 1.0.0")).toBeTruthy();
+    expect(queryByText(/Minimal Mode/i)).toBeNull();
 
     fireEvent.press(getByLabelText("Toggle value masking"));
 

--- a/src/features/trades/__tests__/AddTradeForm.test.tsx
+++ b/src/features/trades/__tests__/AddTradeForm.test.tsx
@@ -68,11 +68,11 @@ describe("AddTradeForm", () => {
     fireEvent.press(getByTestId("conviction-4"));
     fireEvent.changeText(getByLabelText("Note"), "Core portfolio add");
 
-    fireEvent.press(getByText("Review Trade"));
-    expect(getByText("Review buy")).toBeTruthy();
+    fireEvent.press(getByText("Review Holding"));
+    expect(getByText("Derived preview")).toBeTruthy();
     expect(getByText("Total: ₹205.00")).toBeTruthy();
 
-    fireEvent.press(getByText("Confirm Trade"));
+    fireEvent.press(getByText("Save Holding"));
 
     await waitFor(() => {
       expect(store.getState().assets).toHaveLength(1);
@@ -99,7 +99,7 @@ describe("AddTradeForm", () => {
       source: "manual",
     });
     expect(Haptics.notificationAsync).toHaveBeenCalledWith("success");
-    expect(getByText("Trade logged.")).toBeTruthy();
+    expect(getByText("Holding saved.")).toBeTruthy();
   });
 
   it("shows an actionable error for invalid sell quantity", () => {
@@ -114,7 +114,7 @@ describe("AddTradeForm", () => {
     fireEvent.changeText(getByLabelText("Quantity"), "2");
     fireEvent.changeText(getByLabelText("Price per unit"), "100");
     fireEvent.changeText(getByLabelText("Trade date"), "2026-04-20");
-    fireEvent.press(getByText("Review Trade"));
+    fireEvent.press(getByText("Review Holding"));
 
     expect(getByText("Sell quantity exceeds available units.")).toBeTruthy();
     expect(store.getState().trades).toEqual([existingBuy]);

--- a/src/features/trades/add-trade-form.tsx
+++ b/src/features/trades/add-trade-form.tsx
@@ -196,7 +196,7 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
       <View testID="add-holding-screen">
         <ScreenHeader
           title="Add Holding"
-          subtitle="Opening position • local only"
+          subtitle="Portfolio entry • local only"
         />
       </View>
 

--- a/src/features/trades/add-trade-form.tsx
+++ b/src/features/trades/add-trade-form.tsx
@@ -3,7 +3,14 @@ import { useMemo, useState, useSyncExternalStore } from "react";
 import { Pressable, StyleSheet, View } from "react-native";
 import type { StoreApi } from "zustand/vanilla";
 
-import { AppButton, AppText, ScreenContainer } from "@/src/components/common";
+import {
+  AppButton,
+  AppText,
+  PremiumCard,
+  ScreenContainer,
+  ScreenHeader,
+  SectionHeader,
+} from "@/src/components/common";
 import { FormTextField } from "@/src/components/forms";
 import { validateTradeForm } from "@/src/features/trades/tradeForm";
 import { colors, interaction, radii, spacing } from "@/src/theme";
@@ -180,19 +187,17 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
       source: "manual",
     });
     await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-    setSuccessMessage("Trade logged.");
+    setSuccessMessage("Holding saved.");
     setReviewTrade(undefined);
   }
 
   return (
     <ScreenContainer scroll testID="add-trade-screen">
-      <View style={styles.header}>
-        <AppText variant="title" weight="bold">
-          Add Trade
-        </AppText>
-        <AppText color="secondary">
-          Log a buy or sell in under a minute. Holdings stay local.
-        </AppText>
+      <View testID="add-holding-screen">
+        <ScreenHeader
+          title="Add Holding"
+          subtitle="Opening position • local only"
+        />
       </View>
 
       <View style={styles.segmentedControl}>
@@ -218,7 +223,7 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
       </View>
 
       {snapshot.assets.length > 0 ? (
-        <View style={styles.card}>
+        <PremiumCard>
           <AppText color="secondary" variant="caption" weight="medium">
             Existing assets
           </AppText>
@@ -240,13 +245,11 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
               </Pressable>
             ))}
           </View>
-        </View>
+        </PremiumCard>
       ) : null}
 
-      <View style={styles.card}>
-        <AppText variant="body" weight="bold">
-          Asset
-        </AppText>
+      <PremiumCard>
+        <SectionHeader title="Asset" />
         <FormTextField
           error={errors.assetName}
           label="Asset name"
@@ -289,12 +292,10 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
             />
           </View>
         </View>
-      </View>
+      </PremiumCard>
 
-      <View style={styles.card}>
-        <AppText variant="body" weight="bold">
-          Trade details
-        </AppText>
+      <PremiumCard>
+        <SectionHeader title="Position Details" />
         <View style={styles.row}>
           <View style={styles.flex}>
             <FormTextField
@@ -404,12 +405,12 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
           placeholder="Optional note"
           value={notes}
         />
-      </View>
+      </PremiumCard>
 
       {reviewTrade && reviewAsset ? (
-        <View style={styles.reviewCard}>
+        <PremiumCard elevated>
           <AppText variant="body" weight="bold">
-            Review {reviewTrade.type}
+            Derived preview
           </AppText>
           <AppText color="secondary">
             {reviewAsset.symbol} · {reviewTrade.quantity} units @ ₹
@@ -418,7 +419,7 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
           <AppText selectable weight="bold">
             Total: ₹{reviewTrade.totalValue.toFixed(2)}
           </AppText>
-        </View>
+        </PremiumCard>
       ) : null}
 
       {successMessage ? (
@@ -429,14 +430,14 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
 
       <View style={styles.actions}>
         <AppButton
-          title="Review Trade"
+          title="Review Holding"
           testID="review-trade-button"
           onPress={handleReview}
         />
         <AppButton
           disabled={!reviewTrade}
           testID="save-trade-button"
-          title="Confirm Trade"
+          title="Save Holding"
           onPress={handleConfirm}
           variant="secondary"
         />
@@ -452,42 +453,29 @@ const styles = StyleSheet.create({
   },
   assetChip: {
     backgroundColor: colors.surface.elevated,
-    borderColor: colors.border.subtle,
     borderRadius: radii.card,
-    borderWidth: 1,
     gap: spacing.xs,
     padding: spacing.cardInner,
     width: "48%",
   },
   assetChipActive: {
-    borderColor: colors.primary,
+    backgroundColor: colors.deepGreen,
   },
   assetGrid: {
     flexDirection: "row",
     flexWrap: "wrap",
     gap: spacing.sm,
   },
-  card: {
-    backgroundColor: colors.surface.card,
-    borderColor: colors.border.subtle,
-    borderRadius: radii.card,
-    borderWidth: 1,
-    gap: spacing.cardInner,
-    padding: spacing.cardInner,
-  },
   convictionChip: {
     alignItems: "center",
     backgroundColor: colors.surface.elevated,
-    borderColor: colors.border.subtle,
     borderRadius: radii.pill,
-    borderWidth: 1,
     flex: 1,
     justifyContent: "center",
     minHeight: 44,
   },
   convictionChipActive: {
     backgroundColor: colors.primary,
-    borderColor: colors.primary,
   },
   convictionGroup: {
     gap: spacing.xs,
@@ -508,14 +496,6 @@ const styles = StyleSheet.create({
   pressed: {
     opacity: interaction.pressedOpacity,
   },
-  reviewCard: {
-    backgroundColor: colors.surface.elevated,
-    borderColor: colors.primary,
-    borderRadius: radii.card,
-    borderWidth: 1,
-    gap: spacing.xs,
-    padding: spacing.cardInner,
-  },
   row: {
     flexDirection: "row",
     gap: spacing.sm,
@@ -531,9 +511,7 @@ const styles = StyleSheet.create({
   },
   segmentedControl: {
     backgroundColor: colors.surface.card,
-    borderColor: colors.border.subtle,
     borderRadius: radii.pill,
-    borderWidth: 1,
     flexDirection: "row",
     padding: spacing.xs,
   },

--- a/src/theme/__tests__/theme.test.ts
+++ b/src/theme/__tests__/theme.test.ts
@@ -1,21 +1,22 @@
 import { colors, radii, spacing } from "@/src/theme";
 
 describe("theme tokens", () => {
-  it("matches the V1 CogVest dark palette", () => {
-    expect(colors.background).toBe("#1C1B1F");
-    expect(colors.surface.card).toBe("#2A2930");
-    expect(colors.surface.elevated).toBe("#312F36");
+  it("matches the V1 premium true-dark palette", () => {
+    expect(colors.background).toBe("#000000");
+    expect(colors.surface.card).toBe("#1C1C1E");
+    expect(colors.surface.elevated).toBe("#2C2C2E");
     expect(colors.primary).toBe("#2E7D52");
-    expect(colors.text.primary).toBe("#E6E1E5");
-    expect(colors.text.secondary).toBe("#CAC4D0");
-    expect(colors.border.subtle).toBe("rgba(255,255,255,0.08)");
+    expect(colors.profit).toBe("#34C759");
+    expect(colors.text.primary).toBe("#FFFFFF");
+    expect(colors.text.secondary).toBe("#8E8E93");
+    expect(colors.border.subtle).toBe("rgba(255,255,255,0.10)");
   });
 
   it("captures the V1 spacing and radius rules", () => {
     expect(spacing.screenHorizontal).toBe(16);
-    expect(spacing.cardGap).toBe(10);
-    expect(spacing.cardInner).toBe(12);
-    expect(radii.card).toBe(12);
+    expect(spacing.cardGap).toBe(14);
+    expect(spacing.cardInner).toBe(16);
+    expect(radii.card).toBe(20);
     expect(radii.button).toBe(16);
   });
 });

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,20 +1,26 @@
 export {};
 export const colors = {
-  background: "#1C1B1F",
+  background: "#000000",
+  blue: "#0A84FF",
+  cashBlue: "#64D2FF",
+  cryptoAmber: "#FFD60A",
+  deepGreen: "#0E6B4F",
   primary: "#2E7D52",
-  profit: "#4CAF7A",
-  loss: "#D65A5A",
+  profit: "#34C759",
+  loss: "#FF453A",
+  warning: "#FF9F0A",
   border: {
-    subtle: "rgba(255,255,255,0.08)",
+    subtle: "rgba(255,255,255,0.10)",
+    strong: "#38383A",
   },
   surface: {
-    card: "#2A2930",
-    elevated: "#312F36",
+    card: "#1C1C1E",
+    elevated: "#2C2C2E",
   },
   text: {
-    primary: "#E6E1E5",
-    secondary: "#CAC4D0",
-    muted: "#938F99",
+    primary: "#FFFFFF",
+    secondary: "#8E8E93",
+    muted: "#48484A",
     inverse: "#FFFFFF",
   },
 } as const;
@@ -22,8 +28,8 @@ export const colors = {
 export const spacing = {
   xs: 4,
   sm: 8,
-  cardGap: 10,
-  cardInner: 12,
+  cardGap: 14,
+  cardInner: 16,
   md: 16,
   lg: 24,
   xl: 32,
@@ -31,9 +37,10 @@ export const spacing = {
 } as const;
 
 export const radii = {
-  sm: 8,
-  card: 12,
+  sm: 10,
+  card: 20,
   button: 16,
+  sheet: 24,
   pill: 999,
 } as const;
 
@@ -42,7 +49,8 @@ export const typography = {
     caption: 12,
     body: 16,
     title: 20,
-    hero: 32,
+    largeTitle: 32,
+    hero: 42,
   },
   weights: {
     regular: "400",


### PR DESCRIPTION
## Summary
- Keep the deterministic Figma V1 screen generator fixes from the earlier issue #69 work
- Redesign V1 app screens into the premium true-dark UI direction: Dashboard, Holdings, Add Holding, Cash Ledger, Monthly Progress, and Settings
- Add shared premium UI primitives, true-dark theme tokens, Settings/Progress routes, updated tab testIDs, and refreshed Maestro flows

## Verification
- npm run typecheck
- npm test
- npm run doctor
- npm run android:smoke -- --strict
- npm run maestro:check
- npm run maestro:test -- e2e/navigation.yaml
- git diff --check

Refs #60. Follow-up for #69; issue #69 is already closed by the previously merged PR.
