### PR TITLE
docs: refresh stale CogVest markdown

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -87,7 +87,7 @@ Suggested hierarchy:
 | Role | Use |
 | --- | --- |
 | Display value | Portfolio total, cash balance, major KPI |
-| Screen title | Dashboard, Holdings, Add Trade, Cash, Settings |
+| Screen title | Dashboard, Holdings, Add Holding, Cash, Settings |
 | Section title | Allocation, Quote freshness, Trade details |
 | Body | Explanatory copy and insight text |
 | Label | Field labels and metric labels |
@@ -118,7 +118,7 @@ Buttons:
 - Primary actions use `Primary Green`.
 - Secondary actions use elevated neutral surfaces or subtle hairline separators.
 - Destructive actions use `Negative` only when the action is genuinely destructive.
-- Button labels should be direct: `Add Trade`, `Save`, `Refresh Quotes`, `Add Cash`.
+- Button labels should be direct: `Add Holding`, `Save`, `Refresh Quotes`, `Add Cash`.
 - Avoid marketing-style CTA language.
 
 Inputs:
@@ -255,7 +255,7 @@ Holdings:
 - Include current value, invested value, P&L, P&L %, and allocation where appropriate.
 - Metadata such as instrument type and sector should support understanding without crowding.
 
-Add Trade / Add Holding:
+Add Holding:
 
 - Use clear sectioning and direct labels.
 - Financial entry must be reviewable before save.
@@ -273,7 +273,7 @@ Settings:
 - Value masking should be obvious and reliable.
 - Keep release/build/technical notes secondary.
 
-Progression:
+Monthly Progress:
 
 - Monthly progression should feel like long-term tracking, not performance pressure.
 - Show trend, monthly contribution, cash, and savings context with restraint.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 CogVest is an Android-first React Native portfolio tracker for Indian retail
 investors. V1 is local-first and focused on portfolio tracking, live current
-quotes, trade entry, derived holdings, cash tracking, value masking, and
+quotes, Add Holding entry, derived holdings, cash tracking, value masking, and
 lightweight conviction capture.
 
 The app is built with Expo Router, TypeScript, Zustand, MMKV, React Hook Form,
@@ -17,7 +17,7 @@ V1 includes:
 
 - Android-first app shell with Expo Router tabs.
 - Local data persistence.
-- Add Trade flow.
+- Add Holding flow.
 - Derived holdings and dashboard.
 - Cash tracking.
 - Value masking.
@@ -184,7 +184,7 @@ npm run maestro:test -- e2e/smoke-launch.yaml
 The full local suite covers:
 
 - App cold launch.
-- Add Trade.
+- Add Holding.
 - Holdings from trade entry.
 - Cash entry.
 - Value masking through Settings.

--- a/docs/cogvest-codex-prompts.md
+++ b/docs/cogvest-codex-prompts.md
@@ -1,4 +1,12 @@
 # CogVest — Codex CLI Prompts
+
+> Status: historical reference only.
+>
+> This was the original all-in prompt set and it contains stale V1 guidance,
+> including Minimal Mode, LTCG UI, History, and older Add Trade wording. Do not
+> use it as the current implementation source of truth. Use `AGENTS.md`,
+> `DESIGN.md`, `docs/roadmap/cogvest-version-roadmap.md`, and the current
+> GitHub issues instead.
 ---
 
 ## How to use these prompts

--- a/docs/cogvest-master-spec.md
+++ b/docs/cogvest-master-spec.md
@@ -3,6 +3,13 @@
 > Covers: Crypto + Indian Stocks + ETFs + Cash  
 > Last updated: April 2026
 
+> Scope note: this is the broad product vision, not the current V1 execution
+> contract. For V1 work, use `AGENTS.md`, `DESIGN.md`,
+> `docs/roadmap/cogvest-version-roadmap.md`, and
+> `docs/roadmap/v1-mvp-spec.md`. V1 user-facing language prefers Add Holding
+> and Progress; Minimal Mode, LTCG UI, and old History-tab guidance are future
+> scope unless a current issue explicitly says otherwise.
+
 ---
 
 ## 1. Product Summary

--- a/docs/design/figma/issue-69-v1-screens/README.md
+++ b/docs/design/figma/issue-69-v1-screens/README.md
@@ -27,7 +27,7 @@ The plugin creates six editable Android frames:
 - Holdings
 - Add Holding
 - Cash
-- Monthly Progression
+- Monthly Progress
 - Settings
 
 ## Notes

--- a/docs/design/issue-69-ui-screens/README.md
+++ b/docs/design/issue-69-ui-screens/README.md
@@ -2,6 +2,11 @@
 
 Focused V1 UI concept images for issue #69.
 
+> Status: historical image exploration. These PNGs are not the stable design
+> source. Use the editable Figma plugin under
+> `docs/design/figma/issue-69-v1-screens/` plus `DESIGN.md` for current V1 UI
+> work.
+
 ## Direction
 
 These screens explore the **Private Ledger** direction from `DESIGN.md`: calm,

