### PR TITLE
design: add premium V1 design preview

### DIFF
--- a/docs/design/figma/issue-69-v1-screens/README.md
+++ b/docs/design/figma/issue-69-v1-screens/README.md
@@ -37,5 +37,7 @@ The plugin creates seven editable Android frames:
   existing nodes. This avoids Figma rerun failures and keeps revision history
   available for comparison.
 - It does not modify the existing roadmap pages.
+- The Add Holding frame is intentionally taller than one viewport so the Figma
+  source captures the full lookup-first flow from the HTML preview.
 - Use these frames as the stable source for later Figma refinements.
 - Keep `DESIGN.md` as the product design contract.

--- a/docs/design/figma/issue-69-v1-screens/README.md
+++ b/docs/design/figma/issue-69-v1-screens/README.md
@@ -1,14 +1,14 @@
-# CogVest Issue 69 V1 Figma Screens
+# CogVest Issue 86 Premium V1 Figma Screens
 
 This folder contains a deterministic Figma development plugin that creates
-editable V1 screen frames for issue #69.
+editable V1 screen frames for issue #86.
 
 ## Why This Exists
 
 Generated PNG mockups are useful for exploration, but they are unstable design
-sources. This plugin recreates the approved true-dark private ledger direction
-as editable Figma layers: frames, borderless cards, text, vector icons, and
-simple shapes.
+sources. This plugin recreates the approved premium private-ledger direction
+as editable Figma layers: frames, borderless cards, text, vector icons, simple
+shapes, and SVG chart groups.
 
 ## How To Run
 
@@ -16,24 +16,26 @@ simple shapes.
    `https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d`
 2. In Figma desktop, go to `Plugins -> Development -> Import plugin from manifest...`.
 3. Select `docs/design/figma/issue-69-v1-screens/manifest.json`.
-4. Run `Plugins -> Development -> CogVest Issue 69 V1 Screens`.
-5. The plugin creates or refreshes the page `Issue 69 - V1 UI Concepts`.
+4. Run `Plugins -> Development -> CogVest Issue 86 Premium V1 Screens`.
+5. The plugin creates a fresh page named `Issue 86 - Premium V1 Screens`.
 
 ## Output
 
-The plugin creates six editable Android frames:
+The plugin creates seven editable Android frames:
 
 - Dashboard
 - Holdings
 - Add Holding
-- Cash
 - Monthly Progress
+- Cash
 - Settings
+- V1 States
 
 ## Notes
 
-- The plugin clears and recreates only the child layers inside the page named
-  `Issue 69 - V1 UI Concepts`.
+- The plugin creates a fresh versioned page on every run instead of removing
+  existing nodes. This avoids Figma rerun failures and keeps revision history
+  available for comparison.
 - It does not modify the existing roadmap pages.
 - Use these frames as the stable source for later Figma refinements.
 - Keep `DESIGN.md` as the product design contract.

--- a/docs/design/figma/issue-69-v1-screens/README.md
+++ b/docs/design/figma/issue-69-v1-screens/README.md
@@ -21,13 +21,15 @@ shapes, and SVG chart groups.
 
 ## Output
 
-The plugin creates seven editable Android frames:
+The plugin creates nine editable Android frames:
 
 - Dashboard
 - Holdings
-- Add Holding
+- Add Holding - Asset Lookup
+- Add Holding - Position
+- Add Holding - Review
 - Monthly Progress
-- Cash
+- Cash Ledger
 - Settings
 - V1 States
 
@@ -37,7 +39,7 @@ The plugin creates seven editable Android frames:
   existing nodes. This avoids Figma rerun failures and keeps revision history
   available for comparison.
 - It does not modify the existing roadmap pages.
-- The Add Holding frame is intentionally taller than one viewport so the Figma
-  source captures the full lookup-first flow from the HTML preview.
+- Add Holding is split into focused states so the full lookup-first behavior is
+  captured without making one crowded long-form screen.
 - Use these frames as the stable source for later Figma refinements.
 - Keep `DESIGN.md` as the product design contract.

