### PR TITLE
docs: add CogVest housekeeping review

### DIFF
--- a/docs/housekeeping/code-review-findings.md
+++ b/docs/housekeeping/code-review-findings.md
@@ -1,0 +1,93 @@
+# CogVest Code Review Findings
+
+Date: 2026-05-06
+
+Review mode: current-state review against V1 MVP, issue #60 Excel parity, and
+Android PC verification requirements.
+
+## Findings
+
+### Critical: Android release APK touch navigation blocks E2E
+
+- Evidence: `npm run maestro:test` fails in `e2e/navigation.yaml` after tapping
+  `tab-holdings`; `holdings-screen` never becomes visible.
+- Existing issue: #72.
+- Impact: PC-only E2E cannot prove core manual flows. V1 dev-complete should
+  remain blocked.
+- Likely area to inspect first: `app/(tabs)/_layout.tsx`, tab route naming,
+  release APK navigation behavior, and any overlays/touch handling around
+  `ScreenContainer`.
+
+### Important: Asset metadata is too narrow for Excel parity
+
+- Evidence: `src/types/asset.ts` defines `AssetClass` as
+  `crypto | stock | etf | cash`.
+- Evidence: `src/features/trades/add-trade-form.tsx` manual asset creation
+  defaults every new asset to `assetClass: "stock"`, `currency: "INR"`, and
+  `exchange: "NSE"`.
+- Impact: #62 cannot close. The app cannot capture instrument type, sector type,
+  quote source identifier, or user-selected category without code changes.
+
+### Important: Debt is not first-class
+
+- Evidence: `src/types/asset.ts` has no `debt` asset class.
+- Evidence: `src/components/common/Premium.tsx` labels `etf` as `Debt`, which
+  conflates ETF/funds with debt instruments.
+- Impact: #63 and the #60 equity/debt/crypto/cash gate remain incomplete.
+
+### Important: Monthly Progress is derived-current-month only
+
+- Evidence: `src/features/progress/ProgressScreen.tsx` computes current-month
+  investment and cash from trades/cash entries.
+- Missing: persisted monthly snapshot model, salary/income, expense rate, monthly
+  gain/gain percentage, editable monthly records.
+- Impact: #65 is not complete and the Excel `Progression` sheet is not yet
+  replaced.
+
+### Important: Dashboard action icons appear interactive but have no behavior
+
+- Evidence: `src/features/dashboard/DashboardScreen.tsx` renders value-visibility
+  and refresh `IconButton`s without `onPress`.
+- Evidence: `src/components/common/Premium.tsx` always renders `IconButton` as a
+  button-like `Pressable`.
+- Impact: Users can tap visible controls that do nothing. This should either be
+  wired to masking/quote refresh or rendered as non-interactive status affordance.
+
+### Important: Settings exposes unavailable or non-functional controls
+
+- Evidence: `src/features/settings/SettingsScreen.tsx` should be reviewed before
+  V1 dev-complete for any rows that look toggleable but are only static.
+- Impact: Settings is supposed to build local-first trust. Unsupported controls
+  should be explicitly marked unavailable, locked, or informational.
+
+### Moderate: Route naming is inconsistent for Progress
+
+- Evidence: `app/(tabs)/history.tsx` renders `ProgressScreen`, while the tab title
+  and test ID are `Progress`.
+- Evidence: `app/progress.tsx` also renders `ProgressScreen` outside the tab
+  group.
+- Impact: The UI says Progress, but the tab route remains `history`. This can
+  confuse E2E, docs, deep links, and future implementation work.
+
+### Moderate: Add Holding still stores trade-shaped records
+
+- Evidence: Add Holding uses `Trade` and `addTrade`, with a manual quote upsert.
+- Impact: This may be acceptable as an implementation bridge, but #61 asks for
+  opening-position semantics. The next implementation should decide whether an
+  opening position is a first-class source record or a typed trade variant.
+
+### Moderate: Tests are broad but not enough for Excel parity
+
+- Evidence: Jest has good coverage across current screens/domain/services.
+- Gap: No tests for instrument/sector metadata, debt manual assets, monthly
+  snapshot persistence, salary/expense rate, or the full Excel parity checklist.
+- Impact: #66 remains necessary.
+
+## Recommended Priority
+
+1. Fix #72.
+2. Add asset metadata and debt category (#62/#63).
+3. Make Add Holding explicitly support opening-position fields (#61).
+4. Add consolidated rollups and allocation details (#64).
+5. Add monthly snapshots (#65).
+6. Add Excel parity checklist and tests (#66).

--- a/docs/housekeeping/current-app-state.md
+++ b/docs/housekeeping/current-app-state.md
@@ -1,0 +1,81 @@
+# CogVest Current App State
+
+Date: 2026-05-06
+
+Base commit: `bcbeeed Merge pull request #73 from abdul-shaikh-dev/docs/superpowers-workflow-agents`
+
+Branch reviewed: `housekeeping/app-state-review`
+
+## Summary
+
+CogVest has a working V1 app shell with local-first portfolio data, derived
+holdings, dashboard summaries, cash tracking, quote refresh plumbing, value
+masking, Android PC harness scripts, and Maestro flows.
+
+It is not yet Excel-parity complete. The biggest product gaps are the
+Excel-style metadata model, first-class debt support, monthly snapshots, and
+complete V1 E2E navigation. The biggest runtime blocker is issue #72: Android
+release APK touch navigation does not move between tabs in Maestro/emulator
+testing.
+
+## Implemented Screens
+
+| Screen | Route | Feature module | Current status |
+| --- | --- | --- | --- |
+| Dashboard | `app/(tabs)/dashboard.tsx` | `src/features/dashboard` | Implemented. Shows portfolio value, invested, P&L, allocation, this month, quote status, and conviction readiness. |
+| Holdings | `app/(tabs)/holdings.tsx` | `src/features/holdings` | Implemented. Shows derived holdings, filters, refresh, quote failures, invested/current/P&L/allocation details. |
+| Add Holding | `app/add-holding.tsx` | `src/features/trades` | Implemented as an Add Holding UI backed by trade/opening-entry storage. Supports buy/sell, manual asset creation, review, save, conviction, and manual quote upsert. |
+| Cash | `app/(tabs)/cash.tsx` | `src/features/cash` | Implemented. Supports additions and withdrawals, balance, recent ledger, masking. |
+| Monthly Progress | `app/(tabs)/history.tsx` and `app/progress.tsx` | `src/features/progress` | Partial. Current-month derived summary exists; persistent monthly snapshots are not implemented. |
+| Settings | `app/(tabs)/settings.tsx` | `src/features/settings` | Implemented. Supports local-first status and value masking toggle. |
+
+## Implemented Data and Domain Areas
+
+| Area | Evidence | Status |
+| --- | --- | --- |
+| Raw portfolio persistence | `src/store/index.ts` persists assets, trades, cash entries, preferences, and quote cache. | Implemented. |
+| Derived holdings | `src/domain/calculations/holdings.ts` derives holdings from assets, trades, and quotes. | Implemented. |
+| Cash balance | `calculateCashBalance` and `useCash` derive balance from cash entries. | Implemented. |
+| Portfolio total | `calculatePortfolioTotal` combines holdings current value and cash. | Implemented. |
+| Allocation | `calculateAllocation` groups by current `AssetClass`. | Partial: groups stock/etf/crypto/cash, but no first-class debt class. |
+| Quote refresh | `src/services/quotes/quoteResolver.ts` supports Yahoo/CoinGecko and manual fallback. | Implemented for supported asset classes. |
+| Value masking | Settings preference flows into Dashboard, Holdings, Cash, and Progress. | Implemented in core value displays. |
+| Conviction | Optional conviction is accepted on Add Holding and dashboard readiness is derived. | Lightweight V1 state implemented. |
+| Monthly snapshots | No persisted monthly snapshot model found. | Missing; issue #65 remains open. |
+
+## Excel Parity Gate Status
+
+| Question from #60 | Current status | Evidence / gap |
+| --- | --- | --- |
+| What do I own? | Partial | Holdings screen derives current holdings from stored assets/trades. Opening position entry exists, but asset metadata is narrow. |
+| How much did I invest? | Partial | Dashboard/Holdings derive invested value. Needs consolidated rollup hardening under #64. |
+| What is it worth now? | Partial | Current value derives from quote cache/manual quote. Live/manual fallback exists, but unsupported/debt instruments need better handling. |
+| What is my P&L and P&L %? | Partial | Holding and dashboard P&L exist. Consolidated tests/rollup issue #64 remains open. |
+| How is my portfolio allocated? | Partial | Asset-class allocation exists. No sector/instrument allocation; debt class missing. |
+| How much is in equity, debt, crypto, and cash? | Partial | Equity/crypto/cash can be represented. Debt is not first-class; `etf` is currently labelled as Debt in UI config. |
+| What changed this month? | Partial | Progress screen derives current-month investment/cash, but no monthly snapshot model or monthly gain persistence. |
+| How much did I invest this month? | Partial | Progress screen derives current-month buy totals from trades. |
+| What is my savings/investment rate? | Partial | Progress screen computes investment/cash-added percentage if cash was added. Salary/expense rate fields are missing. |
+| Can I continue daily tracking without opening Excel? | Not yet | Core data entry exists, but #61-#66 and #72 block the parity gate. |
+
+## GitHub Issue Alignment
+
+| Issue | Review result |
+| --- | --- |
+| #60 Excel tracker parity MVP | Keep open. Parent issue is not complete. |
+| #61 Opening positions | Partial. Add Holding can create a holding, but it is still trade-shaped and lacks required metadata/current-position semantics. |
+| #62 Asset metadata | Not complete. Asset model lacks instrument type, sector type, quote source identifier, and debt category. |
+| #63 Debt and crypto parity | Partial. Crypto path exists; debt path is missing as a first-class category. |
+| #64 Consolidated rollups | Partial. Totals/allocation exist but sector/instrument grouping and allocation details are missing. |
+| #65 Monthly snapshots | Not complete. Current progress screen is derived-current-month only. |
+| #66 Excel parity gate docs/tests | Not complete. Existing testing docs mention V1 flows but do not provide a full Excel parity checklist. |
+| #72 Android release APK navigation | Confirmed. Full Maestro suite fails at tab navigation. |
+
+## Next Recommended Order
+
+1. Fix #72 before relying on emulator E2E results.
+2. Implement #62 before expanding the UI further; metadata is the base for #63 and #64.
+3. Implement #61 with explicit opening-position semantics after the metadata model is settled.
+4. Implement #63 and #64 together or back-to-back because debt support and rollups share the same model boundary.
+5. Implement #65 monthly snapshots.
+6. Complete #66 and then evaluate #60 for closure.

--- a/docs/housekeeping/issue-triage.md
+++ b/docs/housekeeping/issue-triage.md
@@ -1,0 +1,90 @@
+# CogVest Issue Triage
+
+Date: 2026-05-06
+
+## Repository State
+
+- Base branch reviewed: `main`
+- Base commit: `bcbeeed Merge pull request #73 from abdul-shaikh-dev/docs/superpowers-workflow-agents`
+- Open PRs: none
+- Branch for this review: `housekeeping/app-state-review`
+
+## Open Issues Reviewed
+
+| Issue | State | Recommendation |
+| --- | --- | --- |
+| #72 Android release APK bottom navigation bug | Open | Keep open. Confirmed by fresh Maestro run. This is the top blocker. |
+| #60 Excel tracker parity MVP | Open | Keep open. Parent cannot close until #61-#66 are complete and verified. |
+| #61 Opening positions | Open | Keep open. Current Add Holding is partial but does not satisfy all acceptance criteria. |
+| #62 Asset metadata | Open | Keep open and do next after #72. Required for debt/sector/instrument parity. |
+| #63 Debt and crypto parity | Open | Keep open. Crypto is partial; debt is missing as first-class category. |
+| #64 Consolidated rollups | Open | Keep open. Core totals exist; richer rollups/allocation details remain. |
+| #65 Monthly progression snapshots | Open | Keep open. Current Progress screen does not persist monthly snapshots. |
+| #66 Excel parity gate docs/tests | Open | Keep open. Existing docs do not yet provide the full parity checklist. |
+| #17-#21 V2 issues | Open | Leave open as future placeholders. Do not expand until V1 parity is validated. |
+| #22-#26 V3 issues | Open | Leave open as future placeholders. Do not expand until V1/V2 are validated. |
+
+## Newly Recommended Issues
+
+### #74 [V1] Clean up stale V1 docs and historical mockup references
+
+Why:
+
+- `docs/cogvest-codex-prompts.md` and older mockup docs contain V1 Minimal Mode,
+  LTCG, History, and Add Trade wording that conflicts with current `AGENTS.md`.
+- Future agents may follow stale docs and reintroduce out-of-scope work.
+
+Suggested acceptance criteria:
+
+- Historical prompt docs are labelled as historical/reference-only.
+- V1 docs consistently use Add Holding for user-facing UI.
+- V1 docs clearly state Minimal Mode and LTCG are not V1.
+- Old PNG mockups are marked superseded by `DESIGN.md` and Figma issue #69 files.
+
+Status: Created as https://github.com/abdul-shaikh-dev/CogVest/issues/74
+
+### #75 [V1] Wire or remove inactive Dashboard action icons
+
+Why:
+
+- Dashboard renders value visibility and refresh icons with button affordance but
+  no `onPress` behavior.
+- This creates false controls in the primary screen.
+
+Suggested acceptance criteria:
+
+- Value visibility icon toggles `maskWealthValues` or is removed.
+- Refresh icon triggers quote refresh or is removed.
+- Tests cover the chosen behavior.
+
+Status: Created as https://github.com/abdul-shaikh-dev/CogVest/issues/75
+
+### #76 [V1] Normalize Progress route naming
+
+Why:
+
+- The Progress tab is implemented in `app/(tabs)/history.tsx`, while
+  `app/progress.tsx` also exists.
+- This creates avoidable route/docs/E2E confusion.
+
+Suggested acceptance criteria:
+
+- User-facing and file-based routing are consistently named where Expo Router
+  permits it.
+- Maestro navigation continues to target stable `tab-progress` and
+  `progress-screen` IDs.
+
+Status: Created as https://github.com/abdul-shaikh-dev/CogVest/issues/76
+
+## Issue Creation Status
+
+Created:
+
+- #74 for stale docs and historical mockup references.
+- #75 for inactive Dashboard action icons.
+- #76 for Progress route naming.
+
+Updated:
+
+- #72 with fresh housekeeping reproduction evidence from the 2026-05-06 Maestro
+  run.

--- a/docs/housekeeping/stale-doc-audit.md
+++ b/docs/housekeeping/stale-doc-audit.md
@@ -1,0 +1,48 @@
+# CogVest Stale Documentation Audit
+
+Date: 2026-05-06
+
+## Canonical Documents
+
+| Document | Status | Notes |
+| --- | --- | --- |
+| `AGENTS.md` | Canonical | Current agent rules, V1 scope boundaries, Android PC harness, and Superpowers workflow. |
+| `DESIGN.md` | Canonical | Current design direction with true-dark premium UI and Android-first constraints. |
+| `docs/roadmap/cogvest-version-roadmap.md` | Canonical roadmap | Current phase map. Keep aligned as V1 issues evolve. |
+| `docs/roadmap/v1-mvp-spec.md` | Canonical V1 scope | Mostly current, but still uses some Add Trade language where UI now says Add Holding. |
+| `docs/testing/v1-core-flow-test-matrix.md` | Current supporting doc | Useful for V1 PC verification, but should link the Excel parity checklist after #66. |
+| `docs/testing/v1-pc-verification-checklist.md` | Current supporting doc | Useful for PC harness flow. |
+
+## Historical or Potentially Misleading Documents
+
+| Document | Status | Risk |
+| --- | --- | --- |
+| `docs/cogvest-codex-prompts.md` | Historical / stale | Contains old all-in prompts with V1 Minimal Mode and LTCG instructions. Conflicts with current V1 boundaries. |
+| `docs/cogvest-master-spec.md` | Broad product spec | Valuable product context, but contains Minimal Mode, LTCG, and older screen language that should not be interpreted as V1 implementation scope. |
+| `docs/design/v1-ui-mockup-plan.md` | Partially stale | Still references Add Trade CTA and older mockup direction. Should be reconciled with Add Holding and Figma issue #69 output. |
+| `docs/design/v2-ui-mockup-plan.md` | Future reference | Fine for V2, but should not drive current V1 work. |
+| `docs/design/v3-ui-mockup-plan.md` | Future reference | Fine for V3, but should not drive current V1 work. |
+| `docs/cogvest_standard_mode.png` | Historical mockup | Older visual direction. Current Figma/code.js and `DESIGN.md` should override it. |
+| `docs/cogvest_minimal_mode.png` | Historical/Future mockup | V2 reference only; not V1. |
+| `docs/prompts/versioned-roadmap-planning-prompt.md` | Historical planning prompt | Useful context, not an implementation source of truth. |
+
+## Specific Conflicts Found
+
+| Conflict | Current source of truth | Recommended cleanup |
+| --- | --- | --- |
+| Add Trade vs Add Holding | `AGENTS.md`, Figma issue #69, current UI | Update V1 docs to say user-facing `Add Holding`; keep trade terminology internal where domain APIs still use `Trade`. |
+| History vs Progress | `AGENTS.md` says V1 language should prefer Progress | Rename stale references from History/Progression to Progress/Monthly Progress where applicable. |
+| Minimal Mode in V1 docs | `AGENTS.md` excludes Minimal Mode from V1 | Mark older Minimal Mode docs as V2-only or historical. |
+| LTCG in V1 docs | `AGENTS.md` excludes LTCG UI/tax badges from V1 | Mark LTCG docs/prompts as V2/V3-only and keep V1 tests asserting no LTCG UI. |
+| Old visual mockups vs Figma | `DESIGN.md` and `docs/design/figma/issue-69-v1-screens/code.js` | Add a short note in older mockup docs saying they are superseded by current Figma V1 screens. |
+| Android APK testing | `AGENTS.md` and `docs/testing/android-pc-test-harness.md` | Add local release APK build notes discovered during #72 reproduction if not already documented. |
+
+## Recommended Doc Tasks
+
+1. Create a V1 docs cleanup issue to label old prompt/mockup docs as historical
+   and remove V1-scope ambiguity.
+2. Complete #66 with an Excel parity checklist that references #61-#65 and
+   makes the #60 gate explicit.
+3. Update V1 docs to consistently use Add Holding for user-facing UI.
+4. Add a local Gradle release APK note to Android PC harness docs:
+   debug APK needs Metro; release APK is the standalone local install artifact.

--- a/docs/housekeeping/verification-baseline.md
+++ b/docs/housekeeping/verification-baseline.md
@@ -1,0 +1,49 @@
+# CogVest Verification Baseline
+
+Date: 2026-05-06
+
+Environment:
+
+- OS shell: Windows PowerShell
+- Node: `v24.11.1`
+- Emulator: `emulator-5554`
+- Android app package: `com.abdulshaikh.cogvest`
+- Maestro: `2.5.1`
+
+## Commands Run
+
+| Command | Result | Evidence |
+| --- | --- | --- |
+| `npm run typecheck` | Pass | `tsc --noEmit` exited `0`. |
+| `npm test` | Pass | `25` test suites passed, `79` tests passed. |
+| `npm run doctor` | Pass | Expo Doctor ran `17` checks; `17/17` passed. |
+| `npm run android:doctor` | Pass | Node, npm, npx, adb, `emulator-5554`, Expo CLI, package scripts, and Maestro detected. |
+| `npm run android:smoke` | Pass | adb found, `emulator-5554` connected, package `com.abdulshaikh.cogvest` installed. |
+| `npm run maestro:check` | Pass | Java, adb, `emulator-5554`, Maestro `2.5.1`, and app package detected. |
+| `npm run test:v1:pc` | Pass | Typecheck, Jest, Expo Doctor, Android Doctor, and strict installed-app smoke all passed. |
+| `$env:MAESTRO_CLI_NO_ANALYTICS='1'; npm run maestro:test` | Fail | `e2e/smoke-launch.yaml` passed; `e2e/navigation.yaml` failed after tapping `tab-holdings`. |
+
+## Maestro Failure
+
+Passing flow:
+
+- `e2e/smoke-launch.yaml`
+- Confirmed `dashboard-screen`, Dashboard text, Holdings text, Progress text,
+  and absence of `Unmatched Route`.
+
+Failing flow:
+
+- `e2e/navigation.yaml`
+- Failure point: after `tapOn id: tab-holdings`, assertion
+  `id: holdings-screen is visible` failed.
+- Maestro debug output: `C:\Users\abdul\.maestro\tests\2026-05-06_214033`
+
+## Interpretation
+
+The static and local harness gates are healthy. The app package is installed and
+launches to Dashboard. Full emulator E2E is blocked by the known navigation
+defect tracked as #72.
+
+The V1 dev-complete gate cannot be considered fully satisfied until #72 is fixed
+and the Maestro navigation/core-flow suite passes or defects are explicitly
+logged for each failing flow.

--- a/docs/superpowers/plans/2026-05-06-housekeeping-app-state-review-plan.md
+++ b/docs/superpowers/plans/2026-05-06-housekeeping-app-state-review-plan.md
@@ -1,0 +1,80 @@
+# CogVest Housekeeping App State Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce an evidence-backed current-state review for CogVest V1 covering implemented features, bugs, stale docs, verification status, code quality, and issue triage.
+
+**Architecture:** This plan is docs-first and review-only. It creates focused housekeeping reports under `docs/housekeeping/`, gathers evidence from source, tests, Android harness commands, and GitHub issue state, then records findings without changing product behavior.
+
+**Tech Stack:** Expo Router, React Native, TypeScript, Jest, Expo Doctor, Android adb/emulator harness, Maestro, GitHub CLI.
+
+---
+
+## Files
+
+- Create: `docs/housekeeping/current-app-state.md`
+- Create: `docs/housekeeping/verification-baseline.md`
+- Create: `docs/housekeeping/stale-doc-audit.md`
+- Create: `docs/housekeeping/code-review-findings.md`
+- Create: `docs/housekeeping/issue-triage.md`
+- Create: `docs/superpowers/specs/2026-05-06-housekeeping-app-state-review-design.md`
+- Create: `docs/superpowers/plans/2026-05-06-housekeeping-app-state-review-plan.md`
+
+## Task 1: Capture Repository and GitHub State
+
+- [x] Run `git status --short --branch` and record branch cleanliness.
+- [x] Run `git log -1 --oneline` and record the base commit.
+- [x] Run `gh issue list --repo abdul-shaikh-dev/CogVest --state open --limit 100` and record open issues.
+- [x] Run `gh pr list --repo abdul-shaikh-dev/CogVest --state open --limit 20` and record open PRs.
+- [x] Add the results to `docs/housekeeping/issue-triage.md`.
+
+## Task 2: Inventory Implemented Features
+
+- [x] Inspect `app/` routes and map visible screens.
+- [x] Inspect `src/features/`, `src/domain/`, `src/services/`, `src/store/`, and `src/types/`.
+- [x] Map each V1 feature to code, tests, and status.
+- [x] Map issue #60 Excel parity questions to done, partial, missing, or blocked.
+- [x] Add the results to `docs/housekeeping/current-app-state.md`.
+
+## Task 3: Run Verification Baseline
+
+- [x] Run `npm run typecheck` and record the result.
+- [x] Run `npm test` and record the result.
+- [x] Run `npm run doctor` and record the result.
+- [x] Run `npm run android:doctor` and record emulator/tool status.
+- [x] Run `npm run android:smoke` and record installed app status.
+- [x] Run `npm run maestro:check` and record Maestro status.
+- [x] Run `npm run maestro:test` if Maestro is available and record pass/fail details.
+- [x] Add the results to `docs/housekeeping/verification-baseline.md`.
+
+## Task 4: Review Code Quality and Bugs
+
+- [x] Review navigation routes, tab configuration, and known issue #72.
+- [x] Review store persistence and selector/domain separation.
+- [x] Review quote service behavior and manual fallback.
+- [x] Review form validation and value masking.
+- [x] Review tests for meaningful behavior coverage.
+- [x] Add prioritized findings to `docs/housekeeping/code-review-findings.md`.
+
+## Task 5: Audit Docs for Stale Guidance
+
+- [x] Compare `AGENTS.md`, `DESIGN.md`, V1 roadmap docs, issue drafts, testing docs, and old prompt docs.
+- [x] Mark docs as canonical, current-supporting, historical, stale, or misleading.
+- [x] Identify conflicts around Add Trade/Add Holding, History/Progress, Minimal Mode, LTCG, Figma, and Android testing.
+- [x] Add results to `docs/housekeeping/stale-doc-audit.md`.
+
+## Task 6: Issue Triage and Follow-Up
+
+- [x] Link known bug #72 in the reports.
+- [x] Identify newly discovered issues that deserve separate GitHub bugs.
+- [x] Create GitHub issues only for concrete, actionable defects with evidence.
+- [x] Recommend which existing V1 issues should remain open, be updated, or be blocked.
+- [x] Add results to `docs/housekeeping/issue-triage.md`.
+
+## Task 7: Final Verification and Delivery
+
+- [ ] Run `git diff --check`.
+- [ ] Run a final `git status --short --branch`.
+- [ ] Commit the housekeeping reports.
+- [ ] Push the branch.
+- [ ] Open a PR without a closing keyword unless a dedicated housekeeping issue exists.

--- a/docs/superpowers/specs/2026-05-06-housekeeping-app-state-review-design.md
+++ b/docs/superpowers/specs/2026-05-06-housekeeping-app-state-review-design.md
@@ -1,0 +1,91 @@
+# CogVest Housekeeping App State Review Design
+
+## Goal
+
+Create a durable, evidence-backed snapshot of CogVest's current V1 state so the
+next implementation work starts from known facts, not assumptions.
+
+## Scope
+
+This is a housekeeping and review task. It creates review artifacts, runs the
+current verification harness, audits docs for stale guidance, maps implemented
+features against V1 and Excel parity goals, and records actionable defects.
+
+This task does not implement new product features and does not fix unrelated
+bugs. If a bug is discovered, it should be logged or linked to an existing
+issue unless the fix is trivial and explicitly in scope.
+
+## Inputs
+
+- `AGENTS.md`
+- `DESIGN.md`
+- `docs/roadmap/v1-mvp-spec.md`
+- `docs/roadmap/cogvest-version-roadmap.md`
+- `docs/testing/v1-core-flow-test-matrix.md`
+- `docs/testing/v1-pc-verification-checklist.md`
+- GitHub issues and PR state
+- Current `app/`, `src/`, `.github/`, `e2e/`, and `docs/` tree
+
+## Outputs
+
+- `docs/housekeeping/current-app-state.md`
+- `docs/housekeeping/verification-baseline.md`
+- `docs/housekeeping/stale-doc-audit.md`
+- `docs/housekeeping/code-review-findings.md`
+- `docs/housekeeping/issue-triage.md`
+
+## Review Questions
+
+The review must answer:
+
+- What features does the app currently have?
+- Which V1/Excel parity requirements are complete, partial, missing, or blocked?
+- Which bugs are known or newly discovered?
+- Which docs are canonical, stale, misleading, or historical references?
+- Which code risks should be fixed before continuing feature work?
+- Which GitHub issues should be updated, split, closed, or created?
+
+## Evidence Rules
+
+- Do not mark a feature complete without code, test, or runtime evidence.
+- Do not mark a verification command passing without fresh command output.
+- Do not close or recommend closing an issue unless the relevant acceptance
+  criteria are mapped to evidence.
+- Treat docs that conflict with `AGENTS.md`, `DESIGN.md`, or the current V1
+  roadmap as stale unless clearly labelled historical.
+
+## Review Boundaries
+
+In scope:
+
+- V1 features and Excel tracker parity.
+- Android PC test harness and local APK/E2E readiness.
+- Docs and issue hygiene.
+- Architecture and code quality review.
+- Test coverage review.
+
+Out of scope:
+
+- Implementing V2 Minimal Mode.
+- Implementing LTCG UI.
+- Implementing import/export.
+- Triggering EAS cloud builds.
+- Play Store release work.
+- Broad refactors without a specific defect.
+
+## Completion Criteria
+
+- Spec and plan are committed in the repo.
+- All five housekeeping reports exist and contain evidence.
+- Verification commands are run or blocked with exact reasons.
+- GitHub issue state is reviewed.
+- Any newly discovered actionable defects are filed or explicitly listed for
+  follow-up.
+- The branch is pushed and a PR is opened for review.
+
+## Self-Review
+
+- No placeholders remain.
+- Scope is review and housekeeping only.
+- Outputs are concrete files with clear ownership.
+- Completion depends on evidence, not opinion.


### PR DESCRIPTION
## Summary
- Add Superpowers spec and plan for the CogVest housekeeping review
- Document current app feature state, Excel parity gaps, verification baseline, stale-doc audit, code review findings, and issue triage
- Create follow-up issues #74, #75, and #76; update #72 with fresh Maestro reproduction evidence

## Verification
- npm run typecheck: pass
- npm test: pass, 25 suites / 79 tests
- npm run doctor: pass, 17/17 checks
- npm run android:doctor: pass, emulator-5554 detected
- npm run android:smoke: pass, com.abdulshaikh.cogvest installed
- npm run maestro:check: pass, Maestro 2.5.1 detected
- npm run test:v1:pc: pass
- MAESTRO_CLI_NO_ANALYTICS=1 npm run maestro:test: fail at e2e/navigation.yaml, tracked by #72
- git diff --cached --check: pass