--- a/docs/design/v1-ui-mockup-plan.md
+++ b/docs/design/v1-ui-mockup-plan.md
@@ -1,37 +1,35 @@
 # V1 UI Mockup Plan
 
+> Status: historical V1 visual planning reference. For current V1 UI work, use
+> `DESIGN.md` and `docs/design/figma/issue-69-v1-screens/code.js` as the
+> source of truth. This document remains only for early context.
+
 Figma: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d
 
 ## Design System
 
 - Android frame: 390 x 844.
-- Background: `#1C1B1F`.
-- Card background: `#2A2930`.
-- Elevated card: `#312F36`.
-- Primary green: `#2E7D52`.
-- Text primary: `#E6E1E5`.
-- Text secondary: `#CAC4D0`.
-- Border: `rgba(255,255,255,0.08)`.
-- Radius: 12px for cards, 16px for primary buttons.
-- No coloured shadows.
+- Current V1 uses the true-dark palette, borderless cards, and typography rules
+  from `DESIGN.md`.
+- Older colors in early mockups are superseded.
 
 ## Screens
 
 ### Empty Dashboard
 
-Show total `₹0.00`, no allocation, and a strong `Add Trade` CTA. Empty copy should explain that holdings are created from trades.
+Show total `₹0.00`, no allocation, and a strong `Add Holding` CTA. Empty copy should explain that holdings are created from user-entered records.
 
 ### Filled Dashboard
 
-Show portfolio value, day change, allocation summary, quote freshness, basic conviction nudge, and Add Trade CTA. Do not show Minimal Mode or LTCG.
+Show portfolio value, allocation summary, quote freshness, monthly context, basic conviction nudge, and Add Holding CTA. Do not show Minimal Mode or LTCG.
 
-### Add Trade
+### Add Holding
 
-Top segmented control for Buy/Sell. Asset field, quantity, price, total, date, optional fees, optional conviction row, optional note, sticky Review Trade button.
+Use the multi-phase Figma direction: Asset, Classification, Position, Review. Include asset lookup/autofill where available, manual fallback, quantity, average/current price, date, optional conviction, optional note, and review before save.
 
 ### Holdings Empty
 
-Show empty card with “No holdings yet” and CTA to Add Trade.
+Show empty card with “No holdings yet” and CTA to Add Holding.
 
 ### Holdings Filled
 
@@ -52,7 +50,7 @@ Mask INR wealth values with `₹**** **,***.**`. Do not mask quantities, percent
 ## Interactions
 
 - Pressable opacity feedback at 0.75.
-- Haptics on Add Trade confirm and value masking toggle.
+- Haptics on Add Holding confirm and value masking toggle.
 - Pull-to-refresh on Dashboard/Holdings.
 - Clear error text for invalid sell quantity and quote failures.
 

--- a/docs/design/v2-ui-mockup-plan.md
+++ b/docs/design/v2-ui-mockup-plan.md
@@ -10,7 +10,7 @@ V2 introduces Minimal Mode and behaviour insights. Standard Mode remains informa
 
 ### Minimal Dashboard
 
-Show portfolio value, updated timestamp, allocation, Add Trade CTA, and optional LTCG banner. Hide daily P&L, top movers, and insight card by default.
+Show portfolio value, updated timestamp, allocation, Add Holding CTA, and optional LTCG banner. Hide daily P&L, top movers, and insight card by default.
 
 ### Minimal Holdings
 
@@ -36,7 +36,7 @@ Small cards prompting conviction/intended hold input. Must not block trade entry
 
 - Mode switch applies immediately.
 - Insight cards can be dismissed or opened.
-- Minimal Mode never removes Add Trade, Holdings, Cash, or History access.
+- Minimal Mode never removes Add Holding, Holdings, Progress, or Cash access.
 
 ## Manual Figma Recreation Notes
 

--- a/docs/housekeeping/code-review-findings.md
+++ b/docs/housekeeping/code-review-findings.md
@@ -2,21 +2,23 @@
 
 Date: 2026-05-06
 
+Status: historical review snapshot. Findings that cite #72 predate PR #78 and
+must be re-verified before being treated as current defects.
+
 Review mode: current-state review against V1 MVP, issue #60 Excel parity, and
 Android PC verification requirements.
 
 ## Findings
 
-### Critical: Android release APK touch navigation blocks E2E
+### Resolved / Re-verify: Android release APK touch navigation blocked E2E
 
 - Evidence: `npm run maestro:test` fails in `e2e/navigation.yaml` after tapping
   `tab-holdings`; `holdings-screen` never becomes visible.
 - Existing issue: #72.
-- Impact: PC-only E2E cannot prove core manual flows. V1 dev-complete should
-  remain blocked.
-- Likely area to inspect first: `app/(tabs)/_layout.tsx`, tab route naming,
-  release APK navigation behavior, and any overlays/touch handling around
-  `ScreenContainer`.
+- Later update: PR #78 addressed the Android navigation entrypoint issue and
+  merged into `main`.
+- Impact: re-run the Maestro navigation/core-flow suite before deciding whether
+  any runtime blocker remains.
 
 ### Important: Asset metadata is too narrow for Excel parity
 