--- a/docs/design/figma/issue-69-v1-screens/code.js
+++ b/docs/design/figma/issue-69-v1-screens/code.js
@@ -370,7 +370,7 @@ async function main() {
   // Holdings
   stage = "draw holdings";
   const holdings = screen("Holdings", 448);
-  header(holdings, "Holdings", "24 positions · local data", ["eye", "search"]);
+  header(holdings, "Holdings", "24 positions · local data", ["plus", "search", "eye"]);
   metricStrip(holdings, PAD, 144, [
     { label: "Current", value: "₹12.48L" },
     { label: "Invested", value: "₹11.05L" },

--- a/docs/design/figma/issue-69-v1-screens/code.js
+++ b/docs/design/figma/issue-69-v1-screens/code.js
@@ -335,7 +335,7 @@ async function main() {
   }
 
   stage = "draw canvas";
-  rect(page, -80, -80, 3200, 1120, C.canvas, 0);
+  rect(page, -80, -80, 4300, 1120, C.canvas, 0);
   stage = "draw title";
   pageTitle();
 
@@ -371,7 +371,7 @@ async function main() {
   // Holdings
   stage = "draw holdings";
   const holdings = screen("Holdings", 448);
-  header(holdings, "Holdings", "24 positions · local data", ["plus", "search", "eye"]);
+  header(holdings, "Holdings", "24 positions · local data", ["plus", "search"]);
   metricStrip(holdings, PAD, 144, [
     { label: "Current", value: "₹12.48L" },
     { label: "Invested", value: "₹11.05L" },
@@ -392,55 +392,91 @@ async function main() {
   ].forEach((r, i) => row(holdings, PAD, 326 + i * 82, CONTENT_W, r[0], r[1], r[2], r[3], r[4]));
   nav(holdings, "Holdings");
 
-  // Add Holding
-  stage = "draw add holding";
-  const add = screen("Add Holding", 872, 150, 1100);
-  header(add, "Add Holding", "Opening position · local only", ["help"]);
+  // Add Holding - Asset Lookup
+  stage = "draw add holding asset";
+  const addAsset = screen("Add Holding - Asset Lookup", 872);
+  header(addAsset, "Add Holding", "Opening position · local only", ["help"]);
   ["Asset", "Class", "Position", "Review"].forEach((s, i) => {
     const cx = 55 + i * 94;
-    glyph(add, cx - 14, 144, i === 0 ? "equity" : "neutral", 28);
-    text(add, s, cx - 34, 180, 10, i === 0 ? C.green : C.secondary, i === 0 ? "Bold" : "Regular", 68, "CENTER");
-    if (i < 3) line(add, cx + 20, 158, 50, 0.32);
+    glyph(addAsset, cx - 14, 144, i === 0 ? "equity" : "neutral", 28);
+    text(addAsset, s, cx - 34, 180, 10, i === 0 ? C.green : C.secondary, i === 0 ? "Bold" : "Regular", 68, "CENTER");
+    if (i < 3) line(addAsset, cx + 20, 158, 50, 0.32);
   });
-  card(add, PAD, 216, CONTENT_W, 122);
-  sectionTitle(add, "Find asset", 38, 238);
-  rect(add, 38, 268, 314, 44, C.field, 16);
-  icon(add, "search", 52, 280, C.secondary, 18);
-  text(add, "Search name or symbol", 80, 280, 13, C.secondary, "Regular", 190);
-  text(add, "Only search text is sent to quote providers.", 38, 318, 10.5, C.muted, "Regular", 260);
-  row(add, PAD, 352, CONTENT_W, "equity", "HDFC Bank", "HDFCBANK.NS · NSE · INR · Equity", "₹1,678.25", "Live", C.text);
-  row(add, PAD, 424, CONTENT_W, "crypto", "Bitcoin", "bitcoin · CoinGecko · INR", "₹92.10L", "Live", C.text);
-  card(add, PAD, 510, CONTENT_W, 86);
-  sectionTitle(add, "Selected asset", 38, 530);
-  metric(add, "Name", "HDFC Bank", 38, 558, 88);
-  metric(add, "Ticker", "HDFCBANK.NS", 142, 558, 104);
-  metric(add, "Currency", "INR", 270, 558, 60);
-  card(add, PAD, 610, CONTENT_W, 74);
-  sectionTitle(add, "Next: Classification", 38, 630);
-  metric(add, "Suggested", "Equity · Large Cap", 38, 656, 128);
-  metric(add, "Sector", "Financial Services", 190, 656, 136);
-  card(add, PAD, 698, CONTENT_W, 92);
-  sectionTitle(add, "Position details", 38, 718);
-  metric(add, "Quantity", "25", 38, 750, 70);
-  metric(add, "Average cost", "₹1,450.00", 122, 750, 92);
-  metric(add, "Current price", "₹1,678.25", 232, 750, 96);
-  card(add, PAD, 804, CONTENT_W, 90);
-  sectionTitle(add, "Derived preview", 38, 824);
-  metric(add, "Invested", "₹36,250", 38, 856, 82);
-  metric(add, "Current", "₹41,956", 134, 856, 82);
-  metric(add, "P&L", "+₹5,706 · +15.7%", 230, 856, 112, C.green);
-  card(add, PAD, 908, CONTENT_W, 64);
-  sectionTitle(add, "Review", 38, 928);
-  text(add, "Conviction and notes stay optional. Save only after derived values look right.", 38, 954, 11, C.secondary, "Regular", 276);
-  rect(add, PAD, 992, 176, 48, C.brandGreen, 18);
-  text(add, "Continue", PAD, 1008, 13, C.text, "Bold", 176, "CENTER");
-  rect(add, PAD + 188, 992, 126, 48, C.surface, 18, C.separator, 0.45);
-  text(add, "Enter manually", PAD + 188, 1008, 13, C.text, "Semi Bold", 126, "CENTER");
-  nav(add, "Holdings");
+  card(addAsset, PAD, 216, CONTENT_W, 150);
+  sectionTitle(addAsset, "Find asset", 38, 238);
+  rect(addAsset, 38, 270, 314, 48, C.field, 16);
+  icon(addAsset, "search", 52, 284, C.secondary, 18);
+  text(addAsset, "Search name or symbol", 80, 284, 13, C.secondary, "Regular", 190);
+  text(addAsset, "Only search text is sent to quote providers.", 38, 330, 10.5, C.muted, "Regular", 260);
+  row(addAsset, PAD, 396, CONTENT_W, "equity", "HDFC Bank", "HDFCBANK.NS · NSE · INR · Equity", "₹1,678.25", "Live", C.text);
+  row(addAsset, PAD, 480, CONTENT_W, "crypto", "Bitcoin", "bitcoin · CoinGecko · INR", "₹92.10L", "Live", C.text);
+  card(addAsset, PAD, 588, CONTENT_W, 74);
+  sectionTitle(addAsset, "Selected result", 38, 608, "Change");
+  text(addAsset, "HDFC Bank · HDFCBANK.NS · INR", 38, 638, 13, C.text, "Semi Bold", 230);
+  rect(addAsset, PAD, 704, CONTENT_W, 48, C.brandGreen, 18);
+  text(addAsset, "Continue to position", PAD, 720, 13, C.text, "Bold", CONTENT_W, "CENTER");
+  nav(addAsset, "Holdings");
+
+  // Add Holding - Position
+  stage = "draw add holding position";
+  const addPosition = screen("Add Holding - Position", 1296);
+  header(addPosition, "Add Holding", "Position details · HDFC Bank", ["help"]);
+  ["Asset", "Class", "Position", "Review"].forEach((s, i) => {
+    const cx = 55 + i * 94;
+    glyph(addPosition, cx - 14, 144, i <= 2 ? "equity" : "neutral", 28);
+    text(addPosition, s, cx - 34, 180, 10, i === 2 ? C.green : C.secondary, i === 2 ? "Bold" : "Regular", 68, "CENTER");
+    if (i < 3) line(addPosition, cx + 20, 158, 50, 0.32);
+  });
+  card(addPosition, PAD, 224, CONTENT_W, 112);
+  sectionTitle(addPosition, "Classification", 38, 246, "Edit");
+  metric(addPosition, "Asset class", "Equity", 38, 278, 82);
+  metric(addPosition, "Type", "Large Cap", 132, 278, 82);
+  metric(addPosition, "Sector", "Financial", 234, 278, 96);
+  card(addPosition, PAD, 360, CONTENT_W, 174);
+  sectionTitle(addPosition, "Position details", 38, 382);
+  formField(addPosition, 38, 420, 148, "Quantity", "25");
+  formField(addPosition, 202, 420, 150, "Average cost", "₹1,450.00");
+  formField(addPosition, 38, 492, 148, "Current price", "₹1,678.25");
+  formField(addPosition, 202, 492, 150, "Date acquired", "15 Apr 2024");
+  card(addPosition, PAD, 560, CONTENT_W, 98);
+  sectionTitle(addPosition, "Live quote", 38, 582);
+  text(addPosition, "Provider found HDFCBANK.NS. Manual fallback remains available.", 38, 612, 12, C.secondary, "Regular", 270);
+  rect(addPosition, PAD, 704, CONTENT_W, 48, C.brandGreen, 18);
+  text(addPosition, "Review holding", PAD, 720, 13, C.text, "Bold", CONTENT_W, "CENTER");
+  nav(addPosition, "Holdings");
+
+  // Add Holding - Review
+  stage = "draw add holding review";
+  const addReview = screen("Add Holding - Review", 1720);
+  header(addReview, "Add Holding", "Review before saving", ["help"]);
+  ["Asset", "Class", "Position", "Review"].forEach((s, i) => {
+    const cx = 55 + i * 94;
+    glyph(addReview, cx - 14, 144, "equity", 28);
+    text(addReview, s, cx - 34, 180, 10, i === 3 ? C.green : C.secondary, i === 3 ? "Bold" : "Regular", 68, "CENTER");
+    if (i < 3) line(addReview, cx + 20, 158, 50, 0.32);
+  });
+  card(addReview, PAD, 224, CONTENT_W, 118);
+  sectionTitle(addReview, "Holding summary", 38, 246);
+  metric(addReview, "Asset", "HDFC Bank", 38, 278, 88);
+  metric(addReview, "Ticker", "HDFCBANK.NS", 144, 278, 104);
+  metric(addReview, "Source", "Live", 270, 278, 60);
+  card(addReview, PAD, 366, CONTENT_W, 110);
+  sectionTitle(addReview, "Derived preview", 38, 388);
+  metric(addReview, "Invested", "₹36,250", 38, 424, 82);
+  metric(addReview, "Current", "₹41,956", 134, 424, 82);
+  metric(addReview, "P&L", "+₹5,706 · +15.7%", 230, 424, 112, C.green);
+  card(addReview, PAD, 500, CONTENT_W, 76);
+  sectionTitle(addReview, "Optional context", 38, 520);
+  text(addReview, "Conviction and notes stay optional. CogVest can save without them.", 38, 548, 12, C.secondary, "Regular", 276);
+  rect(addReview, PAD, 704, 176, 48, C.brandGreen, 18);
+  text(addReview, "Save holding", PAD, 720, 13, C.text, "Bold", 176, "CENTER");
+  rect(addReview, PAD + 188, 704, 126, 48, C.surface, 18, C.separator, 0.45);
+  text(addReview, "Enter manually", PAD + 188, 720, 13, C.text, "Semi Bold", 126, "CENTER");
+  nav(addReview, "Holdings");
 
   // Progress
   stage = "draw progress";
-  const progress = screen("Monthly Progress", 1296);
+  const progress = screen("Monthly Progress", 2144);
   header(progress, "Monthly Progress", "May 2026 snapshot", ["eye"]);
   chip(progress, "Apr 2026", PAD, 144, false, 86);
   chip(progress, "May 2026", PAD + 96, 144, true, 94);
@@ -470,7 +506,7 @@ async function main() {
 
   // Cash
   stage = "draw cash";
-  const cash = screen("Cash Ledger", 1720);
+  const cash = screen("Cash Ledger", 2568);
   header(cash, "Cash Ledger", "Manual ledger · local only", ["eye", "plus"]);
   card(cash, PAD, 144, CONTENT_W, 134);
   text(cash, "Cash balance", 38, 166, 12, C.secondary, "Semi Bold", 120);
@@ -497,7 +533,7 @@ async function main() {
 
   // Settings
   stage = "draw settings";
-  const settings = screen("Settings", 2144);
+  const settings = screen("Settings", 2992);
   header(settings, "Settings", "Local-first controls", ["info"]);
   sectionLabel(settings, "Privacy", PAD, 144);
   groupedRows(settings, PAD, 166, [
@@ -529,7 +565,7 @@ async function main() {
 
   // V1 States
   stage = "draw states";
-  const states = screen("V1 States", 2568);
+  const states = screen("V1 States", 3416);
   header(states, "V1 States", "Implementation coverage", []);
   card(states, PAD, 144, CONTENT_W, 128);
   glyph(states, 38, 166, "equity", 56);
@@ -551,7 +587,7 @@ async function main() {
   text(states, "Monthly Progress becomes useful after the first saved snapshot. Keep the chart area calm.", 38, 634, 12, C.secondary, "Regular", 280);
 
   stage = "zoom to screens";
-  figma.viewport.scrollAndZoomIntoView([dashboard, holdings, add, progress, cash, settings, states]);
+  figma.viewport.scrollAndZoomIntoView([dashboard, holdings, addAsset, addPosition, addReview, progress, cash, settings, states]);
   figma.closePlugin("CogVest Issue 86 premium screens generated.");
 }
 

--- a/docs/design/figma/issue-69-v1-screens/code.js
+++ b/docs/design/figma/issue-69-v1-screens/code.js
@@ -175,13 +175,13 @@ async function main() {
     return r;
   }
 
-  function screen(name, x, y = 150) {
+  function screen(name, x, y = 150, height = H) {
     const frame = figma.createFrame();
     page.appendChild(frame);
     frame.name = name;
     frame.x = x;
     frame.y = y;
-    frame.resize(W, H);
+    frame.resize(W, height);
     frame.cornerRadius = 34;
     frame.fills = [paint(C.bg)];
     frame.clipsContent = true;
@@ -197,7 +197,8 @@ async function main() {
   }
 
   function nav(frame, selected) {
-    rect(frame, 0, H - NAV_H, W, NAV_H, C.surface, 0, C.separator, 0.35);
+    const frameH = frame.height || H;
+    rect(frame, 0, frameH - NAV_H, W, NAV_H, C.surface, 0, C.separator, 0.35);
     const items = [
       ["Dashboard", "home"],
       ["Holdings", "holdings"],
@@ -208,9 +209,9 @@ async function main() {
     items.forEach(([label, iconName], i) => {
       const active = label === selected;
       const cx = 38 + i * 78;
-      if (active) rect(frame, cx - 19, H - NAV_H, 38, 3, C.green, 999);
-      icon(frame, iconName, cx - 10, H - 52, active ? C.green : C.secondary, 21);
-      text(frame, label, cx - 34, H - 24, 10, active ? C.green : C.secondary, "Regular", 68, "CENTER");
+      if (active) rect(frame, cx - 19, frameH - NAV_H, 38, 3, C.green, 999);
+      icon(frame, iconName, cx - 10, frameH - 52, active ? C.green : C.secondary, 21);
+      text(frame, label, cx - 34, frameH - 24, 10, active ? C.green : C.secondary, "Regular", 68, "CENTER");
     });
   }
 
@@ -393,7 +394,7 @@ async function main() {
 
   // Add Holding
   stage = "draw add holding";
-  const add = screen("Add Holding", 872);
+  const add = screen("Add Holding", 872, 150, 1100);
   header(add, "Add Holding", "Opening position · local only", ["help"]);
   ["Asset", "Class", "Position", "Review"].forEach((s, i) => {
     const cx = 55 + i * 94;
@@ -408,19 +409,33 @@ async function main() {
   text(add, "Search name or symbol", 80, 280, 13, C.secondary, "Regular", 190);
   text(add, "Only search text is sent to quote providers.", 38, 318, 10.5, C.muted, "Regular", 260);
   row(add, PAD, 352, CONTENT_W, "equity", "HDFC Bank", "HDFCBANK.NS · NSE · INR · Equity", "₹1,678.25", "Live", C.text);
-  card(add, PAD, 438, CONTENT_W, 96);
-  sectionTitle(add, "Position details", 38, 458);
-  formField(add, 38, 490, 148, "Quantity", "25");
-  formField(add, 202, 490, 150, "Average cost", "₹1,450.00");
-  formField(add, 38, 560, 148, "Current price", "₹1,678.25");
-  formField(add, 202, 560, 150, "Price source", "Live");
-  card(add, PAD, 632, CONTENT_W, 92);
-  sectionTitle(add, "Derived preview", 38, 652);
-  metric(add, "Invested", "₹36,250", 38, 684, 82);
-  metric(add, "Current", "₹41,956", 134, 684, 82);
-  metric(add, "P&L", "+₹5,706", 230, 684, 82, C.green);
-  rect(add, PAD, 740, CONTENT_W, 48, C.brandGreen, 18);
-  text(add, "Continue", PAD, 756, 13, C.text, "Bold", CONTENT_W, "CENTER");
+  row(add, PAD, 424, CONTENT_W, "crypto", "Bitcoin", "bitcoin · CoinGecko · INR", "₹92.10L", "Live", C.text);
+  card(add, PAD, 510, CONTENT_W, 86);
+  sectionTitle(add, "Selected asset", 38, 530);
+  metric(add, "Name", "HDFC Bank", 38, 558, 88);
+  metric(add, "Ticker", "HDFCBANK.NS", 142, 558, 104);
+  metric(add, "Currency", "INR", 270, 558, 60);
+  card(add, PAD, 610, CONTENT_W, 74);
+  sectionTitle(add, "Next: Classification", 38, 630);
+  metric(add, "Suggested", "Equity · Large Cap", 38, 656, 128);
+  metric(add, "Sector", "Financial Services", 190, 656, 136);
+  card(add, PAD, 698, CONTENT_W, 92);
+  sectionTitle(add, "Position details", 38, 718);
+  metric(add, "Quantity", "25", 38, 750, 70);
+  metric(add, "Average cost", "₹1,450.00", 122, 750, 92);
+  metric(add, "Current price", "₹1,678.25", 232, 750, 96);
+  card(add, PAD, 804, CONTENT_W, 90);
+  sectionTitle(add, "Derived preview", 38, 824);
+  metric(add, "Invested", "₹36,250", 38, 856, 82);
+  metric(add, "Current", "₹41,956", 134, 856, 82);
+  metric(add, "P&L", "+₹5,706 · +15.7%", 230, 856, 112, C.green);
+  card(add, PAD, 908, CONTENT_W, 64);
+  sectionTitle(add, "Review", 38, 928);
+  text(add, "Conviction and notes stay optional. Save only after derived values look right.", 38, 954, 11, C.secondary, "Regular", 276);
+  rect(add, PAD, 992, 176, 48, C.brandGreen, 18);
+  text(add, "Continue", PAD, 1008, 13, C.text, "Bold", 176, "CENTER");
+  rect(add, PAD + 188, 992, 126, 48, C.surface, 18, C.separator, 0.45);
+  text(add, "Enter manually", PAD + 188, 1008, 13, C.text, "Semi Bold", 126, "CENTER");
   nav(add, "Holdings");
 
   // Progress

--- a/docs/design/figma/issue-69-v1-screens/code.js
+++ b/docs/design/figma/issue-69-v1-screens/code.js
@@ -1,80 +1,64 @@
-// CogVest — Figma Plugin
-// Run from Figma Desktop as a development plugin.
+// CogVest Figma Plugin
+// Generates the approved Issue 86 premium V1 screen set.
 //
 // Main tabs: Dashboard, Holdings, Progress, Cash, Settings
-// Secondary screens: Add Holding
+// Secondary flow: Add Holding
+// State coverage: V1 States
+//
+// This script intentionally creates a fresh versioned page instead of removing
+// existing nodes. That avoids Figma "Removing this node is not allowed" errors
+// seen during reruns and keeps previous revisions available for comparison.
+
+let stage = "initialise";
 
 async function main() {
+  stage = "load fonts";
   await figma.loadFontAsync({ family: "Inter", style: "Regular" });
   await figma.loadFontAsync({ family: "Inter", style: "Medium" });
   await figma.loadFontAsync({ family: "Inter", style: "Semi Bold" });
   await figma.loadFontAsync({ family: "Inter", style: "Bold" });
 
-  // ─── COLOUR SYSTEM ───────────────────────────────────────────
   const C = {
-    // Backgrounds
-    bg: "#0A0A0B",
+    bg: "#000000",
+    canvas: "#0A0A0B",
     surface: "#1C1C1E",
     elevated: "#2C2C2E",
     field: "#111113",
-
-    // Text
     text: "#F5F5F7",
     secondary: "#98989D",
     muted: "#636366",
-    inverse: "#000000",
-
-    // Brand
-    green: "#2E7D52",
-    greenDim: "#1A4A30",
-    greenText: "#4CAF50",
-
-    // Semantic
-    positive: "#34C759",
-    negative: "#FF453A",
-    warning: "#F59E0B",
+    separator: "#38383A",
+    green: "#34C759",
+    brandGreen: "#2E7D52",
     blue: "#0A84FF",
-    amber: "#FF9F0A",
     cashBlue: "#64D2FF",
-    purple: "#BF5AF2",
-
-    // Borders
-    border: "#38383A",
-    borderDim: "#28282A",
+    amber: "#FF9F0A",
+    negative: "#FF453A",
+    equityLine: "#7C83FF",
+    debtLine: "#62C99A",
+    investedLine: "#636366",
   };
 
-  // ─── SPACING SYSTEM ──────────────────────────────────────────
-  const S = {
-    screenPad: 20,
-    cardPad: 16,
-    cardGap: 10,
-    rowH: 52,
-    headerH: 32,
-    navH: 74,
-    navY: 778,
-    radius: {
-      sm: 8,
-      md: 14,
-      lg: 18,
-      full: 999,
-    },
-  };
+  const W = 390;
+  const H = 844;
+  const PAD = 20;
+  const NAV_H = 78;
+  const CONTENT_W = W - PAD * 2;
+  const PAGE_NAME = "Issue 86 - Premium V1 Screens";
 
-  // ─── PAGE SETUP ──────────────────────────────────────────────
-  const PAGE_NAME = "CogVest — Screens";
-  let page = figma.root.children.find((p) => p.name === PAGE_NAME);
-  if (!page) {
-    page = figma.createPage();
-    page.name = PAGE_NAME;
-  }
-
+  stage = "create page";
+  const page = figma.createPage();
+  page.name = uniquePageName(PAGE_NAME);
   await figma.setCurrentPageAsync(page);
 
-  for (const child of [...page.children]) {
-    child.remove();
+  function uniquePageName(base) {
+    const existing = new Set(figma.root.children.map((p) => p.name));
+    if (!existing.has(base)) return base;
+    let i = 2;
+    while (existing.has(`${base} v${i}`)) i += 1;
+    return `${base} v${i}`;
   }
 
-  // ─── PRIMITIVE HELPERS ───────────────────────────────────────
   function rgb(hex) {
     const h = hex.replace("#", "");
     return {
@@ -85,14 +69,10 @@ async function main() {
   }
 
   function paint(hex, opacity = 1) {
-    return {
-      type: "SOLID",
-      color: rgb(hex),
-      opacity,
-    };
+    return { type: "SOLID", color: rgb(hex), opacity };
   }
 
-  function rect(parent, x, y, w, h, radius = 0, fill = C.surface, strokeColor = null, strokeOpacity = 0.5) {
+  function rect(parent, x, y, w, h, fill = C.surface, radius = 0, stroke = null, strokeOpacity = 0.28) {
     const node = figma.createRectangle();
     parent.appendChild(node);
     node.x = x;
@@ -100,916 +80,466 @@ async function main() {
     node.resize(w, h);
     node.cornerRadius = radius;
     node.fills = [paint(fill)];
-
-    if (strokeColor) {
-      node.strokes = [paint(strokeColor, strokeOpacity)];
-      node.strokeWeight = 1;
-    } else {
-      node.strokes = [];
-    }
-
+    node.strokes = stroke ? [paint(stroke, strokeOpacity)] : [];
+    node.strokeWeight = stroke ? 1 : 0;
     return node;
   }
 
-  function card(parent, x, y, w, h, radius = S.radius.lg, fill = C.surface) {
-    return rect(parent, x, y, w, h, radius, fill, C.border, 0.35);
+  function line(parent, x, y, w, opacity = 0.42) {
+    const node = figma.createLine();
+    parent.appendChild(node);
+    node.x = x;
+    node.y = y;
+    node.resize(w, 0);
+    node.strokes = [paint(C.separator, opacity)];
+    node.strokeWeight = 1;
+    return node;
   }
 
-  function t(parent, value, x, y, size, color = C.text, style = "Regular", width = 160, align = "LEFT") {
+  function text(parent, value, x, y, size, color = C.text, style = "Regular", width = 180, align = "LEFT") {
     const node = figma.createText();
     parent.appendChild(node);
     node.x = x;
     node.y = y;
-    node.resize(width, Math.max(size + 10, 18));
+    node.resize(width, 1);
+    node.characters = value;
     node.fontName = { family: "Inter", style };
     node.fontSize = size;
     node.fills = [paint(color)];
     node.textAlignHorizontal = align;
     node.textAutoResize = "HEIGHT";
-    node.characters = value;
     return node;
   }
 
-  function line(parent, x, y, width, color = C.border, opacity = 0.35) {
-    const node = figma.createLine();
-    parent.appendChild(node);
-    node.x = x;
-    node.y = y;
-    node.resize(width, 0);
-    node.strokes = [paint(color, opacity)];
-    node.strokeWeight = 1;
-    return node;
-  }
-
-  function svgNode(parent, svgStr, x, y, w, h) {
-    const node = figma.createNodeFromSvg(svgStr);
-    parent.appendChild(node);
+  function svg(parent, source, x, y, w, h) {
+    // Figma creates SVG nodes on the current page. Move only after geometry is set.
+    const node = figma.createNodeFromSvg(source);
     node.x = x;
     node.y = y;
     node.resize(w, h);
+    parent.appendChild(node);
     return node;
   }
 
-  // ─── ICON SYSTEM ─────────────────────────────────────────────
-  function icon(name, color = C.secondary, size = 20) {
+  function iconSvg(name, color = C.secondary) {
     const s = color;
-
     const icons = {
-      home: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M3 10.8 12 3l9 7.8V21h-6v-6H9v6H3V10.8Z" stroke="${s}" stroke-width="1.8" stroke-linejoin="round"/></svg>`,
-
-      pie: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M12 3v9h9A9 9 0 1 1 12 3Z" stroke="${s}" stroke-width="1.8"/><path d="M14 3.3A9 9 0 0 1 20.7 10H14V3.3Z" stroke="${s}" stroke-width="1.8"/></svg>`,
-
-      plus: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M12 5v14M5 12h14" stroke="${s}" stroke-width="2.2" stroke-linecap="round"/></svg>`,
-
-      wallet: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M4 7h16v12H4z" stroke="${s}" stroke-width="1.8" stroke-linejoin="round"/><path d="M4 7l11-3 2 3" stroke="${s}" stroke-width="1.8"/><path d="M15 13h5" stroke="${s}" stroke-width="1.8"/><circle cx="17" cy="13" r="1" fill="${s}"/></svg>`,
-
-      gear: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="3.5" stroke="${s}" stroke-width="1.8"/><path d="M12 2v2M12 20v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M2 12h2M20 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/></svg>`,
-
-      trend: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M4 16l5-5 4 4 7-8" stroke="${s}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M15 7h5v5" stroke="${s}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
-
-      shield: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M12 3 20 6v6c0 5-3.4 7.8-8 9-4.6-1.2-8-4-8-9V6l8-3Z" stroke="${s}" stroke-width="1.8" stroke-linejoin="round"/></svg>`,
-
-      btc: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M9 4v16M13 4v16M7 7h6.2c2 0 3.3 1 3.3 2.6 0 1.1-.7 2-1.9 2.3 1.5.3 2.4 1.3 2.4 2.8 0 1.8-1.5 3.3-3.8 3.3H7M7 12h6" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/></svg>`,
-
-      eye: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z" stroke="${s}" stroke-width="1.8"/><circle cx="12" cy="12" r="3" stroke="${s}" stroke-width="1.8"/></svg>`,
-
-      eyeOff: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/><path d="M1 1l22 22" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/></svg>`,
-
-      refresh: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M20 7v5h-5M4 17v-5h5" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/><path d="M18 12a6 6 0 0 0-10.2-4.2L4 11m16 2-3.8 3.2A6 6 0 0 1 6 12" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/></svg>`,
-
-      search: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><circle cx="11" cy="11" r="7" stroke="${s}" stroke-width="1.8"/><path d="m16 16 5 5" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/></svg>`,
-
-      back: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="m15 6-6 6 6 6" stroke="${s}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
-
-      chevron: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M9 18l6-6-6-6" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
-
-      check: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M5 12l5 5L20 7" stroke="${s}" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
-
-      sparkle: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><path d="M12 3l1.8 5.2L19 10l-5.2 1.8L12 17l-1.8-5.2L5 10l5.2-1.8L12 3Z" stroke="${s}" stroke-width="1.8" stroke-linejoin="round"/></svg>`,
-
-      info: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" stroke="${s}" stroke-width="1.8"/><path d="M12 11v6" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/><circle cx="12" cy="7.5" r="1" fill="${s}"/></svg>`,
-
-      calendar: `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"><rect x="3" y="4" width="18" height="18" rx="2" stroke="${s}" stroke-width="1.8"/><path d="M3 9h18M8 2v4M16 2v4" stroke="${s}" stroke-width="1.8" stroke-linecap="round"/></svg>`,
+      home: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 10.8 12 3l9 7.8V21h-6v-6H9v6H3z"/></svg>`,
+      holdings: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v9h9A9 9 0 1 1 12 3Z"/><path d="M14 3.3A9 9 0 0 1 20.7 10H14z"/></svg>`,
+      progress: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 3v9l6 3"/></svg>`,
+      cash: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg>`,
+      settings: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2M12 20v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M2 12h2M20 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4"/></svg>`,
+      eye: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg>`,
+      refresh: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20 7v5h-5M4 17v-5h5"/><path d="M18 12a6 6 0 0 0-10.2-4.2L4 11m16 2-3.8 3.2A6 6 0 0 1 6 12"/></svg>`,
+      search: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m16 16 5 5"/></svg>`,
+      up: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg>`,
+      shield: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3 5 6v5c0 4.5 3 7.5 7 9 4-1.5 7-4.5 7-9V6z"/></svg>`,
+      coin: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><path d="M12 7v10M9.2 9h4.1a2 2 0 0 1 0 4H9.2M9.2 13h4.8a2 2 0 0 1 0 4H9.2"/></svg>`,
+      plus: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>`,
+      help: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9.5 9a2.8 2.8 0 1 1 4.9 1.8c-.9.8-1.9 1.3-1.9 3.2"/><path d="M12 18h.01"/></svg>`,
+      info: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${s}" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 11v5M12 8h.01"/></svg>`,
     };
-
-    return icons[name] || icons.trend;
+    return icons[name] || icons.up;
   }
 
-  function ico(parent, name, x, y, size = 20, color = C.secondary) {
-    return svgNode(parent, icon(name, color, size), x, y, size, size);
+  function icon(parent, name, x, y, color = C.secondary, size = 20) {
+    return svg(parent, iconSvg(name, color), x, y, size, size);
   }
 
-  // ─── ASSET CLASS CONFIG ──────────────────────────────────────
-  const assetClass = {
-    equity: { color: C.positive, icon: "trend", label: "Equity" },
-    debt: { color: C.blue, icon: "shield", label: "Debt" },
-    crypto: { color: C.amber, icon: "btc", label: "Crypto" },
-    cash: { color: C.cashBlue, icon: "wallet", label: "Cash" },
+  const assetMeta = {
+    equity: { color: C.green, icon: "up" },
+    debt: { color: C.blue, icon: "shield" },
+    crypto: { color: C.amber, icon: "coin" },
+    cash: { color: C.cashBlue, icon: "cash" },
+    neutral: { color: C.secondary, icon: "up" },
   };
 
-  function assetDot(parent, x, y, type, dotSize = 8) {
-    const ac = assetClass[type] || assetClass.equity;
-    const dot = figma.createEllipse();
-    parent.appendChild(dot);
-    dot.x = x;
-    dot.y = y;
-    dot.resize(dotSize, dotSize);
-    dot.fills = [paint(ac.color)];
-    dot.strokes = [];
-    return dot;
+  function glyph(parent, x, y, type = "neutral", size = 34) {
+    const meta = assetMeta[type] || assetMeta.neutral;
+    const g = figma.createFrame();
+    parent.appendChild(g);
+    g.x = x;
+    g.y = y;
+    g.resize(size, size);
+    g.cornerRadius = size / 2;
+    g.fills = [paint(C.elevated)];
+    g.strokes = [];
+    icon(g, meta.icon, (size - 17) / 2, (size - 17) / 2, meta.color, 17);
+    return g;
   }
 
-  // ─── PILL / BADGE ────────────────────────────────────────────
-  function pill(parent, label, x, y, bgColor, textColor, width = null, height = 24, radius = S.radius.full) {
-    const textW = width ? width - 20 : label.length * 7 + 16;
-    const pillW = width || textW + 20;
-    rect(parent, x, y, pillW, height, radius, bgColor, null);
-    t(parent, label, x, y + (height - 14) / 2, 11, textColor, "Semi Bold", pillW, "CENTER");
-    return pillW;
+  function action(parent, x, y, iconName, label = null) {
+    const r = rect(parent, x, y, 36, 36, C.surface, 13);
+    icon(parent, iconName, x + 8, y + 8, C.text, 20);
+    if (label) text(parent, label, x - 12, y + 40, 10, C.secondary, "Regular", 60, "CENTER");
+    return r;
   }
 
-  function convictionDots(parent, x, y, selected = 4, outOf = 5) {
-    for (let i = 1; i <= outOf; i++) {
-      const dotX = x + (i - 1) * 30;
-      const active = i <= selected;
-
-      rect(parent, dotX, y, 22, 22, S.radius.full, active ? C.greenDim : C.elevated, active ? C.green : C.border, 0.35);
-      t(parent, String(i), dotX, y + 6, 10, active ? C.greenText : C.secondary, "Semi Bold", 22, "CENTER");
-    }
-  }
-
-  // ─── SCREEN FRAME ────────────────────────────────────────────
-  function screen(name, x) {
+  function screen(name, x, y = 150) {
     const frame = figma.createFrame();
     page.appendChild(frame);
     frame.name = name;
     frame.x = x;
-    frame.y = 130;
-    frame.resize(393, 852);
-    frame.cornerRadius = 36;
-    frame.clipsContent = true;
+    frame.y = y;
+    frame.resize(W, H);
+    frame.cornerRadius = 34;
     frame.fills = [paint(C.bg)];
-
-    t(frame, "10:42", 24, 20, 12, C.text, "Semi Bold", 60);
-    t(frame, "◢  ▰ 100%", 300, 20, 11, C.text, "Medium", 80, "RIGHT");
-
+    frame.clipsContent = true;
+    text(frame, "10:42", 22, 18, 12, C.text, "Semi Bold", 60);
+    text(frame, "100%", 330, 18, 12, C.text, "Semi Bold", 42, "RIGHT");
     return frame;
   }
 
-  // ─── HEADER COMPONENTS ───────────────────────────────────────
   function header(frame, title, subtitle, actions = []) {
-    t(frame, title, S.screenPad, 60, 26, C.text, "Bold", 210);
-
-    if (subtitle) {
-      t(frame, subtitle, S.screenPad, 96, 12, C.secondary, "Regular", 245);
-    }
-
-    actions.forEach((action, i) => {
-      const x = 330 - (actions.length - 1 - i) * 42;
-      rect(frame, x, 60, 34, 34, S.radius.sm, C.elevated, C.border, 0.3);
-      ico(frame, action, x + 7, 67, 20, C.secondary);
-    });
+    text(frame, title, PAD, 76, 28, C.text, "Bold", 230);
+    text(frame, subtitle, PAD, 111, 13, C.secondary, "Regular", 240);
+    actions.forEach((a, i) => action(frame, 310 - i * 44, 76, a));
   }
 
-  function headerBack(frame, title, subtitle, action = null) {
-    ico(frame, "back", S.screenPad, 66, 20, C.text);
-    t(frame, title, 54, 60, 22, C.text, "Bold", action ? 220 : 280);
-
-    if (subtitle) {
-      t(frame, subtitle, 54, 92, 11, C.secondary, "Regular", 240);
-    }
-
-    if (action) {
-      rect(frame, 335, 60, 34, 34, S.radius.sm, C.elevated, C.border, 0.3);
-      ico(frame, action, 342, 67, 20, C.secondary);
-    }
-  }
-
-  // ─── BOTTOM NAVIGATION ───────────────────────────────────────
   function nav(frame, selected) {
-    rect(frame, 0, S.navY, 393, S.navH, 0, C.surface, C.border, 0.5);
-
+    rect(frame, 0, H - NAV_H, W, NAV_H, C.surface, 0, C.separator, 0.35);
     const items = [
-      ["Dashboard", "home", 38],
-      ["Holdings", "pie", 118],
-      ["Progress", "trend", 197],
-      ["Cash", "wallet", 276],
-      ["Settings", "gear", 354],
+      ["Dashboard", "home"],
+      ["Holdings", "holdings"],
+      ["Progress", "progress"],
+      ["Cash", "cash"],
+      ["Settings", "settings"],
     ];
-
-    items.forEach(([label, iconName, cx]) => {
+    items.forEach(([label, iconName], i) => {
       const active = label === selected;
-      const iconColor = active ? C.green : C.secondary;
-      const labelColor = active ? C.green : C.secondary;
-
-      if (active) {
-        rect(frame, cx - 18, S.navY, 36, 3, S.radius.full, C.green, null);
-      }
-
-      ico(frame, iconName, cx - 11, S.navY + 14, 22, iconColor);
-
-      t(
-        frame,
-        label,
-        cx - 34,
-        S.navY + 40,
-        10,
-        labelColor,
-        active ? "Medium" : "Regular",
-        68,
-        "CENTER"
-      );
+      const cx = 38 + i * 78;
+      if (active) rect(frame, cx - 19, H - NAV_H, 38, 3, C.green, 999);
+      icon(frame, iconName, cx - 10, H - 52, active ? C.green : C.secondary, 21);
+      text(frame, label, cx - 34, H - 24, 10, active ? C.green : C.secondary, "Regular", 68, "CENTER");
     });
   }
 
-  // ─── METRIC HELPERS ──────────────────────────────────────────
-  function metricPair(parent, label, value, x, y, width = 80, valueColor = C.text) {
-    t(parent, label, x, y, 11, C.secondary, "Regular", width);
-    t(parent, value, x, y + 18, 15, valueColor, "Semi Bold", width);
+  function card(parent, x, y, w, h, radius = 24) {
+    return rect(parent, x, y, w, h, C.surface, radius);
   }
 
-  function metricStrip(frame, x, y, items) {
-    const w = 353;
-    card(frame, x, y, w, 72, S.radius.md);
+  function sectionLabel(parent, value, x, y) {
+    text(parent, value.toUpperCase(), x, y, 10.5, C.muted, "Bold", 160);
+  }
 
-    const colW = Math.floor(w / items.length);
+  function sectionTitle(parent, title, x, y, action = null) {
+    text(parent, title, x, y, 17, C.text, "Bold", 200);
+    if (action) text(parent, action, x + 245, y + 2, 12, C.green, "Semi Bold", 86, "RIGHT");
+  }
 
-    items.forEach(([label, value, color], i) => {
-      const colX = x + 14 + i * colW;
+  function metric(parent, label, value, x, y, w = 90, color = C.text) {
+    text(parent, label, x, y, 11, C.secondary, "Regular", w);
+    text(parent, value, x, y + 19, 14, color, "Semi Bold", w);
+  }
 
-      t(frame, label, colX, y + 12, 10, C.secondary, "Regular", colW - 8);
-      t(frame, value, colX, y + 30, 15, color || C.text, "Semi Bold", colW - 8);
-
-      if (i > 0) {
-        line(frame, colX - 10, y + 16, 0, C.border, 0.4);
-      }
+  function metricStrip(parent, x, y, items) {
+    card(parent, x, y, CONTENT_W, 88, 20);
+    const colW = CONTENT_W / items.length;
+    items.forEach((item, i) => {
+      metric(parent, item.label, item.value, x + 14 + i * colW, y + 22, colW - 18, item.color || C.text);
+      if (i > 0) line(parent, x + i * colW, y + 18, 52, 0.32).rotation = 90;
     });
   }
 
-  function filterChips(frame, y, labels, activeIndex = 0) {
-    let x = S.screenPad;
+  function chip(parent, label, x, y, active = false, w = null) {
+    const width = w || label.length * 7 + 24;
+    rect(parent, x, y, width, 30, active ? C.brandGreen : C.surface, 999, active ? null : C.separator, active ? 0 : 0.55);
+    text(parent, label, x, y + 8, 12, active ? C.text : C.secondary, "Semi Bold", width, "CENTER");
+    return width;
+  }
 
-    labels.forEach((label, i) => {
-      const active = i === activeIndex;
-      const chipW = label.length * 7 + 24;
+  function row(parent, x, y, w, type, title, meta, value, sub = null, valueColor = C.text) {
+    rect(parent, x, y, w, 72, C.surface, 18);
+    glyph(parent, x + 12, y + 19, type, 34);
+    text(parent, title, x + 58, y + 15, 14, C.text, "Semi Bold", 150);
+    text(parent, meta, x + 58, y + 36, 10.5, C.secondary, "Regular", 180);
+    text(parent, value, x + w - 112, y + 15, 14, valueColor, "Bold", 96, "RIGHT");
+    if (sub) text(parent, sub, x + w - 112, y + 38, 10.5, sub.startsWith("-") ? C.negative : C.green, "Semi Bold", 96, "RIGHT");
+  }
 
-      rect(frame, x, y, chipW, 30, S.radius.full, active ? C.green : C.elevated, active ? null : C.border, 0.3);
-      t(frame, label, x, y + 8, 12, active ? C.text : C.secondary, active ? "Semi Bold" : "Regular", chipW, "CENTER");
+  function groupedRows(parent, x, y, rows) {
+    const h = rows.length * 58;
+    card(parent, x, y, CONTENT_W, h, 18);
+    rows.forEach((r, i) => {
+      const yy = y + i * 58;
+      if (i > 0) line(parent, x + 14, yy, CONTENT_W - 28, 0.3);
+      glyph(parent, x + 12, yy + 12, r.type, 34);
+      text(parent, r.title, x + 58, yy + 12, 13.5, C.text, "Semi Bold", 160);
+      text(parent, r.meta, x + 58, yy + 33, 10.5, C.secondary, "Regular", 180);
+      text(parent, r.value, x + CONTENT_W - 96, yy + 18, 13.5, r.color || C.text, "Bold", 82, "RIGHT");
+    });
+    return h;
+  }
 
-      x += chipW + 8;
+  function formField(parent, x, y, w, label, value) {
+    rect(parent, x, y, w, 58, C.field, 16);
+    text(parent, label, x + 12, y + 10, 10.5, C.secondary, "Semi Bold", w - 24);
+    text(parent, value, x + 12, y + 31, 13.5, C.text, "Semi Bold", w - 24);
+  }
+
+  function valueGraph(parent, x, y) {
+    const graph = `
+      <svg width="320" height="160" viewBox="0 0 320 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <defs><linearGradient id="portfolioFade" x1="0" x2="0" y1="0" y2="1"><stop offset="0%" stop-color="${C.text}"/><stop offset="100%" stop-color="${C.text}" stop-opacity="0"/></linearGradient></defs>
+        <path d="M32 24H306M32 58H306M32 92H306M32 126H306" stroke="${C.separator}" stroke-opacity="0.42"/>
+        <path d="M34 104 C60 96 78 108 100 82 C122 58 144 72 166 64 C190 56 208 88 230 38 C252 10 274 64 306 26 L306 132 L34 132Z" fill="url(#portfolioFade)" opacity="0.26"/>
+        <path d="M34 104 C60 96 78 108 100 82 C122 58 144 72 166 64 C190 56 208 88 230 38 C252 10 274 64 306 26" stroke="${C.text}" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M34 118 C72 116 92 112 120 108 C152 104 180 100 210 94 C246 88 276 82 306 76" stroke="${C.investedLine}" stroke-width="3" stroke-dasharray="6 7" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="100" cy="82" r="3.5" fill="${C.surface}" stroke="${C.text}" stroke-width="2"/>
+        <circle cx="230" cy="38" r="3.5" fill="${C.surface}" stroke="${C.text}" stroke-width="2"/>
+        <circle cx="306" cy="26" r="3.5" fill="${C.surface}" stroke="${C.text}" stroke-width="2"/>
+        <circle cx="306" cy="76" r="3" fill="${C.surface}" stroke="${C.investedLine}" stroke-width="2"/>
+        <text x="4" y="28" fill="${C.muted}" font-size="9">20L</text><text x="5" y="95" fill="${C.muted}" font-size="9">10L</text><text x="13" y="130" fill="${C.muted}" font-size="9">0</text>
+        <text x="34" y="152" fill="${C.muted}" font-size="9">Dec</text><text x="138" y="152" fill="${C.muted}" font-size="9">Mar</text><text x="282" y="152" fill="${C.muted}" font-size="9">May</text>
+      </svg>`;
+    return svg(parent, graph, x, y, 320, 160);
+  }
+
+  function assetGraph(parent, x, y) {
+    const graph = `
+      <svg width="320" height="160" viewBox="0 0 320 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M32 24H306M32 58H306M32 92H306M32 126H306" stroke="${C.separator}" stroke-opacity="0.42"/>
+        <path d="M34 98 C58 90 78 106 100 78 C124 52 144 68 166 60 C190 52 210 84 230 38 C252 18 276 58 306 36" stroke="${C.equityLine}" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M34 126 C60 122 78 124 100 116 C128 108 150 112 176 102 C206 92 236 98 262 86 C282 78 294 84 306 76" stroke="${C.debtLine}" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M34 138 C58 132 78 144 102 122 C124 102 140 134 164 112 C188 86 206 126 230 108 C258 78 282 118 306 96" stroke="${C.amber}" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="306" cy="36" r="3.5" fill="${C.surface}" stroke="${C.equityLine}" stroke-width="2"/>
+        <circle cx="306" cy="76" r="3.5" fill="${C.surface}" stroke="${C.debtLine}" stroke-width="2"/>
+        <circle cx="306" cy="96" r="3.5" fill="${C.surface}" stroke="${C.amber}" stroke-width="2"/>
+        <text x="250" y="32" fill="${C.equityLine}" font-size="10" font-weight="700">₹12.45L</text>
+        <text x="254" y="72" fill="${C.debtLine}" font-size="10" font-weight="700">₹3.22L</text>
+        <text x="254" y="92" fill="${C.amber}" font-size="10" font-weight="700">₹1.20L</text>
+        <text x="4" y="28" fill="${C.muted}" font-size="9">15L</text><text x="5" y="95" fill="${C.muted}" font-size="9">7.5L</text><text x="13" y="130" fill="${C.muted}" font-size="9">0</text>
+        <text x="34" y="152" fill="${C.muted}" font-size="9">Dec</text><text x="138" y="152" fill="${C.muted}" font-size="9">Mar</text><text x="282" y="152" fill="${C.muted}" font-size="9">May</text>
+      </svg>`;
+    return svg(parent, graph, x, y, 320, 160);
+  }
+
+  function legend(parent, x, y, items) {
+    let offset = 0;
+    items.forEach((item) => {
+      const dot = figma.createEllipse();
+      parent.appendChild(dot);
+      dot.x = x + offset;
+      dot.y = y + 3;
+      dot.resize(7, 7);
+      dot.fills = [paint(item.color)];
+      text(parent, item.label, x + offset + 12, y, 11, item.color, "Regular", 70);
+      offset += item.label.length * 6 + 38;
     });
   }
 
-  function statusBar(frame, y, message) {
-    rect(frame, S.screenPad, y, 353, 36, S.radius.sm, C.elevated, C.border, 0.2);
-
-    const dot = figma.createEllipse();
-    frame.appendChild(dot);
-    dot.x = S.screenPad + 14;
-    dot.y = y + 13;
-    dot.resize(10, 10);
-    dot.fills = [paint(C.positive)];
-    dot.strokes = [];
-
-    t(frame, message, S.screenPad + 32, y + 11, 11, C.secondary, "Regular", 260);
-    ico(frame, "refresh", 348, y + 8, 18, C.secondary);
+  function pageTitle() {
+    text(page, "CogVest Issue 86 Premium V1 Screens", 24, 24, 30, C.text, "Bold", 900);
+    text(page, "Generated from docs/design/issue-86-premium-preview. Main tabs: Dashboard, Holdings, Progress, Cash, Settings. Add Holding is a secondary flow.", 24, 64, 13, C.secondary, "Regular", 980);
   }
 
-  // ─── DONUT CHART ─────────────────────────────────────────────
-  function donutChart(frame, x, y) {
-    card(frame, x, y, 353, 220, S.radius.lg);
+  stage = "draw canvas";
+  rect(page, -80, -80, 3200, 1120, C.canvas, 0);
+  stage = "draw title";
+  pageTitle();
 
-    t(frame, "Allocation", x + S.cardPad, y + 16, 15, C.text, "Semi Bold", 140);
-    t(frame, "View details", x + 263, y + 18, 11, C.green, "Medium", 76, "RIGHT");
-
-    const segments = [
-      { label: "Equity", pct: 68, color: C.positive },
-      { label: "Debt", pct: 15, color: C.blue },
-      { label: "Crypto", pct: 7, color: C.amber },
-      { label: "Cash", pct: 10, color: C.cashBlue },
-    ];
-
-    const cx = 100;
-    const cy = 110;
-    const outerR = 52;
-    const innerR = 34;
-    const gap = 2;
-
-    const toRad = (deg) => ((deg - 90) * Math.PI) / 180;
-    let start = 0;
-
-    const paths = segments
-      .map((seg) => {
-        const sweep = (seg.pct / 100) * 360;
-        const s1 = start + gap;
-        const e1 = start + sweep - gap;
-        const large = sweep > 180 ? 1 : 0;
-
-        const x1 = cx + outerR * Math.cos(toRad(s1));
-        const y1 = cy + outerR * Math.sin(toRad(s1));
-
-        const x2 = cx + outerR * Math.cos(toRad(e1));
-        const y2 = cy + outerR * Math.sin(toRad(e1));
-
-        const x3 = cx + innerR * Math.cos(toRad(e1));
-        const y3 = cy + innerR * Math.sin(toRad(e1));
-
-        const x4 = cx + innerR * Math.cos(toRad(s1));
-        const y4 = cy + innerR * Math.sin(toRad(s1));
-
-        start += sweep;
-
-        return `<path d="M${x1} ${y1} A${outerR} ${outerR} 0 ${large} 1 ${x2} ${y2} L${x3} ${y3} A${innerR} ${innerR} 0 ${large} 0 ${x4} ${y4}Z" fill="${seg.color}"/>`;
-      })
-      .join("");
-
-    const legendRows = segments
-      .map((seg, i) => {
-        const ly = 68 + i * 26;
-
-        return `
-          <circle cx="212" cy="${ly}" r="5" fill="${seg.color}"/>
-          <text x="226" y="${ly + 4}" font-family="Inter" font-size="12" font-weight="500" fill="${C.text}">${seg.label}</text>
-          <text x="339" y="${ly + 4}" font-family="Inter" font-size="12" fill="${C.secondary}" text-anchor="end">${seg.pct}%</text>
-        `;
-      })
-      .join("");
-
-    const donutSvg = `
-      <svg width="353" height="220" viewBox="0 0 353 220" fill="none" xmlns="http://www.w3.org/2000/svg">
-        ${paths}
-        <circle cx="${cx}" cy="${cy}" r="${innerR - 2}" fill="${C.surface}"/>
-        <text x="${cx}" y="${cy - 6}" font-family="Inter" font-size="17" font-weight="700" fill="${C.text}" text-anchor="middle">68%</text>
-        <text x="${cx}" y="${cy + 12}" font-family="Inter" font-size="10" fill="${C.secondary}" text-anchor="middle">Equity</text>
-        ${legendRows}
-        <text x="14" y="208" font-family="Inter" font-size="10" fill="${C.muted}">Equity-heavy allocation · Consider rebalancing at 70%+</text>
-      </svg>
-    `;
-
-    svgNode(frame, donutSvg, x, y, 353, 220);
-  }
-
-  // ─── HOLDINGS TABLE ──────────────────────────────────────────
-  function holdingsTable(frame, x, y) {
-    const W = 353;
-    const HEADER_H = 32;
-    const ROW_H = 58;
-
-    const rows = [
-      {
-        type: "equity",
-        name: "HDFC Bank",
-        meta: "Equity · Financials",
-        current: "₹1.83L",
-        invested: "₹1.64L",
-        pnl: "+₹18.6K",
-        pnlPct: "+11.4%",
-        alloc: "14.6%",
-      },
-      {
-        type: "equity",
-        name: "Nifty 50 ETF",
-        meta: "Equity · Index",
-        current: "₹50.7K",
-        invested: "₹44.2K",
-        pnl: "+₹6.5K",
-        pnlPct: "+14.7%",
-        alloc: "4.1%",
-      },
-      {
-        type: "debt",
-        name: "Gold Bond",
-        meta: "Debt · Govt Bond",
-        current: "₹57.1K",
-        invested: "₹53.0K",
-        pnl: "+₹4.1K",
-        pnlPct: "+7.7%",
-        alloc: "4.6%",
-      },
-      {
-        type: "crypto",
-        name: "Bitcoin",
-        meta: "Crypto · Manual",
-        current: "₹13.9L",
-        invested: "₹11.1L",
-        pnl: "+₹2.85L",
-        pnlPct: "+25.7%",
-        alloc: "11.1%",
-      },
-      {
-        type: "debt",
-        name: "Liquid Fund",
-        meta: "Debt · Overnight",
-        current: "₹2.50L",
-        invested: "₹2.50L",
-        pnl: "+₹250",
-        pnlPct: "+0.1%",
-        alloc: "2.0%",
-      },
-      {
-        type: "cash",
-        name: "Cash Reserve",
-        meta: "Available cash",
-        current: "₹1.65L",
-        invested: "—",
-        pnl: "+₹70K",
-        pnlPct: "",
-        alloc: "10.0%",
-      },
-    ];
-
-    const tableH = HEADER_H + rows.length * ROW_H;
-
-    card(frame, x, y, W, tableH, S.radius.lg);
-
-    t(frame, "Asset", x + 14, y + 10, 10, C.secondary, "Medium", 110);
-    t(frame, "Current", x + 214, y + 10, 10, C.secondary, "Medium", 68, "RIGHT");
-    t(frame, "P&L", x + 310, y + 10, 10, C.secondary, "Medium", 42, "RIGHT");
-
-    line(frame, x + 14, y + HEADER_H, W - 28, C.border, 0.5);
-
-    rows.forEach((row, i) => {
-      const rowY = y + HEADER_H + i * ROW_H;
-      const pnlColor = row.pnl.startsWith("-") ? C.negative : C.positive;
-      const ac = assetClass[row.type] || assetClass.equity;
-
-      if (i > 0) {
-        line(frame, x + 14, rowY, W - 28, C.border, 0.2);
-      }
-
-      rect(frame, x + 1, rowY + 8, 3, ROW_H - 16, S.radius.full, ac.color, null);
-
-      assetDot(frame, x + 14, rowY + 20, row.type, 8);
-      ico(frame, ac.icon, x + 26, rowY + 14, 16, ac.color);
-
-      t(frame, row.name, x + 50, rowY + 8, 13, C.text, "Semi Bold", 130);
-      t(frame, row.meta, x + 50, rowY + 28, 10, C.secondary, "Regular", 130);
-
-      t(frame, row.current, x + 198, rowY + 8, 13, C.text, "Semi Bold", 84, "RIGHT");
-      t(frame, row.invested, x + 198, rowY + 28, 10, C.secondary, "Regular", 84, "RIGHT");
-
-      t(frame, row.pnl, x + 282, rowY + 8, 13, pnlColor, "Semi Bold", 68, "RIGHT");
-      t(frame, row.pnlPct, x + 282, rowY + 28, 10, C.secondary, "Regular", 68, "RIGHT");
-    });
-  }
-
-  // ─── PORTFOLIO TREND CHART ───────────────────────────────────
-  function trendChart(frame, x, y, w = 353, h = 140) {
-    card(frame, x, y, w, h, S.radius.md);
-
-    t(frame, "Portfolio trend", x + 14, y + 14, 14, C.text, "Semi Bold", 160);
-    t(frame, "Last 6 months", x + 14, y + 34, 11, C.secondary, "Regular", 140);
-
-    const chartSvg = `
-      <svg width="${w}" height="${h}" viewBox="0 0 ${w} ${h}" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-          <linearGradient id="areaGrad" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0" stop-color="${C.positive}" stop-opacity="0.22"/>
-            <stop offset="1" stop-color="${C.positive}" stop-opacity="0"/>
-          </linearGradient>
-        </defs>
-        <line x1="48" y1="56" x2="${w - 20}" y2="56" stroke="${C.border}" stroke-width="0.6" stroke-dasharray="3 5"/>
-        <line x1="48" y1="80" x2="${w - 20}" y2="80" stroke="${C.border}" stroke-width="0.6" stroke-dasharray="3 5"/>
-        <line x1="48" y1="104" x2="${w - 20}" y2="104" stroke="${C.border}" stroke-width="0.6"/>
-        <text x="38" y="60"  font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="end">20L</text>
-        <text x="38" y="84"  font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="end">17L</text>
-        <text x="38" y="108" font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="end">14L</text>
-        <path d="M52 106 L97 96 L142 89 L187 76 L232 65 L277 57 L318 46 L318 104 L52 104Z" fill="url(#areaGrad)"/>
-        <path d="M52 106 L97 96 L142 89 L187 76 L232 65 L277 57 L318 46" stroke="${C.positive}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-        <circle cx="318" cy="46" r="5" fill="${C.bg}" stroke="${C.positive}" stroke-width="2.5"/>
-        <text x="52"  y="126" font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="middle">Dec</text>
-        <text x="97"  y="126" font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="middle">Jan</text>
-        <text x="142" y="126" font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="middle">Feb</text>
-        <text x="187" y="126" font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="middle">Mar</text>
-        <text x="232" y="126" font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="middle">Apr</text>
-        <text x="277" y="126" font-family="Inter" font-size="9" fill="${C.muted}" text-anchor="middle">May</text>
-        <text x="318" y="126" font-family="Inter" font-size="9" fill="${C.positive}" text-anchor="middle" font-weight="600">Jun</text>
-      </svg>
-    `;
-
-    svgNode(frame, chartSvg, x, y, w, h);
-  }
-
-  // ─── SECTION TITLE ───────────────────────────────────────────
-  function sectionTitle(frame, label, x, y, actionLabel = null, actionColor = C.green) {
-    t(frame, label, x, y, 14, C.text, "Semi Bold", 200);
-    if (actionLabel) {
-      t(frame, actionLabel, 345, y + 1, 12, actionColor, "Medium", 80, "RIGHT");
-    }
-  }
-
-  // ──────────────────────────────────────────────────────────────
-  // SCREEN 1 — DASHBOARD
-  // ──────────────────────────────────────────────────────────────
-  const dashboard = screen("1. Dashboard", 24);
-
-  header(dashboard, "Dashboard", "Local portfolio  ·  3 May 2026", ["eye", "refresh", "plus"]);
-
-  const heroY = 124;
-
-  card(dashboard, S.screenPad, heroY, 353, 128, S.radius.lg);
-
-  t(dashboard, "Portfolio value", S.screenPad + 16, heroY + 14, 11, C.secondary, "Medium", 140);
-  t(dashboard, "₹18.42L", S.screenPad + 16, heroY + 34, 34, C.text, "Bold", 180);
-  t(dashboard, "+₹3.10L  (+20.2%)", S.screenPad + 16, heroY + 80, 13, C.positive, "Semi Bold", 170);
-
-  t(dashboard, "Invested", S.screenPad + 226, heroY + 22, 10, C.secondary, "Regular", 90);
-  t(dashboard, "₹15.32L", S.screenPad + 226, heroY + 38, 15, C.text, "Semi Bold", 100);
-
-  t(dashboard, "Today's change", S.screenPad + 226, heroY + 68, 10, C.secondary, "Regular", 110);
-  t(dashboard, "+0.57%", S.screenPad + 226, heroY + 84, 13, C.positive, "Semi Bold", 80);
-
-  statusBar(dashboard, 264, "Quotes updated 2m ago  ·  Manual fallback ready");
-
-  donutChart(dashboard, S.screenPad, 312);
-
-  const convictionY = 546;
-
-  card(dashboard, S.screenPad, convictionY, 353, 72, S.radius.md);
-  ico(dashboard, "sparkle", S.screenPad + 14, convictionY + 17, 18, C.secondary);
-  t(dashboard, "Conviction data is still building", S.screenPad + 44, convictionY + 14, 13, C.text, "Semi Bold", 230);
-  t(dashboard, "Optional conviction improves context over time.", S.screenPad + 44, convictionY + 36, 11, C.secondary, "Regular", 250);
-
-  const monthY = 632;
-
-  card(dashboard, S.screenPad, monthY, 353, 90, S.radius.md);
-  t(dashboard, "This month", S.screenPad + 14, monthY + 14, 13, C.text, "Semi Bold", 120);
-  t(dashboard, "May 2026", 315, monthY + 16, 11, C.green, "Medium", 60, "RIGHT");
-
-  metricPair(dashboard, "Invested", "₹1.20L", S.screenPad + 14, monthY + 46, 88);
-  metricPair(dashboard, "Savings rate", "42%", S.screenPad + 112, monthY + 46, 88);
-  metricPair(dashboard, "Cash change", "+₹70K", S.screenPad + 214, monthY + 46, 88, C.positive);
-
+  // Dashboard
+  stage = "draw dashboard";
+  const dashboard = screen("Dashboard", 24);
+  header(dashboard, "Dashboard", "Local portfolio · 9 May 2026", ["refresh", "eye"]);
+  card(dashboard, PAD, 144, CONTENT_W, 134);
+  text(dashboard, "Portfolio value", 38, 166, 12, C.secondary, "Semi Bold", 120);
+  text(dashboard, "₹18.42L", 38, 190, 42, C.text, "Bold", 180);
+  chip(dashboard, "+₹3.10L · +20.2%", 38, 238, true, 124);
+  metric(dashboard, "Invested", "₹15.32L", 188, 178, 72);
+  metric(dashboard, "P&L", "+₹3.10L", 268, 178, 72, C.green);
+  metric(dashboard, "Quotes", "2m ago", 268, 232, 72);
+  sectionTitle(dashboard, "Allocation", PAD, 302, "View details");
+  groupedRows(dashboard, PAD, 330, [
+    { type: "equity", title: "Equity", meta: "68% · ₹12.71L", value: "68%" },
+    { type: "debt", title: "Debt", meta: "15% · ₹2.76L", value: "15%" },
+    { type: "crypto", title: "Crypto", meta: "7% · ₹1.29L", value: "7%" },
+    { type: "cash", title: "Cash", meta: "10% · ₹1.65L", value: "10%" },
+  ]);
+  card(dashboard, PAD, 584, CONTENT_W, 86);
+  sectionTitle(dashboard, "This month", 38, 606, "May 2026");
+  metric(dashboard, "Invested", "₹1.20L", 38, 632, 80);
+  metric(dashboard, "Savings", "42%", 152, 632, 70);
+  metric(dashboard, "Cash", "+₹70K", 262, 632, 72, C.green);
+  card(dashboard, PAD, 688, CONTENT_W, 74);
+  glyph(dashboard, 36, 708, "neutral");
+  text(dashboard, "Conviction data is still building", 84, 706, 14, C.text, "Semi Bold", 230);
+  text(dashboard, "Optional conviction improves context over time.", 84, 730, 11, C.secondary, "Regular", 230);
   nav(dashboard, "Dashboard");
 
-  // ──────────────────────────────────────────────────────────────
-  // SCREEN 2 — HOLDINGS
-  // ──────────────────────────────────────────────────────────────
-  const holdings = screen("2. Holdings", 448);
-
-  header(holdings, "Holdings", "24 positions  ·  Updated 2m ago", ["search", "plus"]);
-
-  metricStrip(holdings, S.screenPad, 124, [
-    ["Current", "₹12.48L"],
-    ["Invested", "₹11.05L"],
-    ["P&L", "+₹1.42L", C.positive],
-    ["Drift", "3.2%", C.warning],
+  // Holdings
+  stage = "draw holdings";
+  const holdings = screen("Holdings", 448);
+  header(holdings, "Holdings", "24 positions · local data", ["eye", "search"]);
+  metricStrip(holdings, PAD, 144, [
+    { label: "Current", value: "₹12.48L" },
+    { label: "Invested", value: "₹11.05L" },
+    { label: "P&L", value: "+₹1.42L", color: C.green },
+    { label: "Drift", value: "3.2%", color: C.amber },
   ]);
-
-  statusBar(holdings, 208, "Quotes updated 2m ago  ·  1 manual price");
-
-  filterChips(holdings, 256, ["All", "Equity", "Debt", "Crypto", "Cash"], 0);
-
-  holdingsTable(holdings, S.screenPad, 302);
-
+  text(holdings, "Quotes updated 2m ago · 1 manual price", PAD, 246, 12, C.secondary, "Regular", 240);
+  let chipX = PAD;
+  ["All", "Equity", "Debt", "Crypto", "Cash"].forEach((c, i) => {
+    chipX += chip(holdings, c, chipX, 272, i === 0) + 8;
+  });
+  [
+    ["equity", "HDFC Bank", "Equity · Financial Services", "₹1.83L", "+₹18.6K"],
+    ["equity", "Nifty 50 ETF", "Equity · Index Fund", "₹50.7K", "+₹6.5K"],
+    ["debt", "Sovereign Gold Bond", "Debt · Government Bond · Manual", "₹57.1K", "+₹4.1K"],
+    ["crypto", "Bitcoin", "Crypto · Manual price", "₹13.90L", "+₹2.85L"],
+    ["debt", "Liquid Fund", "Debt · Overnight", "₹2.50L", "+₹250"],
+  ].forEach((r, i) => row(holdings, PAD, 326 + i * 82, CONTENT_W, r[0], r[1], r[2], r[3], r[4]));
   nav(holdings, "Holdings");
 
-  // ──────────────────────────────────────────────────────────────
-  // SCREEN 3 — ADD HOLDING
-  // ──────────────────────────────────────────────────────────────
-  const addTrade = screen("3. Add Holding", 872);
-
-  headerBack(addTrade, "Add Holding", "Opening position  ·  local only");
-  ico(addTrade, "info", 348, 66, 18, C.secondary);
-
-  const stepperY = 130;
-  const steps = ["Asset", "Class", "Position", "Review"];
-  const stepX = [54, 150, 246, 342];
-
-  steps.forEach((label, i) => {
-    const cx = stepX[i];
-    const done = i < 2;
-    const active = i === 2;
-    const bg = done || active ? C.green : C.elevated;
-
-    const ellipse = figma.createEllipse();
-    addTrade.appendChild(ellipse);
-    ellipse.x = cx - 12;
-    ellipse.y = stepperY;
-    ellipse.resize(24, 24);
-    ellipse.fills = [paint(bg)];
-    ellipse.strokes = [];
-
-    if (done) {
-      ico(addTrade, "check", cx - 7, stepperY + 4, 14, C.text);
-    } else {
-      t(addTrade, String(i + 1), cx - 12, stepperY + 4, 11, C.text, "Semi Bold", 24, "CENTER");
-    }
-
-    t(addTrade, label, cx - 24, stepperY + 30, 10, active ? C.green : C.secondary, active ? "Semi Bold" : "Regular", 48, "CENTER");
-
-    if (i < steps.length - 1) {
-      const lineColor = done ? C.green : C.border;
-      rect(addTrade, cx + 14, stepperY + 11, stepX[i + 1] - cx - 26, 2, S.radius.full, lineColor, null);
-    }
+  // Add Holding
+  stage = "draw add holding";
+  const add = screen("Add Holding", 872);
+  header(add, "Add Holding", "Opening position · local only", ["help"]);
+  ["Asset", "Class", "Position", "Review"].forEach((s, i) => {
+    const cx = 55 + i * 94;
+    glyph(add, cx - 14, 144, i === 0 ? "equity" : "neutral", 28);
+    text(add, s, cx - 34, 180, 10, i === 0 ? C.green : C.secondary, i === 0 ? "Bold" : "Regular", 68, "CENTER");
+    if (i < 3) line(add, cx + 20, 158, 50, 0.32);
   });
+  card(add, PAD, 216, CONTENT_W, 122);
+  sectionTitle(add, "Find asset", 38, 238);
+  rect(add, 38, 268, 314, 44, C.field, 16);
+  icon(add, "search", 52, 280, C.secondary, 18);
+  text(add, "Search name or symbol", 80, 280, 13, C.secondary, "Regular", 190);
+  text(add, "Only search text is sent to quote providers.", 38, 318, 10.5, C.muted, "Regular", 260);
+  row(add, PAD, 352, CONTENT_W, "equity", "HDFC Bank", "HDFCBANK.NS · NSE · INR · Equity", "₹1,678.25", "Live", C.text);
+  card(add, PAD, 438, CONTENT_W, 96);
+  sectionTitle(add, "Position details", 38, 458);
+  formField(add, 38, 490, 148, "Quantity", "25");
+  formField(add, 202, 490, 150, "Average cost", "₹1,450.00");
+  formField(add, 38, 560, 148, "Current price", "₹1,678.25");
+  formField(add, 202, 560, 150, "Price source", "Live");
+  card(add, PAD, 632, CONTENT_W, 92);
+  sectionTitle(add, "Derived preview", 38, 652);
+  metric(add, "Invested", "₹36,250", 38, 684, 82);
+  metric(add, "Current", "₹41,956", 134, 684, 82);
+  metric(add, "P&L", "+₹5,706", 230, 684, 82, C.green);
+  rect(add, PAD, 740, CONTENT_W, 48, C.brandGreen, 18);
+  text(add, "Continue", PAD, 756, 13, C.text, "Bold", CONTENT_W, "CENTER");
+  nav(add, "Holdings");
 
-  const assetSummaryY = 184;
-
-  card(addTrade, S.screenPad, assetSummaryY, 353, 52, S.radius.md);
-  ico(addTrade, "trend", S.screenPad + 12, assetSummaryY + 16, 18, C.positive);
-  t(addTrade, "HDFC Bank", S.screenPad + 38, assetSummaryY + 10, 14, C.text, "Semi Bold", 160);
-  t(addTrade, "HDFCBANK.NS  ·  NSE  ·  INR", S.screenPad + 38, assetSummaryY + 30, 11, C.secondary, "Regular", 190);
-  t(addTrade, "Edit ›", 330, assetSummaryY + 18, 12, C.secondary, "Medium", 48, "RIGHT");
-
-  const classY = 248;
-
-  card(addTrade, S.screenPad, classY, 353, 52, S.radius.md);
-  ico(addTrade, "pie", S.screenPad + 12, classY + 16, 18, C.positive);
-  t(addTrade, "Classification", S.screenPad + 38, classY + 10, 14, C.text, "Semi Bold", 140);
-  t(addTrade, "Equity · Large Cap · Financial Services", S.screenPad + 38, classY + 30, 11, C.secondary, "Regular", 220);
-  t(addTrade, "Edit ›", 330, classY + 18, 12, C.secondary, "Medium", 48, "RIGHT");
-
-  const posY = 312;
-
-  card(addTrade, S.screenPad, posY, 353, 188, S.radius.md);
-  t(addTrade, "Position details", S.screenPad + 14, posY + 14, 15, C.text, "Semi Bold", 180);
-
-  [
-    [S.screenPad + 14, "Quantity *", "25"],
-    [S.screenPad + 118, "Average cost *", "₹1,450.00"],
-    [S.screenPad + 230, "Current price *", "₹1,678.25"],
-  ].forEach(([ix, label, val]) => {
-    t(addTrade, label, ix, posY + 46, 10, C.secondary, "Regular", 90);
-    rect(addTrade, ix, posY + 64, 88, 34, S.radius.sm, C.field, C.border, 0.3);
-    t(addTrade, val, ix + 8, posY + 75, 13, C.text, "Semi Bold", 72);
-  });
-
-  rect(addTrade, S.screenPad + 14, posY + 108, 50, 24, S.radius.full, C.green, null);
-  t(addTrade, "Live", S.screenPad + 14, posY + 115, 11, C.text, "Semi Bold", 50, "CENTER");
-
-  rect(addTrade, S.screenPad + 72, posY + 108, 60, 24, S.radius.full, C.elevated, C.border, 0.3);
-  t(addTrade, "Manual", S.screenPad + 72, posY + 115, 11, C.secondary, "Regular", 60, "CENTER");
-
-  t(addTrade, "Date acquired: 15 Apr 2024", S.screenPad + 14, posY + 146, 11, C.secondary, "Regular", 200);
-
-  const previewY = 512;
-
-  card(addTrade, S.screenPad, previewY, 353, 82, S.radius.md);
-  t(addTrade, "Derived preview", S.screenPad + 14, previewY + 12, 13, C.secondary, "Medium", 160);
-
-  [
-    ["Invested", "₹36K"],
-    ["Current", "₹41.9K"],
-    ["P&L", "+₹5.9K"],
-    ["Alloc", "2.34%"],
-  ].forEach(([label, val], i) => {
-    const vx = S.screenPad + 14 + i * 82;
-    const vColor = label === "P&L" ? C.positive : C.text;
-
-    t(addTrade, label, vx, previewY + 34, 10, C.secondary, "Regular", 76);
-    t(addTrade, val, vx, previewY + 52, 14, vColor, "Semi Bold", 76);
-  });
-
-  const addConvictionY = 606;
-
-  card(addTrade, S.screenPad, addConvictionY, 353, 58, S.radius.md);
-  t(addTrade, "Conviction optional", S.screenPad + 14, addConvictionY + 10, 13, C.text, "Semi Bold", 160);
-  t(addTrade, "1 low · 5 high", S.screenPad + 14, addConvictionY + 31, 10, C.secondary, "Regular", 100);
-  convictionDots(addTrade, S.screenPad + 184, addConvictionY + 18, 4);
-
-  rect(addTrade, S.screenPad, 676, 353, 48, S.radius.md, C.green, null);
-  t(addTrade, "Save holding", S.screenPad, 692, 14, C.text, "Bold", 353, "CENTER");
-  t(addTrade, "Save and add another", S.screenPad, 734, 11, C.secondary, "Medium", 353, "CENTER");
-
-  nav(addTrade, "Holdings");
-
-  // ──────────────────────────────────────────────────────────────
-  // SCREEN 4 — CASH
-  // ──────────────────────────────────────────────────────────────
-  const cash = screen("4. Cash", 1296);
-
-  header(cash, "Cash", "Manual ledger  ·  local only", ["plus", "eye"]);
-
-  card(cash, S.screenPad, 124, 353, 92, S.radius.lg);
-  ico(cash, "wallet", S.screenPad + 16, 156, 24, C.cashBlue);
-  t(cash, "Cash balance", S.screenPad + 50, 136, 11, C.secondary, "Regular", 130);
-  t(cash, "₹1,65,600", S.screenPad + 50, 158, 28, C.text, "Bold", 180);
-  t(cash, "₹•• •••", 294, 162, 14, C.secondary, "Medium", 60, "RIGHT");
-  t(cash, "+₹70K this month", S.screenPad + 50, 194, 12, C.positive, "Medium", 160);
-
-  metricStrip(cash, S.screenPad, 228, [
-    ["Added", "₹70K", C.positive],
-    ["Invested", "₹45K"],
-    ["Available", "₹1.20L"],
-    ["Savings", "32.8%", C.green],
+  // Progress
+  stage = "draw progress";
+  const progress = screen("Monthly Progress", 1296);
+  header(progress, "Monthly Progress", "May 2026 snapshot", ["eye"]);
+  chip(progress, "Apr 2026", PAD, 144, false, 86);
+  chip(progress, "May 2026", PAD + 96, 144, true, 94);
+  chip(progress, "Jun 2026", PAD + 200, 144, false, 88);
+  metricStrip(progress, PAD, 190, [
+    { label: "Portfolio", value: "₹19.87L" },
+    { label: "Invested", value: "₹1.40L" },
+    { label: "Cash", value: "₹3.25L" },
+    { label: "Savings", value: "34%" },
   ]);
-
-  const addCashY = 312;
-
-  card(cash, S.screenPad, addCashY, 353, 218, S.radius.lg);
-  t(cash, "Add cash entry", S.screenPad + 14, addCashY + 14, 15, C.text, "Semi Bold", 160);
-
-  [
-    ["Deposit", true],
-    ["Withdraw", false],
-    ["Transfer", false],
-  ].forEach(([label, active], i) => {
-    const cx = S.screenPad + 14 + i * 98;
-    const cw = 86;
-
-    rect(cash, cx, addCashY + 44, cw, 28, S.radius.full, active ? C.green : C.elevated, active ? null : C.border, 0.3);
-    t(cash, label, cx, addCashY + 52, 12, active ? C.text : C.secondary, active ? "Semi Bold" : "Regular", cw, "CENTER");
-  });
-
-  t(cash, "Amount (INR) *", S.screenPad + 14, addCashY + 86, 10, C.secondary, "Regular", 120);
-  rect(cash, S.screenPad + 14, addCashY + 104, 148, 36, S.radius.sm, C.field, C.border, 0.3);
-  t(cash, "₹0", S.screenPad + 28, addCashY + 116, 13, C.muted, "Regular", 100);
-
-  t(cash, "Date *", S.screenPad + 178, addCashY + 86, 10, C.secondary, "Regular", 80);
-  rect(cash, S.screenPad + 178, addCashY + 104, 148, 36, S.radius.sm, C.field, C.border, 0.3);
-  t(cash, "03 May 2026", S.screenPad + 192, addCashY + 116, 13, C.text, "Regular", 120);
-  ico(cash, "calendar", S.screenPad + 298, addCashY + 112, 16, C.secondary);
-
-  t(cash, "Note", S.screenPad + 14, addCashY + 152, 10, C.secondary, "Regular", 60);
-  rect(cash, S.screenPad + 50, addCashY + 148, 276, 28, S.radius.sm, C.field, C.border, 0.25);
-  t(cash, "Salary, SIP transfer…", S.screenPad + 62, addCashY + 156, 11, C.muted, "Regular", 230);
-
-  rect(cash, S.screenPad + 14, addCashY + 188, 325, 22, S.radius.full, C.green, null);
-  t(cash, "Save entry", S.screenPad + 14, addCashY + 193, 11, C.text, "Bold", 325, "CENTER");
-
-  sectionTitle(cash, "Recent ledger", S.screenPad, 546, "View all");
-
-  const ledgerRows = [
-    ["Salary added", "+₹70,000", C.positive],
-    ["SIP — Index Fund", "-₹15,000", C.secondary],
-    ["Emergency fund top-up", "+₹10,000", C.positive],
-    ["SIP — Large Cap", "-₹15,000", C.secondary],
-  ];
-
-  card(cash, S.screenPad, 568, 353, ledgerRows.length * 40 + 8, S.radius.md);
-
-  ledgerRows.forEach(([label, value, color], i) => {
-    const ly = 576 + i * 40;
-
-    if (i > 0) {
-      line(cash, S.screenPad + 14, ly, 325, C.border, 0.2);
-    }
-
-    t(cash, label, S.screenPad + 14, ly + 14, 12, C.secondary, "Regular", 180);
-    t(cash, value, 350, ly + 12, 13, color, "Semi Bold", 60, "RIGHT");
-  });
-
-  nav(cash, "Cash");
-
-  // ──────────────────────────────────────────────────────────────
-  // SCREEN 5 — MONTHLY PROGRESS
-  // ──────────────────────────────────────────────────────────────
-  const progress = screen("5. Progress", 1720);
-
-  headerBack(progress, "Progress", "May 2026 snapshot", "calendar");
-
-  t(progress, "‹  Apr 2026", S.screenPad, 122, 12, C.secondary, "Regular", 100);
-  t(progress, "May 2026", 164, 122, 14, C.green, "Semi Bold", 80, "CENTER");
-  t(progress, "Jun 2026  ›", 294, 122, 12, C.secondary, "Regular", 80, "RIGHT");
-
-  metricStrip(progress, S.screenPad, 148, [
-    ["Portfolio", "₹19.87L"],
-    ["Invested", "₹1.40L"],
-    ["Cash", "₹3.25L"],
-    ["Savings", "34%", C.green],
+  card(progress, PAD, 298, CONTENT_W, 238);
+  sectionTitle(progress, "Portfolio vs invested", 38, 318);
+  valueGraph(progress, 36, 344);
+  legend(progress, 58, 500, [
+    { label: "Total value", color: C.text },
+    { label: "Invested", color: C.investedLine },
   ]);
-
-  const changedY = 232;
-
-  card(progress, S.screenPad, changedY, 353, 212, S.radius.lg);
-  t(progress, "What changed this month?", S.screenPad + 14, changedY + 14, 15, C.text, "Semi Bold", 220);
-
-  [
-    ["equity", "Equity", "Market value and contributions", "+₹58,000"],
-    ["debt", "Debt", "Stable allocation", "+₹12,000"],
-    ["crypto", "Crypto", "Manual price movement", "-₹8,500"],
-    ["cash", "Cash", "Net cash change", "+₹70,000"],
-  ].forEach(([type, label, caption, value], i) => {
-    const ac = assetClass[type];
-    const wy = changedY + 52 + i * 38;
-    const isNeg = value.startsWith("-");
-
-    assetDot(progress, S.screenPad + 14, wy + 8, type, 8);
-    ico(progress, ac.icon, S.screenPad + 26, wy + 2, 16, ac.color);
-
-    t(progress, label, S.screenPad + 52, wy, 13, C.text, "Semi Bold", 110);
-    t(progress, caption, S.screenPad + 52, wy + 17, 10, C.secondary, "Regular", 180);
-    t(progress, value, 310, wy + 2, 13, isNeg ? C.negative : C.text, "Semi Bold", 62, "RIGHT");
-  });
-
-  trendChart(progress, S.screenPad, 456, 353, 140);
-
-  const snapY = 610;
-
-  card(progress, S.screenPad, snapY, 353, 118, S.radius.md);
-  t(progress, "Asset class snapshot", S.screenPad + 14, snapY + 12, 14, C.text, "Semi Bold", 200);
-
-  [
-    ["equity", "Equity", "₹12,45,000", "62.6%"],
-    ["debt", "Debt", "₹3,22,000", "16.2%"],
-    ["crypto", "Crypto", "₹1,20,000", "6.0%"],
-    ["cash", "Cash", "₹3,25,470", "16.3%"],
-  ].forEach(([type, label, value, pct], i) => {
-    const sy = snapY + 42 + i * 18;
-
-    assetDot(progress, S.screenPad + 14, sy + 5, type, 7);
-    t(progress, label, S.screenPad + 28, sy, 12, C.text, "Medium", 70);
-    t(progress, value, 250, sy, 12, C.text, "Regular", 80, "RIGHT");
-    t(progress, pct, 340, sy, 12, C.secondary, "Regular", 36, "RIGHT");
-  });
-
+  card(progress, PAD, 552, CONTENT_W, 238);
+  sectionTitle(progress, "Assets vs months", 38, 572);
+  assetGraph(progress, 36, 598);
+  legend(progress, 58, 754, [
+    { label: "Equity", color: C.equityLine },
+    { label: "Debt", color: C.debtLine },
+    { label: "Crypto", color: C.amber },
+  ]);
   nav(progress, "Progress");
 
-  // ──────────────────────────────────────────────────────────────
-  // SCREEN 6 — SETTINGS
-  // ──────────────────────────────────────────────────────────────
-  const settings = screen("6. Settings", 2144);
-
-  header(settings, "Settings", "Local-first controls");
-  ico(settings, "info", 350, 66, 18, C.secondary);
-
-  let sy = 128;
-
-  function settingsSection(title, rows) {
-    t(settings, title, S.screenPad, sy, 13, C.secondary, "Semi Bold", 160);
-    sy += 24;
-
-    const sH = rows.length * 48;
-
-    card(settings, S.screenPad, sy, 353, sH, S.radius.lg);
-
-    rows.forEach(([label, value, valueColor, iconName], i) => {
-      const ry = sy + i * 48;
-
-      if (i > 0) {
-        line(settings, S.screenPad + 14, ry, 325, C.border, 0.25);
-      }
-
-      if (iconName) {
-        ico(settings, iconName, S.screenPad + 14, ry + 14, 18, C.secondary);
-        t(settings, label, S.screenPad + 42, ry + 15, 13, C.text, "Medium", 160);
-      } else {
-        t(settings, label, S.screenPad + 14, ry + 15, 13, C.text, "Medium", 190);
-      }
-
-      if (value) {
-        t(settings, value, 340, ry + 15, 12, valueColor || C.secondary, "Regular", 90, "RIGHT");
-        ico(settings, "chevron", 346, ry + 14, 16, C.muted);
-      }
-    });
-
-    sy += sH + 18;
-  }
-
-  settingsSection("PRIVACY", [
-    ["Local storage", "Active", C.positive, "shield"],
-    ["Account", "None", C.secondary, null],
-    ["Analytics", "Off", C.secondary, null],
+  // Cash
+  stage = "draw cash";
+  const cash = screen("Cash Ledger", 1720);
+  header(cash, "Cash Ledger", "Manual ledger · local only", ["eye", "plus"]);
+  card(cash, PAD, 144, CONTENT_W, 134);
+  text(cash, "Cash balance", 38, 166, 12, C.secondary, "Semi Bold", 120);
+  text(cash, "₹1,65,600", 38, 194, 34, C.text, "Bold", 180);
+  chip(cash, "Available · ₹1.20L", 38, 238, true, 132);
+  metric(cash, "Added", "₹70K", 206, 178, 56);
+  metric(cash, "Invested", "₹45K", 282, 178, 64);
+  metric(cash, "Savings", "32.8%", 282, 232, 64);
+  card(cash, PAD, 300, CONTENT_W, 188);
+  sectionTitle(cash, "Add cash entry", 38, 322);
+  chip(cash, "Deposit", 38, 354, true, 76);
+  chip(cash, "Withdraw", 122, 354, false, 86);
+  chip(cash, "Transfer", 216, 354, false, 78);
+  formField(cash, 38, 400, 148, "Amount (INR)", "₹0");
+  formField(cash, 202, 400, 150, "Date", "09 May 2026");
+  formField(cash, 38, 468, 314, "Note", "Salary, SIP transfer, emergency fund");
+  sectionTitle(cash, "Recent cash ledger", PAD, 524, "View all");
+  groupedRows(cash, PAD, 552, [
+    { type: "cash", title: "Salary added", meta: "Cash deposit", value: "+₹70K", color: C.green },
+    { type: "equity", title: "SIP transfer", meta: "Index Fund", value: "-₹15K" },
+    { type: "cash", title: "Emergency fund top-up", meta: "Cash reserve", value: "+₹10K", color: C.green },
   ]);
+  nav(cash, "Cash");
 
-  settingsSection("DISPLAY", [
-    ["Value masking", "Off", C.secondary, "eye"],
-    ["Display mode", "Standard", C.green, null],
-    ["Base currency", "INR  ₹", C.secondary, null],
+  // Settings
+  stage = "draw settings";
+  const settings = screen("Settings", 2144);
+  header(settings, "Settings", "Local-first controls", ["info"]);
+  sectionLabel(settings, "Privacy", PAD, 144);
+  groupedRows(settings, PAD, 166, [
+    { type: "debt", title: "Privacy", meta: "Local storage active · No account · No cloud", value: "On", color: C.green },
+    { type: "neutral", title: "Value masking", meta: "Hide sensitive values on screen", value: "Ready" },
   ]);
-
-  settingsSection("QUOTES", [
-    ["Live quotes", "15 min", C.secondary, "refresh"],
-    ["Manual fallback", "Enabled", C.positive, null],
-    ["Last updated", "2m ago", C.secondary, null],
+  sectionLabel(settings, "Quotes", PAD, 300);
+  groupedRows(settings, PAD, 322, [
+    { type: "cash", title: "Quotes", meta: "Every 15 min · Manual fallback on", value: "OK", color: C.green },
   ]);
-
-  settingsSection("APP", [
-    ["Density", "Standard", C.secondary, null],
-    ["Version", "1.0.0", C.secondary, null],
+  sectionLabel(settings, "Currency", PAD, 396);
+  card(settings, PAD, 418, CONTENT_W, 106);
+  sectionTitle(settings, "Currency", 38, 438);
+  metric(settings, "Base currency", "INR", 38, 474, 90);
+  metric(settings, "Foreign summary", "On", 150, 474, 90);
+  metric(settings, "Fallback", "On", 264, 474, 74);
+  sectionLabel(settings, "Display", PAD, 546);
+  card(settings, PAD, 568, CONTENT_W, 122);
+  sectionTitle(settings, "Display and app info", 38, 588);
+  groupedRows(settings, 38, 622, [
+    { type: "neutral", title: "Density", meta: "Standard V1", value: "" },
+    { type: "neutral", title: "Minimal Mode", meta: "V2 locked", value: "" },
   ]);
-
-  rect(settings, S.screenPad, sy, 353, 44, S.radius.md, C.bg, C.negative, 0.4);
-  t(settings, "Clear local data", S.screenPad + 14, sy + 14, 13, C.negative, "Medium", 180);
-  t(settings, "Permanently deletes all holdings", 304, sy + 14, 11, C.muted, "Regular", 154, "RIGHT");
-
+  sectionLabel(settings, "Data", PAD, 710);
+  card(settings, PAD, 732, CONTENT_W, 48);
+  text(settings, "Clear local data", 38, 748, 13, C.negative, "Semi Bold", 140);
+  text(settings, "Destructive", 255, 748, 12, C.negative, "Regular", 80, "RIGHT");
   nav(settings, "Settings");
 
-  // ─── PAGE TITLE ──────────────────────────────────────────────
-  t(page, "CogVest — Screens", 24, 24, 28, C.text, "Bold", 900);
-  t(
-    page,
-    "6 screens · Dashboard · Holdings · Add Holding · Cash · Progress · Settings",
-    24,
-    62,
-    13,
-    C.secondary,
-    "Regular",
-    1300
-  );
+  // V1 States
+  stage = "draw states";
+  const states = screen("V1 States", 2568);
+  header(states, "V1 States", "Implementation coverage", []);
+  card(states, PAD, 144, CONTENT_W, 128);
+  glyph(states, 38, 166, "equity", 56);
+  sectionTitle(states, "Empty portfolio", 112, 166);
+  text(states, "No holdings yet. Start with one opening position; no spreadsheet required.", 112, 196, 12, C.secondary, "Regular", 220);
+  rect(states, 112, 230, 150, 36, C.brandGreen, 999);
+  text(states, "Add first holding", 112, 240, 12, C.text, "Bold", 150, "CENTER");
+  card(states, PAD, 298, CONTENT_W, 120);
+  sectionTitle(states, "Quote lookup loading", 38, 320);
+  rect(states, 38, 358, 260, 12, C.elevated, 999);
+  rect(states, 38, 382, 170, 12, C.elevated, 999);
+  text(states, "Skeletons match the result row shape. Avoid spinners for ordinary lookup latency.", 38, 400, 11, C.secondary, "Regular", 280);
+  card(states, PAD, 444, CONTENT_W, 112);
+  sectionTitle(states, "Provider unavailable", 38, 466);
+  text(states, "Could not fetch a live quote. Continue manually and CogVest will mark the price source.", 38, 496, 12, C.secondary, "Regular", 280);
+  text(states, "Enter price manually", 38, 530, 12, C.green, "Semi Bold", 160);
+  card(states, PAD, 582, CONTENT_W, 92);
+  sectionTitle(states, "No monthly snapshots", 38, 604);
+  text(states, "Monthly Progress becomes useful after the first saved snapshot. Keep the chart area calm.", 38, 634, 12, C.secondary, "Regular", 280);
 
-  // ─── VIEWPORT ────────────────────────────────────────────────
-  figma.viewport.scrollAndZoomIntoView([
-    dashboard,
-    holdings,
-    addTrade,
-    cash,
-    progress,
-    settings,
-  ]);
-
-  figma.closePlugin("✓ CogVest screens generated.");
+  stage = "zoom to screens";
+  figma.viewport.scrollAndZoomIntoView([dashboard, holdings, add, progress, cash, settings, states]);
+  figma.closePlugin("CogVest Issue 86 premium screens generated.");
 }
 
-main().catch((err) => figma.closePlugin(`Failed: ${err.message}`));
+main().catch((err) => {
+  figma.closePlugin(`CogVest screen generation failed at ${stage}: ${err.message}`);
+});

--- a/docs/design/figma/issue-69-v1-screens/code.js
+++ b/docs/design/figma/issue-69-v1-screens/code.js
@@ -249,13 +249,14 @@ async function main() {
     return width;
   }
 
-  function row(parent, x, y, w, type, title, meta, value, sub = null, valueColor = C.text) {
+  function row(parent, x, y, w, type, title, meta, value, sub = null, valueColor = C.text, allocation = null) {
     rect(parent, x, y, w, 72, C.surface, 18);
     glyph(parent, x + 12, y + 19, type, 34);
     text(parent, title, x + 58, y + 15, 14, C.text, "Semi Bold", 150);
     text(parent, meta, x + 58, y + 36, 10.5, C.secondary, "Regular", 180);
     text(parent, value, x + w - 112, y + 15, 14, valueColor, "Bold", 96, "RIGHT");
-    if (sub) text(parent, sub, x + w - 112, y + 38, 10.5, sub.startsWith("-") ? C.negative : C.green, "Semi Bold", 96, "RIGHT");
+    if (sub) text(parent, sub, x + w - 112, y + 35, 10.5, sub.startsWith("-") ? C.negative : C.green, "Semi Bold", 96, "RIGHT");
+    if (allocation) text(parent, allocation, x + w - 112, y + 53, 9.5, C.secondary, "Regular", 96, "RIGHT");
   }
 
   function groupedRows(parent, x, y, rows) {
@@ -384,12 +385,12 @@ async function main() {
     chipX += chip(holdings, c, chipX, 272, i === 0) + 8;
   });
   [
-    ["equity", "HDFC Bank", "Equity · Financial Services", "₹1.83L", "+₹18.6K"],
-    ["equity", "Nifty 50 ETF", "Equity · Index Fund", "₹50.7K", "+₹6.5K"],
-    ["debt", "Sovereign Gold Bond", "Debt · Government Bond · Manual", "₹57.1K", "+₹4.1K"],
-    ["crypto", "Bitcoin", "Crypto · Manual price", "₹13.90L", "+₹2.85L"],
-    ["debt", "Liquid Fund", "Debt · Overnight", "₹2.50L", "+₹250"],
-  ].forEach((r, i) => row(holdings, PAD, 326 + i * 82, CONTENT_W, r[0], r[1], r[2], r[3], r[4]));
+    ["equity", "HDFC Bank", "Equity · Financial Services", "₹1.83L", "+₹18.6K", "14.6% allocation"],
+    ["equity", "Nifty 50 ETF", "Equity · Index Fund", "₹50.7K", "+₹6.5K", "4.1% allocation"],
+    ["debt", "Sovereign Gold Bond", "Debt · Government Bond · Manual", "₹57.1K", "+₹4.1K", "4.6% allocation"],
+    ["crypto", "Bitcoin", "Crypto · Manual price", "₹13.90L", "+₹2.85L", "11.1% allocation"],
+    ["debt", "Liquid Fund", "Debt · Overnight", "₹2.50L", "+₹250", "2.0% allocation"],
+  ].forEach((r, i) => row(holdings, PAD, 326 + i * 82, CONTENT_W, r[0], r[1], r[2], r[3], r[4], C.text, r[5]));
   nav(holdings, "Holdings");
 
   // Add Holding - Asset Lookup

--- a/docs/design/figma/issue-69-v1-screens/manifest.json
+++ b/docs/design/figma/issue-69-v1-screens/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "CogVest Issue 69 V1 Screens",
-  "id": "cogvest-issue-69-v1-screens",
+  "name": "CogVest Issue 86 Premium V1 Screens",
+  "id": "cogvest-issue-86-premium-v1-screens",
   "api": "1.0.0",
   "main": "code.js",
   "editorType": ["figma"]

--- a/docs/design/issue-86-premium-preview/README.md
+++ b/docs/design/issue-86-premium-preview/README.md
@@ -1,0 +1,30 @@
+# Issue 86 Premium Preview
+
+Static browser mockup for the CogVest V1 premium design pass.
+
+## Scope
+
+- Dashboard
+- Holdings
+- Add Holding
+- Monthly Progress
+- Cash Ledger
+- Settings
+- V1 States
+- Empty portfolio, quote lookup, provider error, manual price fallback, and no-snapshot state frame
+
+This is a design preview only. It does not modify the Expo app.
+
+## Run
+
+From this folder:
+
+```powershell
+python -m http.server 4173
+```
+
+Open:
+
+```text
+http://127.0.0.1:4173
+```

--- a/docs/design/issue-86-premium-preview/index.html
+++ b/docs/design/issue-86-premium-preview/index.html
@@ -1056,6 +1056,7 @@
               <header class="header-row">
                 <div><h2 class="title">Holdings</h2><p class="subtitle">24 positions · local data</p></div>
                 <div class="actions">
+                  <button class="icon-button" type="button" aria-label="Add holding"><svg viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg></button>
                   <button class="icon-button" type="button" aria-label="Search holdings"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="m16 16 5 5"/></svg></button>
                   <button class="icon-button" type="button" aria-label="Mask holding values"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg></button>
                 </div>

--- a/docs/design/issue-86-premium-preview/index.html
+++ b/docs/design/issue-86-premium-preview/index.html
@@ -1058,7 +1058,6 @@
                 <div class="actions">
                   <button class="icon-button" type="button" aria-label="Add holding"><svg viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg></button>
                   <button class="icon-button" type="button" aria-label="Search holdings"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="m16 16 5 5"/></svg></button>
-                  <button class="icon-button" type="button" aria-label="Mask holding values"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg></button>
                 </div>
               </header>
 
@@ -1113,44 +1112,15 @@
               </section>
 
               <section class="surface data-card">
-                <div class="section-title">Selected asset</div>
-                <div class="data-row"><span>Name</span><strong>HDFC Bank</strong></div>
-                <div class="data-row"><span>Symbol</span><strong>HDFCBANK</strong></div>
+                <div class="section-title">Selected result</div>
+                <div class="data-row"><span>Asset</span><strong>HDFC Bank</strong></div>
                 <div class="data-row"><span>Ticker</span><strong>HDFCBANK.NS</strong></div>
-                <div class="data-row"><span>Currency</span><strong>INR</strong></div>
-              </section>
-
-              <section class="surface data-card">
-                <div class="section-title">Next: Classification</div>
-                <div class="data-row"><span>Suggested</span><strong>Equity · Large Cap</strong></div>
-                <div class="data-row"><span>Sector</span><strong>Financial Services</strong></div>
-              </section>
-
-              <section class="surface data-card">
-                <div class="section-title">Position details</div>
-                <div class="form-grid">
-                  <div class="form-field"><label>Quantity</label><strong>25</strong></div>
-                  <div class="form-field"><label>Average cost</label><strong>₹1,450.00</strong></div>
-                  <div class="form-field"><label>Current price</label><strong>₹1,678.25</strong></div>
-                  <div class="form-field"><label>Price source</label><strong>Live</strong></div>
-                  <div class="form-field full"><label>Date acquired</label><strong>15 Apr 2024</strong></div>
-                </div>
-              </section>
-
-              <section class="surface data-card">
-                <div class="section-title">Derived preview</div>
-                <div class="data-row"><span>Invested</span><strong>₹36,250</strong></div>
-                <div class="data-row"><span>Current</span><strong>₹41,956</strong></div>
-                <div class="data-row"><span>P&L</span><strong class="positive">+₹5,706 · +15.7%</strong></div>
-              </section>
-
-              <section class="surface data-card">
-                <div class="section-title">Review</div>
-                <p class="helper">Conviction and notes stay optional. Save only after derived values look right.</p>
+                <div class="data-row"><span>Next</span><strong>Position details</strong></div>
+                <p class="helper">Classification, quantity, price source, derived preview, and review are separate Figma states.</p>
               </section>
 
               <div class="cta-row">
-                <button class="primary" type="button">Continue</button>
+                <button class="primary" type="button">Continue to position</button>
                 <button class="secondary-action" type="button">Enter manually</button>
               </div>
             </div>

--- a/docs/design/issue-86-premium-preview/index.html
+++ b/docs/design/issue-86-premium-preview/index.html
@@ -1,0 +1,1421 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CogVest Issue 86 Premium Preview</title>
+    <style>
+      :root {
+        --bg: #000000;
+        --canvas: #0a0a0b;
+        --surface: #1c1c1e;
+        --elevated: #2c2c2e;
+        --field: #111113;
+        --text: #f5f5f7;
+        --secondary: #98989d;
+        --muted: #636366;
+        --separator: rgba(255, 255, 255, 0.1);
+        --green: #34c759;
+        --brand-green: #2e7d52;
+        --green-soft: rgba(52, 199, 89, 0.16);
+        --blue: #0a84ff;
+        --cash-blue: #64d2ff;
+        --amber: #ff9f0a;
+        --negative: #ff453a;
+        --radius-lg: 24px;
+        --radius-md: 18px;
+        --radius-sm: 12px;
+        --phone-w: 390px;
+        --phone-h: 844px;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100dvh;
+        background:
+          radial-gradient(circle at 18% 8%, rgba(46, 125, 82, 0.12), transparent 28rem),
+          radial-gradient(circle at 78% 22%, rgba(255, 255, 255, 0.04), transparent 24rem),
+          #050505;
+        color: var(--text);
+        font-family:
+          "Geist", "Satoshi", "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+        letter-spacing: -0.01em;
+      }
+
+      .page {
+        width: min(100%, 1440px);
+        margin: 0 auto;
+        padding: 40px 28px 56px;
+      }
+
+      .preview-header {
+        display: flex;
+        align-items: end;
+        justify-content: space-between;
+        gap: 24px;
+        margin-bottom: 28px;
+      }
+
+      .eyebrow {
+        margin: 0 0 8px;
+        color: var(--green);
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+      }
+
+      h1 {
+        margin: 0;
+        max-width: 760px;
+        font-size: clamp(32px, 5vw, 64px);
+        line-height: 0.96;
+        letter-spacing: -0.06em;
+      }
+
+      .preview-note {
+        max-width: 440px;
+        margin: 0;
+        color: var(--secondary);
+        font-size: 14px;
+        line-height: 1.6;
+      }
+
+      .screen-tabs {
+        display: none;
+        gap: 8px;
+        margin-bottom: 18px;
+      }
+
+      .screen-tabs button {
+        border: 0;
+        border-radius: 999px;
+        padding: 10px 14px;
+        background: var(--surface);
+        color: var(--secondary);
+        font: inherit;
+        cursor: pointer;
+        transition:
+          transform 160ms ease,
+          background 160ms ease,
+          color 160ms ease;
+      }
+
+      .screen-tabs button.active {
+        background: var(--green);
+        color: #07150d;
+        font-weight: 800;
+      }
+
+      .screens {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(320px, var(--phone-w)));
+        gap: 26px;
+        align-items: start;
+        justify-content: center;
+      }
+
+      .phone-shell {
+        width: var(--phone-w);
+        height: var(--phone-h);
+        border-radius: 42px;
+        padding: 10px;
+        background: linear-gradient(160deg, rgba(255, 255, 255, 0.14), transparent 22%, rgba(255, 255, 255, 0.04));
+        box-shadow: 0 32px 90px rgba(0, 0, 0, 0.42);
+      }
+
+      .phone {
+        position: relative;
+        height: 100%;
+        overflow: hidden;
+        border-radius: 34px;
+        background: var(--bg);
+      }
+
+      .status {
+        display: flex;
+        justify-content: space-between;
+        padding: 18px 22px 0;
+        color: var(--text);
+        font-size: 12px;
+        font-weight: 600;
+      }
+
+      .status-icons {
+        display: flex;
+        gap: 4px;
+        align-items: center;
+      }
+
+      .status-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 2px;
+        background: var(--text);
+        opacity: 0.9;
+      }
+
+      .content {
+        height: calc(100% - 92px);
+        overflow-y: auto;
+        padding: 34px 20px 112px;
+        scrollbar-width: none;
+      }
+
+      .content::-webkit-scrollbar {
+        display: none;
+      }
+
+      .header-row {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 16px;
+        margin-bottom: 20px;
+      }
+
+      .title {
+        margin: 0 0 4px;
+        font-size: 30px;
+        line-height: 1;
+        letter-spacing: -0.05em;
+      }
+
+      .subtitle {
+        margin: 0;
+        color: var(--secondary);
+        font-size: 13px;
+      }
+
+      .actions {
+        display: flex;
+        gap: 10px;
+      }
+
+      .icon-button {
+        border: 0;
+        display: grid;
+        place-items: center;
+        width: 36px;
+        height: 36px;
+        border-radius: 13px;
+        background: var(--surface);
+        color: var(--text);
+        cursor: pointer;
+        transition:
+          transform 160ms ease,
+          background 160ms ease,
+          color 160ms ease;
+      }
+
+      .icon-button svg,
+      .nav svg,
+      .glyph svg,
+      .search-input svg {
+        width: 19px;
+        height: 19px;
+        stroke: currentColor;
+        stroke-width: 1.8;
+        fill: none;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+
+      .surface {
+        border-radius: var(--radius-lg);
+        background: var(--surface);
+      }
+
+      .hero {
+        padding: 20px;
+        margin-bottom: 20px;
+      }
+
+      .label {
+        color: var(--secondary);
+        font-size: 12px;
+        font-weight: 600;
+      }
+
+      .hero-value {
+        margin: 8px 0 8px;
+        font-size: 44px;
+        line-height: 0.95;
+        font-weight: 850;
+        letter-spacing: -0.07em;
+      }
+
+      .gain-pill {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        padding: 7px 10px;
+        background: var(--green-soft);
+        color: var(--green);
+        font-size: 13px;
+        font-weight: 800;
+      }
+
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0;
+        margin-top: 18px;
+        border-top: 1px solid var(--separator);
+        padding-top: 16px;
+      }
+
+      .metric {
+        min-width: 0;
+        padding-right: 12px;
+      }
+
+      .metric + .metric {
+        border-left: 1px solid var(--separator);
+        padding-left: 12px;
+      }
+
+      .metric strong {
+        display: block;
+        margin-top: 5px;
+        font-size: 15px;
+        letter-spacing: -0.03em;
+      }
+
+      .section {
+        margin-bottom: 18px;
+      }
+
+      .section-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin: 0 0 10px;
+      }
+
+      .section-label {
+        margin: 18px 2px 8px;
+        color: var(--muted);
+        font-size: 11px;
+        font-weight: 800;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+
+      .section-title {
+        font-size: 17px;
+        font-weight: 800;
+      }
+
+      .section-action {
+        border: 0;
+        padding: 0;
+        background: transparent;
+        color: var(--green);
+        font: inherit;
+        font-size: 12px;
+        font-weight: 700;
+        cursor: pointer;
+      }
+
+      .group {
+        border-radius: var(--radius-md);
+        background: var(--surface);
+        overflow: hidden;
+      }
+
+      .row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        min-height: 58px;
+        padding: 12px 14px;
+      }
+
+      .row + .row {
+        border-top: 1px solid var(--separator);
+      }
+
+      .glyph {
+        display: grid;
+        place-items: center;
+        flex: 0 0 34px;
+        width: 34px;
+        height: 34px;
+        border-radius: 50%;
+        background: var(--elevated);
+      }
+
+      .glyph svg {
+        width: 17px;
+        height: 17px;
+      }
+
+      .equity {
+        color: var(--green);
+      }
+
+      .debt {
+        color: var(--blue);
+      }
+
+      .crypto {
+        color: var(--amber);
+      }
+
+      .cash {
+        color: var(--cash-blue);
+      }
+
+      .row-main {
+        min-width: 0;
+        flex: 1;
+      }
+
+      .row-title {
+        font-size: 14px;
+        font-weight: 800;
+        letter-spacing: -0.03em;
+      }
+
+      .row-meta {
+        margin-top: 3px;
+        color: var(--secondary);
+        font-size: 11px;
+      }
+
+      .row-value {
+        text-align: right;
+        font-size: 14px;
+        font-weight: 850;
+      }
+
+      .row-sub {
+        margin-top: 3px;
+        color: var(--green);
+        font-size: 11px;
+        font-weight: 750;
+      }
+
+      .progress-line {
+        width: 86px;
+        height: 4px;
+        border-radius: 999px;
+        background: var(--elevated);
+        overflow: hidden;
+      }
+
+      .progress-line span {
+        display: block;
+        height: 100%;
+        border-radius: inherit;
+        background: currentColor;
+      }
+
+      .month-card,
+      .insight {
+        padding: 15px;
+      }
+
+      .mini-metrics {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0;
+        margin-top: 14px;
+      }
+
+      .mini-metrics div + div {
+        border-left: 1px solid var(--separator);
+        padding-left: 12px;
+      }
+
+      .mini-metrics strong {
+        display: block;
+        margin-top: 6px;
+        font-size: 15px;
+      }
+
+      .insight {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+      }
+
+      .insight p {
+        margin: 3px 0 0;
+        color: var(--secondary);
+        font-size: 12px;
+      }
+
+      .summary {
+        padding: 14px 16px;
+        margin-bottom: 14px;
+      }
+
+      .summary .metric-grid {
+        margin-top: 0;
+        padding-top: 0;
+        border-top: 0;
+        grid-template-columns: repeat(4, 1fr);
+      }
+
+      .quote-line {
+        margin: 10px 0 12px;
+        color: var(--secondary);
+        font-size: 12px;
+      }
+
+      .chips {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 16px;
+      }
+
+      .chip {
+        border: 0;
+        border-radius: 999px;
+        padding: 8px 13px;
+        background: var(--surface);
+        color: var(--secondary);
+        font: inherit;
+        font-size: 12px;
+        font-weight: 700;
+        cursor: pointer;
+        transition:
+          transform 160ms ease,
+          background 160ms ease,
+          color 160ms ease;
+      }
+
+      .chip.active {
+        background: var(--brand-green);
+        color: var(--text);
+      }
+
+      .holding {
+        min-height: 74px;
+      }
+
+      .holding .row-meta:last-child {
+        display: flex;
+        gap: 9px;
+        white-space: nowrap;
+      }
+
+      .search-card {
+        padding: 16px;
+        margin-bottom: 14px;
+      }
+
+      .search-input {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        height: 46px;
+        padding: 0 14px;
+        border-radius: 16px;
+        background: var(--field);
+        color: var(--secondary);
+        font-size: 14px;
+      }
+
+      .helper {
+        margin: 9px 0 12px;
+        color: var(--muted);
+        font-size: 11px;
+      }
+
+      .result {
+        width: 100%;
+        border: 0;
+        color: inherit;
+        font: inherit;
+        text-align: left;
+        border-radius: 18px;
+        margin-top: 8px;
+        background: transparent;
+        cursor: pointer;
+        transition:
+          transform 160ms ease,
+          background 160ms ease,
+          outline-color 160ms ease;
+      }
+
+      .result.selected {
+        background: rgba(52, 199, 89, 0.1);
+        outline: 1px solid rgba(52, 199, 89, 0.22);
+      }
+
+      .group .result {
+        margin-top: 0;
+        border-radius: 0;
+      }
+
+      .tag {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        padding: 4px 7px;
+        background: var(--green-soft);
+        color: var(--green);
+        font-size: 10px;
+        font-weight: 800;
+      }
+
+      .stepper {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        margin-bottom: 18px;
+      }
+
+      .step {
+        position: relative;
+        flex: 1;
+        text-align: center;
+        color: var(--secondary);
+        font-size: 10px;
+      }
+
+      .step::before {
+        content: "";
+        display: block;
+        width: 28px;
+        height: 28px;
+        margin: 0 auto 7px;
+        border-radius: 50%;
+        background: var(--elevated);
+      }
+
+      .step.active {
+        color: var(--green);
+        font-weight: 800;
+      }
+
+      .step.active::before {
+        background: var(--brand-green);
+      }
+
+      .data-card {
+        padding: 14px;
+        margin-bottom: 14px;
+      }
+
+      .data-row {
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        padding: 10px 0;
+        font-size: 13px;
+      }
+
+      .data-row + .data-row {
+        border-top: 1px solid var(--separator);
+      }
+
+      .data-row span:first-child {
+        color: var(--secondary);
+      }
+
+      .form-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 12px;
+        margin-top: 14px;
+      }
+
+      .form-field {
+        min-height: 58px;
+        border-radius: 16px;
+        padding: 11px 12px;
+        background: var(--field);
+      }
+
+      .form-field.full {
+        grid-column: 1 / -1;
+      }
+
+      .form-field label {
+        display: block;
+        color: var(--secondary);
+        font-size: 11px;
+        font-weight: 650;
+      }
+
+      .form-field strong {
+        display: block;
+        margin-top: 7px;
+        font-size: 14px;
+        letter-spacing: -0.03em;
+      }
+
+      .trend-graph {
+        width: 100%;
+        height: 160px;
+        margin-top: 16px;
+        color: var(--secondary);
+      }
+
+      .trend-grid {
+        stroke: var(--separator);
+        stroke-width: 1;
+      }
+
+      .trend-line {
+        fill: none;
+        stroke-width: 2.4;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+
+      .trend-portfolio {
+        stroke: var(--text);
+        stroke-width: 4;
+      }
+
+      .trend-invested {
+        stroke: var(--muted);
+        stroke-width: 3;
+        stroke-dasharray: 6 7;
+      }
+
+      .trend-equity {
+        stroke: #7c83ff;
+        color: #7c83ff;
+      }
+
+      .trend-debt {
+        stroke: #62c99a;
+        color: #62c99a;
+      }
+
+      .trend-crypto {
+        stroke: var(--amber);
+        color: var(--amber);
+      }
+
+      .legend-portfolio {
+        color: var(--text);
+      }
+
+      .legend-invested {
+        color: var(--muted);
+      }
+
+      .axis-label {
+        fill: var(--secondary);
+        font-size: 10px;
+        font-weight: 750;
+        letter-spacing: -0.03em;
+      }
+
+      .trend-area {
+        fill: url("#portfolioFade");
+        opacity: 0.26;
+      }
+
+      .trend-axis {
+        fill: var(--muted);
+        font-size: 9px;
+        letter-spacing: -0.02em;
+      }
+
+      .trend-point {
+        fill: var(--surface);
+        stroke-width: 2;
+      }
+
+      .trend-legend {
+        display: flex;
+        gap: 12px;
+        margin-top: 10px;
+        color: var(--secondary);
+        font-size: 11px;
+      }
+
+      .trend-legend span {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+      }
+
+      .trend-legend i {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: currentColor;
+      }
+
+      .empty-illustration {
+        display: grid;
+        place-items: center;
+        width: 64px;
+        height: 64px;
+        margin-bottom: 16px;
+        border-radius: 22px;
+        background: var(--elevated);
+        color: var(--green);
+      }
+
+      .empty-illustration svg {
+        width: 28px;
+        height: 28px;
+        stroke: currentColor;
+        stroke-width: 1.8;
+        fill: none;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+
+      .cta-row {
+        position: sticky;
+        bottom: 0;
+        margin-top: 16px;
+        padding: 12px 0 4px;
+        display: grid;
+        gap: 10px;
+        background: linear-gradient(to top, var(--bg) 76%, rgba(0, 0, 0, 0));
+      }
+
+      .primary {
+        height: 48px;
+        border: 0;
+        border-radius: 18px;
+        background: var(--brand-green);
+        color: var(--text);
+        font: inherit;
+        font-weight: 850;
+        cursor: pointer;
+        transition:
+          transform 160ms ease,
+          background 160ms ease;
+      }
+
+      .primary.full-width {
+        width: 100%;
+      }
+
+      .secondary-action {
+        border: 0;
+        background: transparent;
+        color: var(--secondary);
+        font: inherit;
+        font-size: 12px;
+        font-weight: 750;
+        cursor: pointer;
+        transition:
+          transform 160ms ease,
+          color 160ms ease;
+      }
+
+      .nav {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        display: grid;
+        grid-template-columns: repeat(5, 1fr);
+        height: 78px;
+        padding: 8px 14px 10px;
+        background: rgba(28, 28, 30, 0.96);
+        border-top: 1px solid var(--separator);
+      }
+
+      .nav-item {
+        border: 0;
+        background: transparent;
+        position: relative;
+        display: grid;
+        place-items: center;
+        align-content: center;
+        gap: 4px;
+        color: var(--secondary);
+        font: inherit;
+        font-size: 10px;
+        cursor: pointer;
+        transition:
+          transform 160ms ease,
+          color 160ms ease;
+      }
+
+      .nav-item.active {
+        color: var(--green);
+      }
+
+      .nav-item.active::before {
+        content: "";
+        position: absolute;
+        top: -8px;
+        width: 38px;
+        height: 3px;
+        border-radius: 999px;
+        background: var(--green);
+      }
+
+      .positive {
+        color: var(--green);
+      }
+
+      .negative {
+        color: var(--negative);
+      }
+
+      .manual {
+        color: var(--amber);
+      }
+
+      .skeleton-line {
+        height: 12px;
+        margin-top: 14px;
+        border-radius: 999px;
+        background: linear-gradient(90deg, var(--elevated), #3a3a3c, var(--elevated));
+        background-size: 180% 100%;
+        animation: shimmer 1.7s ease-in-out infinite;
+      }
+
+      .skeleton-line.short {
+        width: 58%;
+      }
+
+      .state-action {
+        display: inline-flex;
+        align-items: center;
+        margin-top: 16px;
+        border: 0;
+        border-radius: 999px;
+        padding: 9px 12px;
+        background: var(--brand-green);
+        color: var(--text);
+        font: inherit;
+        font-size: 12px;
+        font-weight: 800;
+        cursor: pointer;
+      }
+
+      :where(.screen-tabs button, .icon-button, .section-action, .chip, .result, .primary, .secondary-action, .nav-item, .state-action):focus-visible {
+        outline: 2px solid var(--cash-blue);
+        outline-offset: 3px;
+      }
+
+      :where(.screen-tabs button, .icon-button, .section-action, .chip, .result, .primary, .secondary-action, .state-action):active {
+        transform: translateY(1px) scale(0.98);
+      }
+
+      .nav-item:active {
+        transform: translateY(1px) scale(0.98);
+      }
+
+      @keyframes shimmer {
+        0% {
+          background-position: 100% 0;
+        }
+
+        100% {
+          background-position: -100% 0;
+        }
+      }
+
+      @media (max-width: 1240px) {
+        .screens {
+          grid-template-columns: 1fr;
+        }
+
+        .screen-tabs {
+          display: flex;
+        }
+
+        .phone-shell {
+          display: none;
+          margin: 0 auto;
+        }
+
+        .phone-shell.active {
+          display: block;
+        }
+
+        .preview-header {
+          display: block;
+        }
+
+        .preview-note {
+          margin-top: 16px;
+        }
+
+      }
+
+      @media (max-width: 460px) {
+        .page {
+          padding: 22px 10px 32px;
+        }
+
+        .phone-shell {
+          width: min(100%, var(--phone-w));
+          padding: 0;
+          border-radius: 0;
+        }
+
+        .phone {
+          border-radius: 0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <header class="preview-header">
+        <div>
+          <p class="eyebrow">CogVest V1 · Issue 86</p>
+          <h1>Premium private-ledger direction</h1>
+        </div>
+        <p class="preview-note">
+          V1 design pass focused on hierarchy, fewer boxes, durable
+          holdings, Add Holding lookup first, cash tracking, monthly progress,
+          local-first settings, and implementation-ready states.
+        </p>
+      </header>
+
+      <nav class="screen-tabs" aria-label="Preview screens">
+        <button class="active" data-target="dashboard">Dashboard</button>
+        <button data-target="holdings">Holdings</button>
+        <button data-target="add">Add Holding</button>
+        <button data-target="progress">Progress</button>
+        <button data-target="cash">Cash</button>
+        <button data-target="settings">Settings</button>
+        <button data-target="states">States</button>
+      </nav>
+
+      <section class="screens">
+        <article class="phone-shell active" data-screen="dashboard">
+          <div class="phone">
+            <div class="status"><span>10:42</span><span class="status-icons"><i class="status-dot"></i><i class="status-dot"></i>100%</span></div>
+            <div class="content">
+              <header class="header-row">
+                <div>
+                  <h2 class="title">Dashboard</h2>
+                  <p class="subtitle">Local portfolio · 9 May 2026</p>
+                </div>
+                <div class="actions">
+                  <button class="icon-button" type="button" aria-label="Mask portfolio values"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg></button>
+                  <button class="icon-button" type="button" aria-label="Refresh quotes"><svg viewBox="0 0 24 24"><path d="M20 7v5h-5M4 17v-5h5"/><path d="M18 12a6 6 0 0 0-10.2-4.2L4 11m16 2-3.8 3.2A6 6 0 0 1 6 12"/></svg></button>
+                </div>
+              </header>
+
+              <section class="surface hero">
+                <div class="label">Portfolio value</div>
+                <div class="hero-value">₹18.42L</div>
+                <span class="gain-pill">+₹3.10L · +20.2%</span>
+                <div class="metric-grid">
+                  <div class="metric"><span class="label">Invested</span><strong>₹15.32L</strong></div>
+                  <div class="metric"><span class="label">P&L</span><strong class="positive">+₹3.10L</strong></div>
+                  <div class="metric"><span class="label">Quotes</span><strong>2m ago</strong></div>
+                </div>
+              </section>
+
+              <section class="section">
+                <div class="section-head"><span class="section-title">Allocation</span><button class="section-action" type="button">View details</button></div>
+                <div class="group">
+                  <div class="row"><span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span><div class="row-main"><div class="row-title">Equity</div><div class="progress-line equity"><span style="width:68%"></span></div></div><div class="row-value">68%<div class="row-meta">₹12.71L</div></div></div>
+                  <div class="row"><span class="glyph debt"><svg viewBox="0 0 24 24"><path d="M12 3 5 6v5c0 4.5 3 7.5 7 9 4-1.5 7-4.5 7-9V6z"/></svg></span><div class="row-main"><div class="row-title">Debt</div><div class="progress-line debt"><span style="width:15%"></span></div></div><div class="row-value">15%<div class="row-meta">₹2.76L</div></div></div>
+                  <div class="row"><span class="glyph crypto"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 7v10M9.2 9h4.1a2 2 0 0 1 0 4H9.2M9.2 13h4.8a2 2 0 0 1 0 4H9.2"/></svg></span><div class="row-main"><div class="row-title">Crypto</div><div class="progress-line crypto"><span style="width:7%"></span></div></div><div class="row-value">7%<div class="row-meta">₹1.29L</div></div></div>
+                  <div class="row"><span class="glyph cash"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg></span><div class="row-main"><div class="row-title">Cash</div><div class="progress-line cash"><span style="width:10%"></span></div></div><div class="row-value">10%<div class="row-meta">₹1.65L</div></div></div>
+                </div>
+              </section>
+
+              <section class="surface month-card">
+                <div class="section-head"><span class="section-title">This month</span><button class="section-action" type="button">May 2026</button></div>
+                <div class="mini-metrics">
+                  <div><span class="label">Invested</span><strong>₹1.20L</strong></div>
+                  <div><span class="label">Savings</span><strong>42%</strong></div>
+                  <div><span class="label">Cash</span><strong class="positive">+₹70K</strong></div>
+                </div>
+              </section>
+
+              <section class="surface insight">
+                <span class="glyph"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span>
+                <div><div class="row-title">Conviction data is still building</div><p>Optional conviction improves context over time.</p></div>
+              </section>
+            </div>
+            <div class="nav">
+              <button class="nav-item active" type="button"><svg viewBox="0 0 24 24"><path d="M3 10.8 12 3l9 7.8V21h-6v-6H9v6H3z"/></svg><span>Dashboard</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M12 3v9h9A9 9 0 1 1 12 3Z"/><path d="M14 3.3A9 9 0 0 1 20.7 10H14z"/></svg><span>Holdings</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M12 3v9l6 3"/><circle cx="12" cy="12" r="9"/></svg><span>Progress</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg><span>Cash</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2M12 20v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M2 12h2M20 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4"/></svg><span>Settings</span></button>
+            </div>
+          </div>
+        </article>
+
+        <article class="phone-shell" data-screen="holdings">
+          <div class="phone">
+            <div class="status"><span>10:42</span><span class="status-icons"><i class="status-dot"></i><i class="status-dot"></i>100%</span></div>
+            <div class="content">
+              <header class="header-row">
+                <div><h2 class="title">Holdings</h2><p class="subtitle">24 positions · local data</p></div>
+                <div class="actions">
+                  <button class="icon-button" type="button" aria-label="Search holdings"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="m16 16 5 5"/></svg></button>
+                  <button class="icon-button" type="button" aria-label="Mask holding values"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg></button>
+                </div>
+              </header>
+
+              <section class="surface summary">
+                <div class="metric-grid">
+                  <div class="metric"><span class="label">Current</span><strong>₹12.48L</strong></div>
+                  <div class="metric"><span class="label">Invested</span><strong>₹11.05L</strong></div>
+                  <div class="metric"><span class="label">P&L</span><strong class="positive">+₹1.42L</strong></div>
+                  <div class="metric"><span class="label">Drift</span><strong style="color:var(--amber)">3.2%</strong></div>
+                </div>
+              </section>
+              <div class="quote-line">Quotes updated 2m ago · 1 manual price</div>
+              <div class="chips" aria-label="Holding filters"><button class="chip active" type="button">All</button><button class="chip" type="button">Equity</button><button class="chip" type="button">Debt</button><button class="chip" type="button">Crypto</button><button class="chip" type="button">Cash</button></div>
+
+              <section class="group">
+                <button class="row holding result" type="button"><span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span><div class="row-main"><div class="row-title">HDFC Bank</div><div class="row-meta">Equity · Financial Services</div><div class="row-meta"><span>Invested ₹1.64L</span><span>14.6%</span><span>Live</span></div></div><div class="row-value">₹1.83L<div class="row-sub">+₹18.6K</div></div></button>
+                <button class="row holding result" type="button"><span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span><div class="row-main"><div class="row-title">Nifty 50 ETF</div><div class="row-meta">Equity · Index Fund</div><div class="row-meta"><span>Invested ₹44.2K</span><span>4.1%</span><span>Live</span></div></div><div class="row-value">₹50.7K<div class="row-sub">+₹6.5K</div></div></button>
+                <button class="row holding result" type="button"><span class="glyph debt"><svg viewBox="0 0 24 24"><path d="M12 3 5 6v5c0 4.5 3 7.5 7 9 4-1.5 7-4.5 7-9V6z"/></svg></span><div class="row-main"><div class="row-title">Sovereign Gold Bond</div><div class="row-meta">Debt · Government Bond</div><div class="row-meta"><span>Invested ₹53.0K</span><span>4.6%</span><span>Manual</span></div></div><div class="row-value">₹57.1K<div class="row-sub">+₹4.1K</div></div></button>
+                <button class="row holding result" type="button"><span class="glyph crypto"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 7v10M9.2 9h4.1a2 2 0 0 1 0 4H9.2M9.2 13h4.8a2 2 0 0 1 0 4H9.2"/></svg></span><div class="row-main"><div class="row-title">Bitcoin</div><div class="row-meta">Crypto · Manual price</div><div class="row-meta"><span>Invested ₹11.05L</span><span>11.1%</span><span>Manual</span></div></div><div class="row-value">₹13.90L<div class="row-sub">+₹2.85L</div></div></button>
+                <button class="row holding result" type="button"><span class="glyph debt"><svg viewBox="0 0 24 24"><path d="M12 3 5 6v5c0 4.5 3 7.5 7 9 4-1.5 7-4.5 7-9V6z"/></svg></span><div class="row-main"><div class="row-title">Liquid Fund</div><div class="row-meta">Debt · Overnight</div><div class="row-meta"><span>Invested ₹2.50L</span><span>2.0%</span><span>Manual</span></div></div><div class="row-value">₹2.50L<div class="row-sub">+₹250</div></div></button>
+              </section>
+            </div>
+            <div class="nav">
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M3 10.8 12 3l9 7.8V21h-6v-6H9v6H3z"/></svg><span>Dashboard</span></button>
+              <button class="nav-item active" type="button"><svg viewBox="0 0 24 24"><path d="M12 3v9h9A9 9 0 1 1 12 3Z"/><path d="M14 3.3A9 9 0 0 1 20.7 10H14z"/></svg><span>Holdings</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M12 3v9l6 3"/><circle cx="12" cy="12" r="9"/></svg><span>Progress</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg><span>Cash</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2M12 20v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M2 12h2M20 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4"/></svg><span>Settings</span></button>
+            </div>
+          </div>
+        </article>
+
+        <article class="phone-shell" data-screen="add">
+          <div class="phone">
+            <div class="status"><span>10:42</span><span class="status-icons"><i class="status-dot"></i><i class="status-dot"></i>100%</span></div>
+            <div class="content">
+              <header class="header-row">
+                <div><h2 class="title">Add Holding</h2><p class="subtitle">Opening position · local only</p></div>
+                <div class="actions"><button class="icon-button" type="button" aria-label="Open Add Holding help"><svg viewBox="0 0 24 24"><path d="M9.5 9a2.8 2.8 0 1 1 4.9 1.8c-.9.8-1.9 1.3-1.9 3.2"/><path d="M12 18h.01"/></svg></button></div>
+              </header>
+
+              <div class="stepper">
+                <div class="step active">Asset</div><div class="step">Class</div><div class="step">Position</div><div class="step">Review</div>
+              </div>
+
+              <section class="surface search-card">
+                <div class="section-title">Find asset</div>
+                <div class="search-input" style="margin-top:12px"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="m16 16 5 5"/></svg>Search name or symbol</div>
+                <p class="helper">Only search text is sent to quote providers.</p>
+                <button class="row result selected" type="button"><span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span><div class="row-main"><div class="row-title">HDFC Bank</div><div class="row-meta">HDFCBANK.NS · NSE · INR · Equity</div></div><div class="row-value">₹1,678.25<div class="tag">Live</div></div></button>
+                <button class="row result" type="button"><span class="glyph crypto"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 7v10M9.2 9h4.1a2 2 0 0 1 0 4H9.2M9.2 13h4.8a2 2 0 0 1 0 4H9.2"/></svg></span><div class="row-main"><div class="row-title">Bitcoin</div><div class="row-meta">bitcoin · CoinGecko · INR</div></div><div class="row-value">₹92.10L<div class="tag">Live</div></div></button>
+              </section>
+
+              <section class="surface data-card">
+                <div class="section-title">Selected asset</div>
+                <div class="data-row"><span>Name</span><strong>HDFC Bank</strong></div>
+                <div class="data-row"><span>Symbol</span><strong>HDFCBANK</strong></div>
+                <div class="data-row"><span>Ticker</span><strong>HDFCBANK.NS</strong></div>
+                <div class="data-row"><span>Currency</span><strong>INR</strong></div>
+              </section>
+
+              <section class="surface data-card">
+                <div class="section-title">Next: Classification</div>
+                <div class="data-row"><span>Suggested</span><strong>Equity · Large Cap</strong></div>
+                <div class="data-row"><span>Sector</span><strong>Financial Services</strong></div>
+              </section>
+
+              <section class="surface data-card">
+                <div class="section-title">Position details</div>
+                <div class="form-grid">
+                  <div class="form-field"><label>Quantity</label><strong>25</strong></div>
+                  <div class="form-field"><label>Average cost</label><strong>₹1,450.00</strong></div>
+                  <div class="form-field"><label>Current price</label><strong>₹1,678.25</strong></div>
+                  <div class="form-field"><label>Price source</label><strong>Live</strong></div>
+                  <div class="form-field full"><label>Date acquired</label><strong>15 Apr 2024</strong></div>
+                </div>
+              </section>
+
+              <section class="surface data-card">
+                <div class="section-title">Derived preview</div>
+                <div class="data-row"><span>Invested</span><strong>₹36,250</strong></div>
+                <div class="data-row"><span>Current</span><strong>₹41,956</strong></div>
+                <div class="data-row"><span>P&L</span><strong class="positive">+₹5,706 · +15.7%</strong></div>
+              </section>
+
+              <section class="surface data-card">
+                <div class="section-title">Review</div>
+                <p class="helper">Conviction and notes stay optional. Save only after derived values look right.</p>
+              </section>
+
+              <div class="cta-row">
+                <button class="primary" type="button">Continue</button>
+                <button class="secondary-action" type="button">Enter manually</button>
+              </div>
+            </div>
+            <div class="nav">
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M3 10.8 12 3l9 7.8V21h-6v-6H9v6H3z"/></svg><span>Dashboard</span></button>
+              <button class="nav-item active" type="button"><svg viewBox="0 0 24 24"><path d="M12 3v9h9A9 9 0 1 1 12 3Z"/><path d="M14 3.3A9 9 0 0 1 20.7 10H14z"/></svg><span>Holdings</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M12 3v9l6 3"/><circle cx="12" cy="12" r="9"/></svg><span>Progress</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg><span>Cash</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2M12 20v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M2 12h2M20 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4"/></svg><span>Settings</span></button>
+            </div>
+          </div>
+        </article>
+
+        <article class="phone-shell" data-screen="progress">
+          <div class="phone">
+            <div class="status"><span>10:42</span><span class="status-icons"><i class="status-dot"></i><i class="status-dot"></i>100%</span></div>
+            <div class="content">
+              <header class="header-row">
+                <div><h2 class="title">Monthly Progress</h2><p class="subtitle">May 2026 snapshot</p></div>
+                <div class="actions"><button class="icon-button" type="button" aria-label="Mask progress values"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg></button></div>
+              </header>
+
+              <div class="chips" aria-label="Month selector"><button class="chip" type="button">Apr 2026</button><button class="chip active" type="button">May 2026</button><button class="chip" type="button">Jun 2026</button></div>
+
+              <section class="surface summary">
+                <div class="metric-grid">
+                  <div class="metric"><span class="label">Portfolio</span><strong>₹19.87L</strong></div>
+                  <div class="metric"><span class="label">Invested</span><strong>₹1.40L</strong></div>
+                  <div class="metric"><span class="label">Cash</span><strong>₹3.25L</strong></div>
+                  <div class="metric"><span class="label">Savings</span><strong>34%</strong></div>
+                </div>
+              </section>
+
+              <section class="surface data-card">
+                <div class="section-title">Portfolio vs invested</div>
+                <svg class="trend-graph" viewBox="0 0 320 160" role="img" aria-label="Portfolio value versus invested value by month">
+                  <defs>
+                    <linearGradient id="portfolioFade" x1="0" x2="0" y1="0" y2="1">
+                      <stop offset="0%" stop-color="#f5f5f7"/>
+                      <stop offset="100%" stop-color="#f5f5f7" stop-opacity="0"/>
+                    </linearGradient>
+                  </defs>
+                  <path class="trend-grid" d="M32 24H306M32 58H306M32 92H306M32 126H306"/>
+                  <path class="trend-area" d="M34 104 C60 96 78 108 100 82 C122 58 144 72 166 64 C190 56 208 88 230 38 C252 10 274 64 306 26 L306 132 L34 132Z"/>
+                  <path class="trend-line trend-portfolio" d="M34 104 C60 96 78 108 100 82 C122 58 144 72 166 64 C190 56 208 88 230 38 C252 10 274 64 306 26"/>
+                  <path class="trend-line trend-invested" d="M34 118 C72 116 92 112 120 108 C152 104 180 100 210 94 C246 88 276 82 306 76"/>
+                  <circle class="trend-point trend-portfolio" cx="100" cy="82" r="3.5"/>
+                  <circle class="trend-point trend-portfolio" cx="230" cy="38" r="3.5"/>
+                  <circle class="trend-point trend-portfolio" cx="306" cy="26" r="3.5"/>
+                  <circle class="trend-point trend-invested" cx="306" cy="76" r="3"/>
+                  <text class="trend-axis" x="4" y="28">20L</text>
+                  <text class="trend-axis" x="5" y="95">10L</text>
+                  <text class="trend-axis" x="13" y="130">0</text>
+                  <text class="trend-axis" x="34" y="152">Dec</text>
+                  <text class="trend-axis" x="138" y="152">Mar</text>
+                  <text class="trend-axis" x="282" y="152">May</text>
+                </svg>
+                <div class="trend-legend" aria-label="Portfolio trend legend"><span class="legend-portfolio"><i></i>Total value</span><span class="legend-invested"><i></i>Invested</span></div>
+                <p class="helper">X-axis shows months. Y-axis shows amount in INR.</p>
+              </section>
+
+              <section class="surface data-card">
+                <div class="section-title">Assets vs months</div>
+                <svg class="trend-graph" viewBox="0 0 320 160" role="img" aria-label="Asset value trends by month excluding cash">
+                  <path class="trend-grid" d="M32 24H306M32 58H306M32 92H306M32 126H306"/>
+                  <path class="trend-line trend-equity" d="M34 98 C58 90 78 106 100 78 C124 52 144 68 166 60 C190 52 210 84 230 38 C252 18 276 58 306 36"/>
+                  <path class="trend-line trend-debt" d="M34 126 C60 122 78 124 100 116 C128 108 150 112 176 102 C206 92 236 98 262 86 C282 78 294 84 306 76"/>
+                  <path class="trend-line trend-crypto" d="M34 138 C58 132 78 144 102 122 C124 102 140 134 164 112 C188 86 206 126 230 108 C258 78 282 118 306 96"/>
+                  <circle class="trend-point trend-equity" cx="306" cy="36" r="3.5"/>
+                  <circle class="trend-point trend-debt" cx="306" cy="76" r="3.5"/>
+                  <circle class="trend-point trend-crypto" cx="306" cy="96" r="3.5"/>
+                  <text class="axis-label trend-equity" x="250" y="32">₹12.45L</text>
+                  <text class="axis-label trend-debt" x="254" y="72">₹3.22L</text>
+                  <text class="axis-label trend-crypto" x="254" y="92">₹1.20L</text>
+                  <text class="trend-axis" x="4" y="28">15L</text>
+                  <text class="trend-axis" x="5" y="95">7.5L</text>
+                  <text class="trend-axis" x="13" y="130">0</text>
+                  <text class="trend-axis" x="34" y="152">Dec</text>
+                  <text class="trend-axis" x="138" y="152">Mar</text>
+                  <text class="trend-axis" x="282" y="152">May</text>
+                </svg>
+                <div class="trend-legend" aria-label="Asset trend legend"><span class="trend-equity"><i></i>Equity</span><span class="trend-debt"><i></i>Debt</span><span class="trend-crypto"><i></i>Crypto</span></div>
+                <p class="helper">Cash is excluded from this asset graph and tracked separately in Cash Ledger.</p>
+              </section>
+
+              <section class="section">
+                <div class="section-head"><span class="section-title">What changed?</span><button class="section-action" type="button">Details</button></div>
+                <div class="group">
+                  <div class="row"><span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span><div class="row-main"><div class="row-title">Equity</div><div class="row-meta">Market value and contributions</div></div><div class="row-value">+₹58K</div></div>
+                  <div class="row"><span class="glyph debt"><svg viewBox="0 0 24 24"><path d="M12 3 5 6v5c0 4.5 3 7.5 7 9 4-1.5 7-4.5 7-9V6z"/></svg></span><div class="row-main"><div class="row-title">Debt</div><div class="row-meta">Stable allocation</div></div><div class="row-value">+₹12K</div></div>
+                  <div class="row"><span class="glyph crypto"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 7v10M9.2 9h4.1a2 2 0 0 1 0 4H9.2M9.2 13h4.8a2 2 0 0 1 0 4H9.2"/></svg></span><div class="row-main"><div class="row-title">Crypto</div><div class="row-meta">Manual price movement</div></div><div class="row-value negative">-₹8.5K</div></div>
+                  <div class="row"><span class="glyph cash"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg></span><div class="row-main"><div class="row-title">Cash</div><div class="row-meta">Net cash change</div></div><div class="row-value">+₹70K</div></div>
+                </div>
+              </section>
+
+              <section class="surface data-card">
+                <div class="section-title">Closing snapshot</div>
+                <div class="data-row"><span>Equity</span><strong>₹12.45L · 62.6%</strong></div>
+                <div class="data-row"><span>Debt</span><strong>₹3.22L · 16.2%</strong></div>
+                <div class="data-row"><span>Crypto</span><strong>₹1.20L · 6.0%</strong></div>
+                <div class="data-row"><span>Cash</span><strong>₹3.25L · 16.3%</strong></div>
+              </section>
+            </div>
+            <div class="nav">
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M3 10.8 12 3l9 7.8V21h-6v-6H9v6H3z"/></svg><span>Dashboard</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M12 3v9h9A9 9 0 1 1 12 3Z"/><path d="M14 3.3A9 9 0 0 1 20.7 10H14z"/></svg><span>Holdings</span></button>
+              <button class="nav-item active" type="button"><svg viewBox="0 0 24 24"><path d="M12 3v9l6 3"/><circle cx="12" cy="12" r="9"/></svg><span>Progress</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg><span>Cash</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2M12 20v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M2 12h2M20 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4"/></svg><span>Settings</span></button>
+            </div>
+          </div>
+        </article>
+
+        <article class="phone-shell" data-screen="cash">
+          <div class="phone">
+            <div class="status"><span>10:42</span><span class="status-icons"><i class="status-dot"></i><i class="status-dot"></i>100%</span></div>
+            <div class="content">
+              <header class="header-row">
+                <div><h2 class="title">Cash Ledger</h2><p class="subtitle">Manual ledger · local only</p></div>
+                <div class="actions"><button class="icon-button" type="button" aria-label="Add cash entry"><svg viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg></button><button class="icon-button" type="button" aria-label="Mask cash values"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg></button></div>
+              </header>
+
+              <section class="surface hero">
+                <div class="label">Cash balance</div>
+                <div class="hero-value">₹1,65,600</div>
+                <span class="gain-pill">Available · ₹1.20L</span>
+                <div class="metric-grid">
+                  <div class="metric"><span class="label">Added</span><strong>₹70K</strong></div>
+                  <div class="metric"><span class="label">Invested</span><strong>₹45K</strong></div>
+                  <div class="metric"><span class="label">Savings</span><strong>32.8%</strong></div>
+                </div>
+              </section>
+
+              <section class="surface search-card">
+                <div class="section-title">Add cash entry</div>
+                <div class="chips" aria-label="Cash entry type"><button class="chip active" type="button">Deposit</button><button class="chip" type="button">Withdraw</button><button class="chip" type="button">Transfer</button></div>
+                <div class="form-grid">
+                  <div class="form-field"><label>Amount (INR)</label><strong>₹0</strong></div>
+                  <div class="form-field"><label>Date</label><strong>09 May 2026</strong></div>
+                  <div class="form-field full"><label>Note</label><strong>Salary, SIP transfer, emergency fund</strong></div>
+                </div>
+                <button class="primary full-width" type="button">Save entry</button>
+              </section>
+
+              <section class="section">
+                <div class="section-head"><span class="section-title">Recent cash ledger</span><button class="section-action" type="button">View all</button></div>
+                <div class="group">
+                  <div class="row"><span class="glyph cash"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg></span><div class="row-main"><div class="row-title">Salary added</div><div class="row-meta">Cash deposit</div></div><div class="row-value positive">+₹70K</div></div>
+                  <div class="row"><span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span><div class="row-main"><div class="row-title">SIP transfer</div><div class="row-meta">Index Fund</div></div><div class="row-value">-₹15K</div></div>
+                  <div class="row"><span class="glyph cash"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg></span><div class="row-main"><div class="row-title">Emergency fund top-up</div><div class="row-meta">Cash reserve</div></div><div class="row-value positive">+₹10K</div></div>
+                </div>
+              </section>
+            </div>
+            <div class="nav">
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M3 10.8 12 3l9 7.8V21h-6v-6H9v6H3z"/></svg><span>Dashboard</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M12 3v9h9A9 9 0 1 1 12 3Z"/><path d="M14 3.3A9 9 0 0 1 20.7 10H14z"/></svg><span>Holdings</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M12 3v9l6 3"/><circle cx="12" cy="12" r="9"/></svg><span>Progress</span></button>
+              <button class="nav-item active" type="button"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg><span>Cash</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2M12 20v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M2 12h2M20 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4"/></svg><span>Settings</span></button>
+            </div>
+          </div>
+        </article>
+
+        <article class="phone-shell" data-screen="settings">
+          <div class="phone">
+            <div class="status"><span>10:42</span><span class="status-icons"><i class="status-dot"></i><i class="status-dot"></i>100%</span></div>
+            <div class="content">
+              <header class="header-row">
+                <div><h2 class="title">Settings</h2><p class="subtitle">Local-first controls</p></div>
+                <div class="actions"><button class="icon-button" type="button" aria-label="About CogVest"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 11v5M12 8h.01"/></svg></button></div>
+              </header>
+
+              <div class="section-label">Privacy</div>
+              <section class="group">
+                <div class="row"><span class="glyph debt"><svg viewBox="0 0 24 24"><path d="M12 3 5 6v5c0 4.5 3 7.5 7 9 4-1.5 7-4.5 7-9V6z"/><path d="M9.5 12.5 11 14l3.5-4"/></svg></span><div class="row-main"><div class="row-title">Privacy</div><div class="row-meta">Local storage active · No account · No cloud</div></div><div class="row-value positive">On</div></div>
+                <div class="row"><span class="glyph"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg></span><div class="row-main"><div class="row-title">Value masking</div><div class="row-meta">Hide sensitive values on screen</div></div><div class="row-value">Ready</div></div>
+              </section>
+
+              <div class="section-label">Quotes</div>
+              <section class="group">
+                <div class="row"><span class="glyph cash"><svg viewBox="0 0 24 24"><path d="M20 7v5h-5M4 17v-5h5"/><path d="M18 12a6 6 0 0 0-10.2-4.2L4 11m16 2-3.8 3.2A6 6 0 0 1 6 12"/></svg></span><div class="row-main"><div class="row-title">Quotes</div><div class="row-meta">Every 15 min · Manual fallback on</div></div><div class="row-value positive">OK</div></div>
+              </section>
+
+              <div class="section-label">Currency</div>
+              <section class="surface data-card">
+                <div class="section-title">Currency</div>
+                <div class="data-row"><span>Base currency</span><strong>INR</strong></div>
+                <div class="data-row"><span>Foreign summary</span><strong>On</strong></div>
+                <div class="data-row"><span>USD and crypto fallback</span><strong>On</strong></div>
+              </section>
+
+              <div class="section-label">Display</div>
+              <section class="surface data-card">
+                <div class="section-title">Display and app info</div>
+                <div class="data-row"><span>Density</span><strong>Standard V1</strong></div>
+                <div class="data-row"><span>Minimal Mode</span><strong>V2 locked</strong></div>
+                <div class="data-row"><span>App version</span><strong>1.0.0 preview</strong></div>
+              </section>
+
+              <div class="section-label">Data</div>
+              <section class="surface data-card">
+                <div class="section-title negative">Data</div>
+                <div class="data-row"><span>Clear local data</span><strong class="negative">Destructive</strong></div>
+              </section>
+            </div>
+            <div class="nav">
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M3 10.8 12 3l9 7.8V21h-6v-6H9v6H3z"/></svg><span>Dashboard</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M12 3v9h9A9 9 0 1 1 12 3Z"/><path d="M14 3.3A9 9 0 0 1 20.7 10H14z"/></svg><span>Holdings</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M12 3v9l6 3"/><circle cx="12" cy="12" r="9"/></svg><span>Progress</span></button>
+              <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg><span>Cash</span></button>
+              <button class="nav-item active" type="button"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2M12 20v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M2 12h2M20 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4"/></svg><span>Settings</span></button>
+            </div>
+          </div>
+        </article>
+
+        <article class="phone-shell" data-screen="states">
+          <div class="phone">
+            <div class="status"><span>10:42</span><span class="status-icons"><i class="status-dot"></i><i class="status-dot"></i>100%</span></div>
+            <div class="content">
+              <header class="header-row">
+                <div><h2 class="title">V1 States</h2><p class="subtitle">Implementation coverage</p></div>
+              </header>
+
+              <section class="surface data-card">
+                <div class="empty-illustration"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></div>
+                <div class="section-title">Empty portfolio</div>
+                <p class="helper">No holdings yet. Start with one opening position; no spreadsheet required.</p>
+                <button class="primary full-width" type="button">Add first holding</button>
+              </section>
+
+              <section class="surface data-card">
+                <div class="section-title">Quote lookup loading</div>
+                <div class="skeleton-line"></div>
+                <div class="skeleton-line short"></div>
+                <p class="helper">Skeletons match the result row shape. Avoid spinners for ordinary lookup latency.</p>
+              </section>
+
+              <section class="surface data-card">
+                <div class="section-title negative">Provider unavailable</div>
+                <p class="helper">Could not fetch a live quote. Continue manually and CogVest will mark the price source.</p>
+                <button class="secondary-action" type="button">Enter price manually</button>
+              </section>
+
+              <section class="surface data-card">
+                <div class="section-title">No monthly snapshots</div>
+                <p class="helper">Monthly Progress becomes useful after the first saved snapshot. Until then, keep the chart area calm.</p>
+              </section>
+            </div>
+          </div>
+        </article>
+      </section>
+
+    </main>
+
+    <script>
+      const buttons = document.querySelectorAll(".screen-tabs button");
+      const screens = document.querySelectorAll(".phone-shell");
+
+      buttons.forEach((button) => {
+        button.addEventListener("click", () => {
+          buttons.forEach((item) => item.classList.toggle("active", item === button));
+          screens.forEach((screen) => {
+            screen.classList.toggle("active", screen.dataset.screen === button.dataset.target);
+          });
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/docs/superpowers/plans/2026-05-09-issue-86-premium-design-preview-plan.md
+++ b/docs/superpowers/plans/2026-05-09-issue-86-premium-design-preview-plan.md
@@ -1,0 +1,74 @@
+# Issue 86 Premium Design Preview Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a static browser preview for the premium CogVest V1 screens.
+
+**Architecture:** A single static HTML document with embedded CSS and lightweight JavaScript tab switching. This keeps the preview independent from Expo app code while making the design easy to inspect in a browser.
+
+**Tech Stack:** HTML, CSS, JavaScript, local static server.
+
+---
+
+### Task 1: Static Preview Artifact
+
+**Files:**
+- Create: `docs/design/issue-86-premium-preview/index.html`
+- Create: `docs/design/issue-86-premium-preview/README.md`
+
+- [x] Create a focused static mockup folder.
+- [x] Implement Dashboard, Holdings, and Add Holding as phone frames.
+- [x] Align the bottom Add button consistently across screens.
+- [x] Add README instructions for local preview.
+
+### Task 2: Local Preview Verification
+
+**Files:**
+- Read: `docs/design/issue-86-premium-preview/index.html`
+
+- [x] Start a local static server from the preview folder.
+- [x] Verify the server responds with the HTML page.
+- [x] Share the local URL for browser review.
+
+### Task 3: Taste Review Fixes
+
+**Files:**
+- Modify: `docs/design/issue-86-premium-preview/index.html`
+- Modify: `docs/superpowers/specs/2026-05-09-issue-86-premium-design-preview.md`
+
+- [x] Add explicit empty, loading/error, and manual fallback state coverage.
+- [x] Replace static action-like spans/divs with semantic buttons.
+- [x] Replace inconsistent text glyph icons with inline SVG primitives.
+- [x] Add keyboard focus and tactile press states.
+- [x] Change Add Holding CTA from absolute positioning to a sticky footer pattern.
+
+### Task 4: Remaining V1 Screens
+
+**Files:**
+- Modify: `docs/design/issue-86-premium-preview/index.html`
+- Modify: `docs/design/issue-86-premium-preview/README.md`
+- Modify: `docs/superpowers/specs/2026-05-09-issue-86-premium-design-preview.md`
+
+- [x] Add Monthly Progress screen with monthly metrics, change summary, trend placeholder, and asset snapshot.
+- [x] Add Cash Ledger screen with cash balance, cash entry, and recent ledger rows.
+- [x] Add Settings screen with privacy, value masking, quotes, currency, display, and destructive data sections.
+- [x] Expand preview tabs from three screens to the full V1 preview set.
+
+### Task 5: Design Review Fixes
+
+**Files:**
+- Modify: `docs/design/issue-86-premium-preview/index.html`
+- Modify: `docs/design/issue-86-premium-preview/README.md`
+- Modify: `docs/superpowers/specs/2026-05-09-issue-86-premium-design-preview.md`
+
+- [x] Replace bottom Add tab with Progress across all phone nav bars.
+- [x] Keep Add Holding as a secondary Holdings flow.
+- [x] Expand Add Holding with position details, derived preview, and review handoff.
+- [x] Convert Cash entry from static rows to form-like field blocks.
+- [x] Replace Monthly Progress placeholder line with a simple mini-trend treatment.
+- [x] Replace Settings finance/category icons with trust-oriented icons.
+- [x] Add a phone-frame V1 States screen for empty, loading, error, and no-snapshot states.
+- [x] Change Monthly Progress from a bar-style trend to two line graphs: total portfolio value vs invested value, and asset values vs months.
+- [x] Remove duplicate external state cards now that V1 States exists as a phone frame.
+- [x] Move Monthly Progress graphs above the "What changed" breakdown.
+- [x] Add Settings group labels for privacy, quotes, currency, display, and data.

--- a/docs/superpowers/specs/2026-05-09-issue-86-premium-design-preview.md
+++ b/docs/superpowers/specs/2026-05-09-issue-86-premium-design-preview.md
@@ -1,0 +1,65 @@
+# Issue 86 Premium Design Preview Spec
+
+## Goal
+
+Create a browser-viewable static mockup for the CogVest V1 premium design
+screens: Dashboard, Holdings, Add Holding, Monthly Progress, Cash, Settings,
+and V1 state coverage.
+
+## Scope
+
+- Create a design-only HTML/CSS/JS preview under `docs/design/issue-86-premium-preview/`.
+- Do not modify React Native app code.
+- Use the approved design direction from issue #86:
+  - premium dark private-ledger UI
+  - fewer bordered boxes
+  - stronger financial hierarchy
+  - Holdings as grouped durable-position rows
+  - Add Holding lookup/autofill as the primary path
+- Standardize the bottom Add button alignment to match the better-aligned
+- Use the V1 tab model: Dashboard, Holdings, Progress, Cash, Settings.
+- Keep Add Holding as a secondary Holdings flow, not a bottom-tab destination.
+
+## Screens
+
+1. Dashboard
+2. Holdings
+3. Add Holding
+4. Monthly Progress
+5. Cash Ledger
+6. Settings
+7. V1 States
+
+## Design Rules
+
+- True black background remains intentional for CogVest.
+- Cards are borderless by default.
+- Hairline separators appear only inside grouped content.
+- Green is reserved for active tab, primary action, positive P&L, and selected
+  state.
+- No purple, neon, trading-terminal visuals, LTCG UI, or Minimal Mode.
+- Use realistic V1 sample values only for mockup communication.
+
+## Acceptance
+
+- The preview can be opened from a local static server.
+- All six screens render in a desktop grid and stack/toggle on narrow widths.
+- Bottom navigation Add button is consistently centered/aligned across screens.
+- Holdings no longer looks like a table.
+- Add Holding presents search/autofill first and manual entry as fallback.
+- Preview includes explicit state coverage notes for empty portfolio, quote
+  lookup loading/error, and manual price fallback.
+- Static controls use semantic button markup where they represent tappable
+  app actions, so the preview remains a safer implementation reference.
+- Bottom navigation follows the V1 app model: Dashboard, Holdings, Progress,
+  Cash, Settings.
+- Add Holding includes lookup, classification, position details, derived
+  preview, and review handoff.
+- Cash entry uses form-like field blocks, not static ledger rows.
+- Monthly Progress uses two graph-style treatments: total portfolio value vs
+  invested value by month, then asset values vs months for equity, debt, and
+  crypto. Cash remains tracked separately.
+- State coverage is shown only inside the V1 States phone frame.
+- Monthly Progress prioritizes graph review before the change breakdown.
+- Settings uses grouped section labels for privacy, quotes, currency, display,
+  and data controls.


### PR DESCRIPTION
## Summary

- Adds the Issue 86 premium V1 browser preview for Dashboard, Holdings, Add Holding, Monthly Progress, Cash Ledger, Settings, and V1 States.
- Updates the Figma development plugin to generate editable Issue 86 premium V1 screens on a fresh versioned page.
- Adds the missing Add Holding entry point on the populated Holdings screen while keeping Add Holding out of the bottom-tab model.

## Verification

- `node --check docs/design/figma/issue-69-v1-screens/code.js`
- Reviewed design-source markers for Issue 86 page generation, Holdings add action, V1 States, and the two Monthly Progress graph sections.

Closes #86
