### PR TITLE
Fix Android APK navigation entrypoint

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,21 +1,32 @@
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
+import { StyleSheet } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
 export default function RootLayout() {
   return (
-    <SafeAreaProvider>
-      <StatusBar style="light" />
-      <Stack
-        screenOptions={{
-          contentStyle: { backgroundColor: "#1C1B1F" },
-          headerStyle: { backgroundColor: "#1C1B1F" },
-          headerTintColor: "#E6E1E5",
-        }}
-      >
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="settings" options={{ title: "Settings" }} />
-      </Stack>
-    </SafeAreaProvider>
+    <GestureHandlerRootView style={styles.root}>
+      <SafeAreaProvider>
+        <StatusBar style="light" />
+        <Stack
+          screenOptions={{
+            contentStyle: { backgroundColor: "#1C1B1F" },
+            headerStyle: { backgroundColor: "#1C1B1F" },
+            headerTintColor: "#E6E1E5",
+          }}
+        >
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="add-holding" options={{ title: "Add Holding" }} />
+          <Stack.Screen name="settings" options={{ title: "Settings" }} />
+        </Stack>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
   );
 }
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+});

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,2 @@
+import "react-native-gesture-handler";
+import "expo-router/entry";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cogvest",
   "version": "1.0.0",
-  "main": "expo-router/entry",
+  "main": "./index.ts",
   "scripts": {
     "start": "expo start",
     "start:clear": "expo start --clear",

--- a/src/__tests__/androidIdentity.test.ts
+++ b/src/__tests__/androidIdentity.test.ts
@@ -1,9 +1,11 @@
 import appConfig from "../../app.json";
+import packageJson from "../../package.json";
 
 describe("Android app identity", () => {
   const expo = appConfig.expo;
 
   it("configures the public app identity", () => {
+    expect(packageJson.main).toBe("./index.ts");
     expect(expo.name).toBe("CogVest");
     expect(expo.slug).toBe("cogvest");
     expect(expo.scheme).toBe("cogvest");

--- a/src/__tests__/rootLayout.test.tsx
+++ b/src/__tests__/rootLayout.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+
+import RootLayout from "../../app/_layout";
+
+jest.mock("expo-router", () => {
+  const React = require("react");
+
+  const Stack = ({ children }: { children: React.ReactNode }) =>
+    React.createElement("Stack", {}, children);
+  Stack.Screen = ({ name, options }: { name: string; options?: unknown }) =>
+    React.createElement("Stack.Screen", { name, options });
+
+  return { Stack };
+});
+
+jest.mock("expo-status-bar", () => {
+  const React = require("react");
+
+  return {
+    StatusBar: ({ style }: { style: string }) => React.createElement("StatusBar", { style }),
+  };
+});
+
+jest.mock("react-native-safe-area-context", () => {
+  const React = require("react");
+
+  return {
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("SafeAreaProvider", {}, children),
+  };
+});
+
+jest.mock("react-native-gesture-handler", () => {
+  const React = require("react");
+
+  return {
+    GestureHandlerRootView: ({ children, style }: { children: React.ReactNode; style?: unknown }) =>
+      React.createElement("GestureHandlerRootView", { style }, children),
+  };
+});
+
+type TestElement = React.ReactElement<{
+  children?: React.ReactNode;
+  name?: string;
+  style?: unknown;
+}>;
+
+function isElement(node: unknown): node is TestElement {
+  return React.isValidElement(node);
+}
+
+function collectScreenNames(node: unknown): string[] {
+  if (!isElement(node)) {
+    return [];
+  }
+
+  const ownName = typeof node.props.name === "string" ? [node.props.name] : [];
+  const childNames = React.Children.toArray(node.props.children).flatMap(collectScreenNames);
+
+  return [...ownName, ...childNames];
+}
+
+describe("RootLayout", () => {
+  it("wraps navigation with the gesture handler root required by native navigation", () => {
+    const layout = RootLayout() as TestElement;
+
+    expect(layout.type).toBe(GestureHandlerRootView);
+    expect(layout.props.style).toEqual({ flex: 1 });
+  });
+
+  it("registers the add holding route used by dashboard and holdings actions", () => {
+    const layout = RootLayout();
+
+    expect(collectScreenNames(layout)).toEqual(
+      expect.arrayContaining(["(tabs)", "settings", "add-holding"]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add a project entrypoint that imports `react-native-gesture-handler` before Expo Router boots.
- Wrap the root navigator in `GestureHandlerRootView` so native gesture/touch handling is initialized at the app root.
- Register the root `add-holding` stack route used by dashboard/holdings actions.
- Add regression coverage for the Android entrypoint and root layout route wiring.

## Root Cause / Evidence

The installed release APK could render Dashboard and deep-link routes, but emulator-driven tab/action taps were unreliable in the original APK session. The app did not have an explicit gesture-handler-first entrypoint or gesture root wrapper, which is required for reliable native navigation/touch handling in this stack. During verification, the emulator later entered a system-level ANR state; after rebooting the emulator, the rebuilt release APK passed the Maestro navigation flow.

## Validation

- `npm run typecheck`
- `npm test`
- `npm run doctor`
- local release APK build: `android\gradlew.bat :app:assembleRelease --console=plain`
- installed APK on `emulator-5554`: `adb install -r android\app\build\outputs\apk\release\app-release.apk`
- `npm run android:smoke -- --strict`
- `npm run maestro:check`
- `npm run maestro:test -- e2e/navigation.yaml`
- `npm run test:v1:pc`

Closes #72