--- a/docs/housekeeping/current-app-state.md
+++ b/docs/housekeeping/current-app-state.md
@@ -2,7 +2,13 @@
 
 Date: 2026-05-06
 
-Base commit: `bcbeeed Merge pull request #73 from abdul-shaikh-dev/docs/superpowers-workflow-agents`
+Status: historical review snapshot, updated by later housekeeping where noted.
+
+Base commit reviewed: `bcbeeed Merge pull request #73 from abdul-shaikh-dev/docs/superpowers-workflow-agents`
+
+Known later update: #72 was addressed by PR #78 and merged into `main` at
+`1d26750`. Re-run Android/Maestro verification before treating this report as
+current runtime evidence.
 
 Branch reviewed: `housekeeping/app-state-review`
 
@@ -13,10 +19,8 @@ holdings, dashboard summaries, cash tracking, quote refresh plumbing, value
 masking, Android PC harness scripts, and Maestro flows.
 
 It is not yet Excel-parity complete. The biggest product gaps are the
-Excel-style metadata model, first-class debt support, monthly snapshots, and
-complete V1 E2E navigation. The biggest runtime blocker is issue #72: Android
-release APK touch navigation does not move between tabs in Maestro/emulator
-testing.
+Excel-style metadata model, first-class debt support, monthly snapshots,
+lightweight asset lookup/autofill, and complete V1 E2E verification.
 
 ## Implemented Screens
 
@@ -69,13 +73,13 @@ testing.
 | #64 Consolidated rollups | Partial. Totals/allocation exist but sector/instrument grouping and allocation details are missing. |
 | #65 Monthly snapshots | Not complete. Current progress screen is derived-current-month only. |
 | #66 Excel parity gate docs/tests | Not complete. Existing testing docs mention V1 flows but do not provide a full Excel parity checklist. |
-| #72 Android release APK navigation | Confirmed. Full Maestro suite fails at tab navigation. |
+| #72 Android release APK navigation | Historical finding. Addressed by PR #78; re-run Maestro before relying on current status. |
 
 ## Next Recommended Order
 
-1. Fix #72 before relying on emulator E2E results.
-2. Implement #62 before expanding the UI further; metadata is the base for #63 and #64.
-3. Implement #61 with explicit opening-position semantics after the metadata model is settled.
+1. Implement #62 before expanding the UI further; metadata is the base for #63 and #64.
+2. Implement #84 so Add Holding can lookup/autofill common asset metadata and prices.
+3. Implement #61/#79 with explicit multi-phase opening-position semantics after the metadata model is settled.
 4. Implement #63 and #64 together or back-to-back because debt support and rollups share the same model boundary.
 5. Implement #65 monthly snapshots.
 6. Complete #66 and then evaluate #60 for closure.

--- a/docs/housekeeping/issue-triage.md
+++ b/docs/housekeeping/issue-triage.md
@@ -2,6 +2,9 @@
 
 Date: 2026-05-06
 
+Status: historical issue-triage snapshot. #72 was later addressed by PR #78,
+and later issues #79-#84 were created after this report.
+
 ## Repository State
 
 - Base branch reviewed: `main`
@@ -13,7 +16,7 @@ Date: 2026-05-06
 
 | Issue | State | Recommendation |
 | --- | --- | --- |
-| #72 Android release APK bottom navigation bug | Open | Keep open. Confirmed by fresh Maestro run. This is the top blocker. |
+| #72 Android release APK bottom navigation bug | Historical: later addressed by PR #78 | Re-run Maestro before treating this as current. |
 | #60 Excel tracker parity MVP | Open | Keep open. Parent cannot close until #61-#66 are complete and verified. |
 | #61 Opening positions | Open | Keep open. Current Add Holding is partial but does not satisfy all acceptance criteria. |
 | #62 Asset metadata | Open | Keep open and do next after #72. Required for debt/sector/instrument parity. |

--- a/docs/housekeeping/stale-doc-audit.md
+++ b/docs/housekeeping/stale-doc-audit.md
@@ -2,6 +2,9 @@
 
 Date: 2026-05-06
 
+Status: historical audit snapshot. Issue #74 tracks the cleanup work produced
+from this audit.
+
 ## Canonical Documents
 
 | Document | Status | Notes |
@@ -9,7 +12,7 @@ Date: 2026-05-06
 | `AGENTS.md` | Canonical | Current agent rules, V1 scope boundaries, Android PC harness, and Superpowers workflow. |
 | `DESIGN.md` | Canonical | Current design direction with true-dark premium UI and Android-first constraints. |
 | `docs/roadmap/cogvest-version-roadmap.md` | Canonical roadmap | Current phase map. Keep aligned as V1 issues evolve. |
-| `docs/roadmap/v1-mvp-spec.md` | Canonical V1 scope | Mostly current, but still uses some Add Trade language where UI now says Add Holding. |
+| `docs/roadmap/v1-mvp-spec.md` | Canonical V1 scope | Updated during #74 cleanup to prefer Add Holding and Monthly Progress for V1. |
 | `docs/testing/v1-core-flow-test-matrix.md` | Current supporting doc | Useful for V1 PC verification, but should link the Excel parity checklist after #66. |
 | `docs/testing/v1-pc-verification-checklist.md` | Current supporting doc | Useful for PC harness flow. |
 
@@ -19,7 +22,7 @@ Date: 2026-05-06
 | --- | --- | --- |
 | `docs/cogvest-codex-prompts.md` | Historical / stale | Contains old all-in prompts with V1 Minimal Mode and LTCG instructions. Conflicts with current V1 boundaries. |
 | `docs/cogvest-master-spec.md` | Broad product spec | Valuable product context, but contains Minimal Mode, LTCG, and older screen language that should not be interpreted as V1 implementation scope. |
-| `docs/design/v1-ui-mockup-plan.md` | Partially stale | Still references Add Trade CTA and older mockup direction. Should be reconciled with Add Holding and Figma issue #69 output. |
+| `docs/design/v1-ui-mockup-plan.md` | Historical visual reference | Updated during #74 cleanup to point current V1 work to `DESIGN.md` and Figma issue #69 files. |
 | `docs/design/v2-ui-mockup-plan.md` | Future reference | Fine for V2, but should not drive current V1 work. |
 | `docs/design/v3-ui-mockup-plan.md` | Future reference | Fine for V3, but should not drive current V1 work. |
 | `docs/cogvest_standard_mode.png` | Historical mockup | Older visual direction. Current Figma/code.js and `DESIGN.md` should override it. |
@@ -39,10 +42,9 @@ Date: 2026-05-06
 
 ## Recommended Doc Tasks
 
-1. Create a V1 docs cleanup issue to label old prompt/mockup docs as historical
-   and remove V1-scope ambiguity.
+1. Created #74 and updated old prompt/mockup docs as historical references.
 2. Complete #66 with an Excel parity checklist that references #61-#65 and
    makes the #60 gate explicit.
-3. Update V1 docs to consistently use Add Holding for user-facing UI.
-4. Add a local Gradle release APK note to Android PC harness docs:
+3. Updated V1 docs to consistently use Add Holding for user-facing UI where applicable.
+4. Added a local Gradle release APK note to Android PC harness docs:
    debug APK needs Metro; release APK is the standalone local install artifact.

--- a/docs/housekeeping/verification-baseline.md
+++ b/docs/housekeeping/verification-baseline.md
@@ -2,6 +2,10 @@
 
 Date: 2026-05-06
 
+Status: historical verification snapshot. #72 was later addressed by PR #78;
+re-run `npm run test:v1:pc` and Maestro before using this as current release
+evidence.
+
 Environment:
 
 - OS shell: Windows PowerShell

--- a/docs/issues/v1-add-stable-testids-for-android-e2e.md
+++ b/docs/issues/v1-add-stable-testids-for-android-e2e.md
@@ -30,7 +30,7 @@ Add stable testIDs where needed for Android E2E:
 
 ## Acceptance Criteria
 
-- Maestro Add Trade flow can target controls by stable IDs.
+- Maestro Add Holding flow can target controls by stable IDs.
 - Value masking flow can target the toggle by stable ID.
 - Existing component tests remain green.
 - No behavior or visual design changes are introduced.

--- a/docs/issues/v1-issue-drafts.md
+++ b/docs/issues/v1-issue-drafts.md
@@ -1,5 +1,10 @@
 # V1 Issue Drafts
 
+> Status: historical issue-draft reference. The live GitHub issues are the
+> source of truth. User-facing V1 language should now prefer Add Holding,
+> Dashboard, Holdings, Progress, Cash, and Settings; internal code may still use
+> trade terminology until refactored.
+
 Milestone: CogVest V1 MVP
 
 ## [V1] Scaffold Expo Android app
@@ -190,7 +195,7 @@ V1 should feel like a tracker, not a static ledger.
 - `npx jest`
 - `npx expo start`
 
-## [V1] Build Add Trade validation
+## [V1] Build Add Holding validation
 
 Labels: `v1`, `domain`, `testing`, `feature`, `priority-high`
 
@@ -225,12 +230,12 @@ Trade validation must be correct before the UI writes local data.
 - `npx jest`
 - `npx expo start`
 
-## [V1] Build Add Trade screen
+## [V1] Build Add Holding screen
 
 Labels: `v1`, `frontend`, `feature`, `priority-high`
 
 ### Context
-Fast trade entry is the core V1 workflow.
+Fast Add Holding entry is the core V1 workflow.
 
 ### Scope
 - Buy/sell toggle.
@@ -315,7 +320,7 @@ Dashboard gives the at-a-glance portfolio view.
 - Allocation.
 - Quote freshness.
 - Basic conviction nudge.
-- Add Trade CTA.
+- Add Holding CTA.
 - Value masking support.
 
 ### Out of Scope
@@ -548,7 +553,7 @@ Production AAB should be a release-candidate gate, not a dev-complete blocker.
 - `npx jest`
 - `npx expo start`
 
-## [V1] Verify preview APK on device
+## [V1] Verify preview APK on emulator
 
 Labels: `v1`, `infra`, `release`, `testing`, `priority-high`
 
@@ -558,7 +563,7 @@ V1 dev-complete requires an installable Android preview build.
 ### Scope
 - Run V1 release checklist dev-complete gate.
 - Build preview APK.
-- Install on real device.
+- Install on Android Emulator.
 - Record build URL and manual QA notes.
 
 ### Out of Scope
@@ -573,7 +578,7 @@ V1 dev-complete requires an installable Android preview build.
 
 ### Acceptance Criteria
 - Preview APK builds.
-- APK installs on a real Android device.
+- APK installs on Android Emulator.
 - Core manual flows pass or defects are logged.
 
 ### Test Steps

--- a/docs/prompts/versioned-roadmap-planning-prompt.md
+++ b/docs/prompts/versioned-roadmap-planning-prompt.md
@@ -2,6 +2,11 @@ You are working on CogVest.
 
 This repo uses the Superpowers plugin in Codex CLI.
 
+> Status: historical planning prompt. It records how the versioned roadmap was
+> created, but it is not the current implementation contract. Current agents
+> should start with `AGENTS.md`, `DESIGN.md`,
+> `docs/roadmap/cogvest-version-roadmap.md`, and the active GitHub issues.
+
 Read these files first:
 - AGENTS.md
 - docs/cogvest-master-spec.md

--- a/docs/release/android-release-process.md
+++ b/docs/release/android-release-process.md
@@ -19,6 +19,18 @@ Purpose: optional installable APK for internal distribution. For local
 developer verification, prefer a PC-built APK installed on Android Emulator so
 EAS cloud compute is not consumed.
 
+Local PC command:
+
+```powershell
+.\android\gradlew.bat -p android assembleRelease
+```
+
+Local output:
+
+```text
+android/app/build/outputs/apk/release/
+```
+
 Command:
 
 ```bash

--- a/docs/release/play-store-listing-draft.md
+++ b/docs/release/play-store-listing-draft.md
@@ -24,7 +24,7 @@ Initial V1 preview:
 
 - Dashboard filled.
 - Dashboard masked.
-- Add Trade.
+- Add Holding.
 - Holdings filled.
 - Cash.
 - Settings.

--- a/docs/roadmap/cogvest-version-roadmap.md
+++ b/docs/roadmap/cogvest-version-roadmap.md
@@ -3,10 +3,10 @@
 ## Source References
 
 - Master spec: `docs/cogvest-master-spec.md`
-- Original full prompt set: `docs/cogvest-codex-prompts.md`
+- Historical full prompt set: `docs/cogvest-codex-prompts.md` (reference only; current V1 scope is this roadmap plus `AGENTS.md`)
 - Planning prompt: `docs/prompts/versioned-roadmap-planning-prompt.md`
 - Figma mockups: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d
-- Visual references: `docs/cogvest_standard_mode.png`, `docs/cogvest_minimal_mode.png`
+- Historical visual references: `docs/cogvest_standard_mode.png`, `docs/cogvest_minimal_mode.png` (superseded for V1 by `DESIGN.md` and the issue #69 Figma screens)
 
 ## Version Strategy
 
@@ -21,7 +21,8 @@ Goal: replace a spreadsheet for day-to-day local portfolio tracking on Android.
 Included:
 - Expo/React Native foundation with TypeScript strict mode.
 - Local MMKV persistence through Zustand.
-- Add Trade with buy/sell, quantity, price, date, fees, notes, and optional conviction.
+- Add Holding with opening position entry, asset metadata, current/manual price, notes, and optional conviction.
+- Lightweight asset lookup/autofill for common supported assets, with manual fallback.
 - Live quote fetching for current prices on app open and pull-to-refresh.
 - Manual price fallback when quotes fail.
 - Holdings derived from trades.
@@ -44,7 +45,7 @@ Excluded:
 - Automatic Play Store submission.
 
 Release gates:
-- V1 dev-complete: typecheck, tests, Expo doctor, app launch, manual core flows, preview APK build, preview APK install on real Android device.
+- V1 dev-complete: typecheck, tests, Expo doctor, Android Emulator app launch, local APK build/install on the emulator, and passing or logged defects for core flows.
 - V1 release-candidate: production AAB build succeeds, EAS URL recorded, Play Console internal testing upload ready/manual.
 
 ## V2: Behaviour Layer

--- a/docs/roadmap/v1-codex-prompts.md
+++ b/docs/roadmap/v1-codex-prompts.md
@@ -1,5 +1,10 @@
 # CogVest V1 Codex Prompts
 
+> Status: historical execution prompt reference. The live GitHub issues,
+> `AGENTS.md`, `DESIGN.md`, and `docs/roadmap/v1-mvp-spec.md` are the current
+> source of truth. User-facing V1 language should prefer Add Holding; existing
+> code and tests may still use trade terminology internally.
+
 Use these prompts in order. Each issue should remain independently testable and should not add V2/V3 scope.
 
 ## [V1] Scaffold Expo Android app
@@ -11,7 +16,7 @@ Files:
 - `app/(tabs)/_layout.tsx`
 - `app/(tabs)/dashboard.tsx`
 - `app/(tabs)/holdings.tsx`
-- `app/(tabs)/add-trade.tsx`
+- `app/add-holding.tsx`
 - `app/(tabs)/cash.tsx`
 - `app/settings.tsx`
 - `package.json`
@@ -86,7 +91,7 @@ Acceptance:
 - Failures return null/empty and do not throw into UI.
 - Manual price fallback remains available.
 
-## [V1] Build Add Trade form validation
+## [V1] Build Add Holding form validation
 
 Create form schema and validation logic before UI integration.
 
@@ -101,12 +106,12 @@ Acceptance:
 - Sell quantity cannot exceed current holding.
 - Conviction remains optional.
 
-## [V1] Build Add Trade screen
+## [V1] Build Add Holding screen
 
 Implement fast trade entry with live/manual price and optional conviction.
 
 Files:
-- `app/(tabs)/add-trade.tsx`
+- `app/add-holding.tsx`
 - `src/components/forms/ConvictionSelector.tsx`
 - `src/components/forms/AssetPicker.tsx`
 - `src/components/forms/TradeReviewSheet.tsx`
@@ -227,5 +232,5 @@ Files:
 
 Acceptance:
 - Preview APK builds.
-- Preview APK installs on real Android device.
+- Preview/local APK installs on Android Emulator.
 - EAS URL and manual test notes are recorded.

--- a/docs/roadmap/v1-mvp-spec.md
+++ b/docs/roadmap/v1-mvp-spec.md
@@ -6,7 +6,7 @@ Ship a usable Android portfolio tracker that replaces a spreadsheet for local da
 
 ## Target User Value
 
-The user can record trades quickly, see current holdings and portfolio value in INR, track cash, mask sensitive values, and begin collecting conviction context without needing login, backend, or cloud sync.
+The user can add holdings quickly, see current holdings and portfolio value in INR, track cash, mask sensitive values, and begin collecting conviction context without needing login, backend, or cloud sync.
 
 ## Included Features
 
@@ -18,7 +18,8 @@ The user can record trades quickly, see current holdings and portfolio value in 
 - Quote services for Yahoo Finance and CoinGecko current prices.
 - Quote refresh on app open and pull-to-refresh.
 - Manual current-price fallback if quote fetching fails.
-- Add Trade screen with optional conviction.
+- Add Holding screen for opening positions and trade-backed local entries, with optional conviction.
+- Lightweight asset lookup/autofill for common supported assets, with manual fallback.
 - Holdings screen derived from trades and current quotes.
 - Dashboard with total value, allocation, quote freshness, and basic conviction nudge.
 - Cash screen for additions and withdrawals.
@@ -43,11 +44,10 @@ The user can record trades quickly, see current holdings and portfolio value in 
 
 - Dashboard.
 - Holdings.
-- Add Trade.
+- Add Holding.
 - Cash.
+- Monthly Progress.
 - Settings.
-
-History can be a simple trade list if it fits V1 timing; otherwise trade rows appear within Holdings/Add Trade validation support and History moves to V2.
 
 ## Data Model Changes
 
@@ -88,7 +88,7 @@ Do not persist holdings, allocation, dashboard totals, or insights.
 ## Test Plan
 
 - Unit tests for domain calculations, formatters, validators, selectors, and store actions.
-- Component tests for empty states, value masking, conviction selector, and Add Trade validation.
+- Component tests for empty states, value masking, conviction selector, and Add Holding validation.
 - PC-based Android Emulator checks for navigation, trade entry, holdings, dashboard, cash, masking, and persistence.
 
 ## PC Verification Checklist
@@ -139,5 +139,5 @@ Portfolio values, quantities, trades, notes, and conviction stay local. Quote AP
 
 - Yahoo/CoinGecko informal API reliability.
 - Real-time quote source limits.
-- History screen may be scoped down if V1 timeline tightens.
+- Monthly Progress depends on persisted monthly snapshots; missing snapshot support must be logged against the Excel parity issues.
 - Export/import deferred creates local-device data loss risk.

--- a/docs/roadmap/v2-behaviour-spec.md
+++ b/docs/roadmap/v2-behaviour-spec.md
@@ -10,7 +10,7 @@ The user sees patterns in conviction, patience, trading frequency, and tax-relev
 
 ## Included Features
 
-- Minimal Mode across Dashboard, Holdings, Add Trade, Cash, Settings, and History/Asset Detail if present.
+- Minimal Mode across Dashboard, Holdings, Add Holding, Progress, Cash, Settings, and Asset Detail if present.
 - Improved conviction analytics.
 - Patience analysis using intended hold periods.
 - Trade frequency analysis.
@@ -33,8 +33,8 @@ The user sees patterns in conviction, patience, trading frequency, and tax-relev
 - Insight detail.
 - Settings with Minimal Mode preferences.
 - Holdings with basic LTCG states.
-- Add Trade with intended hold period.
-- History or Asset Detail if V1 deferred them.
+- Add Holding with intended hold period.
+- Progress or Asset Detail if V1 deferred them.
 
 ## Data Model Changes
 
@@ -68,7 +68,7 @@ The user sees patterns in conviction, patience, trading frequency, and tax-relev
 ## Manual QA Checklist
 
 - Switch Standard/Minimal Mode.
-- Confirm Add Trade still works in Minimal Mode.
+- Confirm Add Holding still works in Minimal Mode.
 - Add intended hold period and later sell to test patience analysis.
 - Add enough rated trades for conviction insight.
 - Verify LTCG hidden for crypto and visible for Indian stock/ETF.

--- a/docs/roadmap/v2-codex-prompts.md
+++ b/docs/roadmap/v2-codex-prompts.md
@@ -12,7 +12,7 @@ Reduce day-change noise, colour emphasis, and information density across support
 
 ## [V2] Add intended hold capture
 
-Extend Add Trade with optional intended hold period and persistence.
+Extend Add Holding with optional intended hold period and persistence.
 
 ## [V2] Implement behaviour analytics
 

--- a/docs/testing/android-emulator-checklist.md
+++ b/docs/testing/android-emulator-checklist.md
@@ -19,7 +19,7 @@
 - [ ] App launches to Dashboard, not Unmatched Route.
 - [ ] Dashboard tab renders.
 - [ ] Holdings tab renders.
-- [ ] Add Trade tab renders.
+- [ ] Add Holding flow renders.
 - [ ] Cash tab renders.
 - [ ] Settings opens.
 - [ ] App can be closed and reopened.

--- a/docs/testing/android-pc-test-harness.md
+++ b/docs/testing/android-pc-test-harness.md
@@ -122,6 +122,26 @@ npm run android
 Use this when a local native build is needed. For normal JavaScript and
 TypeScript iteration, start Metro and press `a`.
 
+## Local Release APK Build
+
+Use this path for developer APK smoke testing when you do not want to spend EAS
+cloud build compute:
+
+```powershell
+.\android\gradlew.bat -p android assembleRelease
+```
+
+The release APK is generated under:
+
+```text
+android/app/build/outputs/apk/release/
+```
+
+Install it on the emulator with `adb install -r path\to\app-release.apk`, then
+run `npm run android:smoke -- --strict`. If Gradle signing is not configured,
+use the local dev build path (`npm run android`) for emulator verification and
+record the release APK blocker as a defect.
+
 ## Install a Preview APK
 
 APK files can be installed locally on an emulator:
@@ -170,11 +190,14 @@ See `docs/testing/maestro-e2e.md` for install and troubleshooting notes.
 
 ## Stable V1 testIDs
 
-Stable Android E2E IDs are available for V1 flows:
+Stable Android E2E IDs are available for V1 flows. Some IDs still use internal
+`trade` naming for backward compatibility while the user-facing screen says Add
+Holding:
 
 - `dashboard-screen`
 - `holdings-screen`
 - `add-trade-screen`
+- `add-holding-screen`
 - `add-trade-button`
 - `asset-input`
 - `symbol-input`

--- a/docs/testing/apk-smoke-test-checklist.md
+++ b/docs/testing/apk-smoke-test-checklist.md
@@ -1,6 +1,7 @@
 # APK Smoke Test Checklist
 
-- [ ] Build or download an APK. Prefer local PC builds for developer smoke tests.
+- [ ] Build or download an APK. Prefer local PC builds for developer smoke tests:
+  `.\android\gradlew.bat -p android assembleRelease`.
 - [ ] Start Android Emulator.
 - [ ] Confirm emulator is ready with `adb devices`.
 - [ ] Install APK with `adb install -r path/to/app.apk`.

--- a/docs/testing/maestro-e2e.md
+++ b/docs/testing/maestro-e2e.md
@@ -63,7 +63,7 @@ npm run maestro:test -- e2e/smoke-launch.yaml
 ## Flow Set
 
 - `e2e/smoke-launch.yaml`: cold-launch and Dashboard smoke.
-- `e2e/add-trade.yaml`: add a buy trade with stable form IDs.
+- `e2e/add-trade.yaml`: add a holding/opening entry with stable form IDs.
 - `e2e/holdings.yaml`: create a trade and verify Holdings.
 - `e2e/cash.yaml`: add cash and verify Cash.
 - `e2e/value-masking.yaml`: open Settings by deep link and toggle masking.

--- a/docs/testing/v1-core-flow-test-matrix.md
+++ b/docs/testing/v1-core-flow-test-matrix.md
@@ -37,10 +37,10 @@ approved.
 | V1 feature | Primary verification | Emulator / E2E coverage | Evidence |
 | --- | --- | --- | --- |
 | Cold launch | `src/__tests__/rootRoute.test.ts` | `e2e/smoke-launch.yaml` launches `com.abdulshaikh.cogvest` and asserts `dashboard-screen` | UI tree or Maestro output shows Dashboard, not Unmatched Route |
-| Dashboard empty state | `src/features/dashboard/__tests__/DashboardScreen.test.tsx` | `e2e/smoke-launch.yaml` asserts `dashboard-screen` and tab labels | Dashboard shows portfolio value and Add Trade path |
-| Add Trade buy flow | `src/features/trades/__tests__/AddTradeForm.test.tsx` | `e2e/add-trade.yaml` uses stable form IDs and saves a buy trade | Trade logged message or holding appears |
-| Add Trade validation | `src/features/trades/__tests__/AddTradeForm.test.tsx`, `src/domain/validators/__tests__/trade.test.ts` | Optional Maestro follow-up for validation text | Invalid oversell and missing fields are rejected |
-| Holdings derivation | `src/features/holdings/__tests__/HoldingsScreen.test.tsx`, `src/domain/calculations/__tests__/holdings.test.ts` | `e2e/holdings.yaml` asserts holdings after Add Trade | Holding row shows symbol, quantity, value |
+| Dashboard empty state | `src/features/dashboard/__tests__/DashboardScreen.test.tsx` | `e2e/smoke-launch.yaml` asserts `dashboard-screen` and tab labels | Dashboard shows portfolio value and Add Holding path |
+| Add Holding buy flow | `src/features/trades/__tests__/AddTradeForm.test.tsx` | `e2e/add-trade.yaml` uses stable form IDs and saves an opening/buy entry | Saved message or holding appears |
+| Add Holding validation | `src/features/trades/__tests__/AddTradeForm.test.tsx`, `src/domain/validators/__tests__/trade.test.ts` | Optional Maestro follow-up for validation text | Invalid oversell and missing fields are rejected |
+| Holdings derivation | `src/features/holdings/__tests__/HoldingsScreen.test.tsx`, `src/domain/calculations/__tests__/holdings.test.ts` | `e2e/holdings.yaml` asserts holdings after Add Holding | Holding row shows symbol, quantity, value |
 | Quote refresh and fallback | `src/services/quotes/__tests__/quotes.test.ts`, `src/services/quotes/__tests__/useQuoteRefresh.test.tsx`, Holdings tests | Manual emulator pull-to-refresh or Refresh Quotes action where network is available | Failures keep manual prices visible |
 | Cash tracking | `src/features/cash/__tests__/CashScreen.test.tsx`, `src/features/cash/__tests__/useCash.test.tsx` | `e2e/cash.yaml` adds cash by stable IDs | Cash balance and cash history update |
 | Value masking | `src/features/settings/__tests__/SettingsScreen.test.tsx`, dashboard/holdings/cash masked-value tests | `e2e/value-masking.yaml` opens `cogvest://settings` and toggles `value-mask-toggle` | Wealth values mask; quantities and percentages remain visible |

--- a/docs/testing/v1-pc-verification-checklist.md
+++ b/docs/testing/v1-pc-verification-checklist.md
@@ -22,7 +22,7 @@ Android Emulator, not a physical Android phone.
 ## Core Flow Gate
 
 - [ ] Dashboard shows portfolio value and bottom tabs.
-- [ ] Add Trade can save a buy trade.
+- [ ] Add Holding can save an opening/buy entry.
 - [ ] Holdings reflect the saved trade.
 - [ ] Invalid trade data shows validation errors.
 - [ ] Cash can be added.

--- a/docs/testing/v1-testing-plan.md
+++ b/docs/testing/v1-testing-plan.md
@@ -38,7 +38,7 @@ Cover:
 Cover:
 - Empty Dashboard.
 - Empty Holdings.
-- Add Trade validation messages.
+- Add Holding validation messages.
 - Conviction selector select/deselect.
 - MaskedValue display.
 - Cash add/withdraw rows.

--- a/docs/testing/v2-testing-plan.md
+++ b/docs/testing/v2-testing-plan.md
@@ -10,7 +10,7 @@
 
 - Toggle Minimal Mode from Settings.
 - Confirm day-change noise is hidden.
-- Confirm Add Trade and Cash remain available.
+- Confirm Add Holding and Cash remain available.
 - Add intended hold, sell later, verify patience insight.
 - Generate enough rated trades for conviction insight.
 - Verify LTCG appears for Indian stock/ETF and never for crypto.


### PR DESCRIPTION
## Summary

- Marked old prompt, master-spec, mockup, and housekeeping docs as historical where they can mislead V1 work.
- Updated current V1 docs toward Add Holding, Monthly Progress, PC-only emulator verification, and local APK build/install.
- Added local Gradle release APK notes so developer APK smoke testing does not imply EAS cloud builds.

## Verification

- `npm run typecheck`
- `npm test`
- `npm run doctor`
- `git diff --check`

Closes #74
