### PR TITLE
Add opening position entry

### DIFF
--- a/app/add-holding.tsx
+++ b/app/add-holding.tsx
@@ -1,5 +1,5 @@
-import { AddTradeForm } from "@/src/features/trades";
+import { AddOpeningPositionForm } from "@/src/features/openingPositions";
 
 export default function AddHoldingScreen() {
-  return <AddTradeForm />;
+  return <AddOpeningPositionForm />;
 }

--- a/docs/superpowers/plans/2026-05-09-issue-61-opening-positions.md
+++ b/docs/superpowers/plans/2026-05-09-issue-61-opening-positions.md
@@ -1,0 +1,77 @@
+# Issue 61 Opening Positions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build V1 opening-position entry so Excel tracker holdings can be entered directly and derived across CogVest.
+
+**Architecture:** Add a raw `OpeningPosition` model to the store, migrate persisted snapshots to include it, and extend domain holding calculations to merge opening positions with trades. Add a dedicated Add Holding form for opening positions while preserving the existing Add Trade form.
+
+**Tech Stack:** Expo Router, React Native, TypeScript, Zustand vanilla store, Jest, React Native Testing Library.
+
+---
+
+### Task 1: Raw Model And Store
+
+**Files:**
+- Create: `src/types/openingPosition.ts`
+- Modify: `src/types/index.ts`
+- Modify: `src/store/index.ts`
+- Modify: `src/store/selectors.ts`
+- Test: `src/store/__tests__/portfolioStore.test.ts`
+
+- [ ] Add `OpeningPosition` with quantity, average cost, optional current price, date, optional conviction, and notes.
+- [ ] Add `openingPositions` to `RawPortfolioSnapshot` and store actions.
+- [ ] Migrate schema v1 snapshots by defaulting `openingPositions` to an empty array.
+- [ ] Persist opening positions as raw data only.
+- [ ] Add tests for add/update/remove, persistence, and rehydration.
+
+### Task 2: Domain Derivation
+
+**Files:**
+- Modify: `src/domain/calculations/holdings.ts`
+- Test: `src/domain/calculations/__tests__/holdings.test.ts`
+
+- [ ] Extend `calculateHolding` and `calculateHoldings` to accept opening positions.
+- [ ] Treat opening positions as cost-basis events before trade events.
+- [ ] Use quote cache first, then manual opening-position current price.
+- [ ] Add tests for opening-only holdings, opening-plus-sell holdings, and allocation/dashboard-compatible output.
+
+### Task 3: Add Holding Flow
+
+**Files:**
+- Create: `src/features/openingPositions/openingPositionForm.ts`
+- Create: `src/features/openingPositions/AddOpeningPositionForm.tsx`
+- Create: `src/features/openingPositions/index.ts`
+- Modify: `app/add-holding.tsx`
+- Test: `src/features/openingPositions/__tests__/openingPositionForm.test.ts`
+- Test: `src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx`
+
+- [ ] Validate asset identity, asset class, quantity, average cost, current price, and acquisition date.
+- [ ] Render a focused Add Holding form with derived preview and optional conviction.
+- [ ] Save a new asset, opening position, and manual quote cache entry.
+- [ ] Keep `app/(tabs)/add-trade.tsx` using `AddTradeForm`.
+- [ ] Add component tests for saving a RELIANCE-style opening position.
+
+### Task 4: Dashboard And Holdings Wiring
+
+**Files:**
+- Modify: `src/features/holdings/useHoldings.ts`
+- Modify: `src/features/dashboard/useDashboard.ts`
+- Test: existing hook tests if needed
+
+- [ ] Pass `snapshot.openingPositions` into `calculateHoldings`.
+- [ ] Ensure quote refresh manual prices include current cached prices.
+- [ ] Update hook tests only if existing assertions require the new raw field.
+
+### Task 5: Verification And Delivery
+
+**Commands:**
+- `npm run typecheck`
+- `npm test`
+- `npm run doctor`
+
+- [ ] Run verification commands and record results.
+- [ ] Review changes against issue #61 acceptance.
+- [ ] Commit with a focused message.
+- [ ] Push branch and open PR with `Closes #61`.
+

--- a/docs/superpowers/specs/2026-05-09-issue-61-opening-positions.md
+++ b/docs/superpowers/specs/2026-05-09-issue-61-opening-positions.md
@@ -1,0 +1,26 @@
+# Issue 61 Opening Positions Design
+
+## Goal
+Add a V1 Add Holding path that lets the user enter existing portfolio positions from the Excel tracker without reconstructing historical trades.
+
+## Product Boundary
+CogVest should persist an opening position record and derive holdings, dashboard totals, allocation, and P&L from domain functions. This must not turn into an editable spreadsheet grid, and it must not remove or rewrite the existing Add Trade flow.
+
+## Data Model
+Create a raw `OpeningPosition` record with asset id, quantity, average cost, optional manual current price, acquisition/start date, optional conviction, and notes. Store opening positions alongside assets, trades, cash entries, and preferences in the raw portfolio snapshot.
+
+Opening positions are raw input data. Derived values such as invested value, current value, P&L, P&L %, and allocation stay out of persistence.
+
+## Domain Derivation
+`calculateHolding` treats opening positions as initial buy-like cost basis events. Later buy/sell trades continue to adjust units and weighted average cost as they do today. `calculateHoldings` includes assets that have either opening positions or trades.
+
+Quote priority is live/manual quote cache first, then opening-position manual current price, then zero. This keeps live quote refresh authoritative while still supporting offline/manual Excel parity.
+
+## UI Flow
+`app/add-holding.tsx` becomes the opening-position flow. The existing tab trade form remains unchanged for normal buy/sell trades.
+
+The Add Holding screen captures asset identity, asset class, quantity, average cost, current/manual price, acquisition date, optional conviction, and notes. It shows a derived preview before saving and then stores the asset, opening position, and manual quote cache entry.
+
+## Testing
+Add tests for domain derivation, raw persistence/rehydration, form validation, and the Add Holding save flow. Existing trade tests must continue to pass.
+

--- a/src/components/common/Premium.tsx
+++ b/src/components/common/Premium.tsx
@@ -55,7 +55,8 @@ const assetClassConfig: Record<
 > = {
   cash: { color: colors.cashBlue, icon: "wallet-outline", label: "Cash" },
   crypto: { color: colors.cryptoAmber, icon: "logo-bitcoin", label: "Crypto" },
-  etf: { color: colors.blue, icon: "shield-outline", label: "Debt" },
+  debt: { color: colors.blue, icon: "shield-outline", label: "Debt" },
+  etf: { color: colors.blue, icon: "pie-chart-outline", label: "ETF" },
   neutral: { color: colors.text.secondary, icon: "analytics-outline", label: "Info" },
   stock: { color: colors.primary, icon: "trending-up-outline", label: "Equity" },
 };

--- a/src/domain/calculations/__tests__/holdings.test.ts
+++ b/src/domain/calculations/__tests__/holdings.test.ts
@@ -8,7 +8,7 @@ import {
   daysHeld,
   getConvictionReadiness,
 } from "@/src/domain/calculations";
-import type { Asset, CashEntry, Quote, Trade } from "@/src/types";
+import type { Asset, CashEntry, OpeningPosition, Quote, Trade } from "@/src/types";
 
 const reliance: Asset = {
   assetClass: "stock",
@@ -37,6 +37,20 @@ function trade(overrides: Partial<Trade>): Trade {
     quantity: 1,
     totalValue: 100,
     type: "buy",
+    ...overrides,
+  };
+}
+
+function openingPosition(
+  overrides: Partial<OpeningPosition>,
+): OpeningPosition {
+  return {
+    assetId: reliance.id,
+    averageCostPrice: 1400,
+    currentPrice: 1678.25,
+    date: "2026-04-15T00:00:00.000Z",
+    id: `opening-${Math.random()}`,
+    quantity: 25,
     ...overrides,
   };
 }
@@ -122,6 +136,76 @@ describe("holding calculations", () => {
     expect(holdings).toHaveLength(1);
     expect(holdings[0]?.asset).toEqual(reliance);
     expect(holdings[0]?.currentPrice).toBe(125);
+  });
+
+  it("derives an Excel-style opening position without historical trades", () => {
+    const holding = calculateHolding({
+      asset: reliance,
+      currentPrice: 1678.25,
+      openingPositions: [openingPosition({})],
+      trades: [],
+    });
+
+    expect(holding.totalUnits).toBe(25);
+    expect(holding.averageCostPrice).toBe(1400);
+    expect(holding.totalInvested).toBe(35000);
+    expect(holding.currentValue).toBe(41956.25);
+    expect(holding.unrealisedPnL).toBe(6956.25);
+    expect(holding.unrealisedPnLPct).toBeCloseTo(19.875, 3);
+  });
+
+  it("uses opening-position manual price when quote cache is empty", () => {
+    const holdings = calculateHoldings({
+      assets: [reliance],
+      openingPositions: [openingPosition({ currentPrice: 1600 })],
+      quoteCache: {},
+      trades: [],
+    });
+
+    expect(holdings).toHaveLength(1);
+    expect(holdings[0]?.currentPrice).toBe(1600);
+    expect(holdings[0]?.currentValue).toBe(40000);
+  });
+
+  it("lets quote cache override opening-position manual price", () => {
+    const holdings = calculateHoldings({
+      assets: [reliance],
+      openingPositions: [openingPosition({ currentPrice: 1600 })],
+      quoteCache: {
+        [reliance.id]: {
+          assetId: reliance.id,
+          asOf: "2026-05-09T00:00:00.000Z",
+          currency: "INR",
+          price: 1700,
+          source: "yahoo",
+        },
+      },
+      trades: [],
+    });
+
+    expect(holdings[0]?.currentPrice).toBe(1700);
+  });
+
+  it("keeps opening-position cost basis stable after a later sell", () => {
+    const holding = calculateHolding({
+      asset: reliance,
+      currentPrice: 1500,
+      openingPositions: [openingPosition({ averageCostPrice: 1000, quantity: 10 })],
+      trades: [
+        trade({
+          date: "2026-04-20T00:00:00.000Z",
+          pricePerUnit: 1500,
+          quantity: 4,
+          totalValue: 6000,
+          type: "sell",
+        }),
+      ],
+    });
+
+    expect(holding.totalUnits).toBe(6);
+    expect(holding.averageCostPrice).toBe(1000);
+    expect(holding.totalInvested).toBe(6000);
+    expect(holding.currentValue).toBe(9000);
   });
 });
 
@@ -229,6 +313,22 @@ describe("date and conviction calculations", () => {
       lowConvictionCount: 1,
       ratedTradeCount: 2,
       requiredTradeCount: 5,
+    });
+  });
+
+  it("includes opening-position conviction in readiness", () => {
+    expect(
+      getConvictionReadiness(
+        [trade({ conviction: 2 })],
+        2,
+        [openingPosition({ conviction: 5 })],
+      ),
+    ).toEqual({
+      highConvictionCount: 1,
+      isReady: true,
+      lowConvictionCount: 1,
+      ratedTradeCount: 2,
+      requiredTradeCount: 2,
     });
   });
 });

--- a/src/domain/calculations/holdings.ts
+++ b/src/domain/calculations/holdings.ts
@@ -3,6 +3,7 @@ import type {
   AssetClass,
   CashEntry,
   Holding,
+  OpeningPosition,
   QuoteCache,
   Trade,
 } from "@/src/types";
@@ -10,11 +11,13 @@ import type {
 type CalculateHoldingInput = {
   asset: Asset;
   currentPrice: number;
+  openingPositions?: OpeningPosition[];
   trades: Trade[];
 };
 
 type CalculateHoldingsInput = {
   assets: Asset[];
+  openingPositions?: OpeningPosition[];
   quoteCache: QuoteCache;
   trades: Trade[];
 };
@@ -56,23 +59,43 @@ function sortTradesByDate(trades: Trade[]) {
 export function calculateHolding({
   asset,
   currentPrice,
+  openingPositions = [],
   trades,
 }: CalculateHoldingInput): Holding {
   let averageCostPrice = 0;
   let totalUnits = 0;
+  const costBasisEvents = [
+    ...openingPositions.map((position) => ({
+      date: position.date,
+      fees: 0,
+      pricePerUnit: position.averageCostPrice,
+      quantity: position.quantity,
+      type: "opening" as const,
+    })),
+    ...sortTradesByDate(trades).map((trade) => ({
+      date: trade.date,
+      fees: trade.fees ?? 0,
+      pricePerUnit: trade.pricePerUnit,
+      quantity: trade.quantity,
+      type: trade.type,
+    })),
+  ].sort(
+    (left, right) =>
+      new Date(left.date).getTime() - new Date(right.date).getTime(),
+  );
 
-  for (const trade of sortTradesByDate(trades)) {
-    if (trade.type === "buy") {
+  for (const event of costBasisEvents) {
+    if (event.type === "buy" || event.type === "opening") {
       const existingCost = totalUnits * averageCostPrice;
-      const buyCost = trade.pricePerUnit * trade.quantity + (trade.fees ?? 0);
-      const nextUnits = totalUnits + trade.quantity;
+      const buyCost = event.pricePerUnit * event.quantity + event.fees;
+      const nextUnits = totalUnits + event.quantity;
 
       averageCostPrice = nextUnits > 0 ? (existingCost + buyCost) / nextUnits : 0;
       totalUnits = nextUnits;
       continue;
     }
 
-    totalUnits = Math.max(0, totalUnits - trade.quantity);
+    totalUnits = Math.max(0, totalUnits - event.quantity);
 
     if (totalUnits === 0) {
       averageCostPrice = 0;
@@ -99,21 +122,32 @@ export function calculateHolding({
 
 export function calculateHoldings({
   assets,
+  openingPositions = [],
   quoteCache,
   trades,
 }: CalculateHoldingsInput) {
   return assets
     .map((asset) => {
       const assetTrades = trades.filter((trade) => trade.assetId === asset.id);
+      const assetOpeningPositions = openingPositions.filter(
+        (position) => position.assetId === asset.id,
+      );
 
-      if (assetTrades.length === 0) {
+      if (assetTrades.length === 0 && assetOpeningPositions.length === 0) {
         return null;
       }
 
-      const currentPrice = quoteCache[asset.id]?.price ?? 0;
+      const latestManualPrice = [...assetOpeningPositions]
+        .filter((position) => position.currentPrice !== undefined)
+        .sort(
+          (left, right) =>
+            new Date(right.date).getTime() - new Date(left.date).getTime(),
+        )[0]?.currentPrice;
+      const currentPrice = quoteCache[asset.id]?.price ?? latestManualPrice ?? 0;
       const holding = calculateHolding({
         asset,
         currentPrice,
+        openingPositions: assetOpeningPositions,
         trades: assetTrades,
       });
 
@@ -215,20 +249,26 @@ export function daysHeld(fromIsoDate: string, toIsoDate = new Date().toISOString
 export function getConvictionReadiness(
   trades: Trade[],
   requiredTradeCount = defaultConvictionTradeCount,
+  openingPositions: OpeningPosition[] = [],
 ): ConvictionReadiness {
-  const ratedTrades = trades.filter((trade) => trade.conviction !== undefined);
-  const highConvictionCount = ratedTrades.filter(
-    (trade) => trade.conviction !== undefined && trade.conviction >= 4,
+  const ratedConvictions = [
+    ...trades.map((trade) => trade.conviction),
+    ...openingPositions.map((position) => position.conviction),
+  ].filter((conviction): conviction is NonNullable<typeof conviction> =>
+    conviction !== undefined,
+  );
+  const highConvictionCount = ratedConvictions.filter(
+    (conviction) => conviction >= 4,
   ).length;
-  const lowConvictionCount = ratedTrades.filter(
-    (trade) => trade.conviction !== undefined && trade.conviction <= 2,
+  const lowConvictionCount = ratedConvictions.filter(
+    (conviction) => conviction <= 2,
   ).length;
 
   return {
     highConvictionCount,
-    isReady: ratedTrades.length >= requiredTradeCount,
+    isReady: ratedConvictions.length >= requiredTradeCount,
     lowConvictionCount,
-    ratedTradeCount: ratedTrades.length,
+    ratedTradeCount: ratedConvictions.length,
     requiredTradeCount,
   };
 }

--- a/src/features/dashboard/useDashboard.ts
+++ b/src/features/dashboard/useDashboard.ts
@@ -63,6 +63,7 @@ export function useDashboard({
   const holdings = withQuoteMetadata(
     calculateHoldings({
       assets: snapshot.assets,
+      openingPositions: snapshot.openingPositions,
       quoteCache: snapshot.quoteCache,
       trades: snapshot.trades,
     }),
@@ -76,7 +77,11 @@ export function useDashboard({
       holdings,
     }),
     cashBalance,
-    convictionReadiness: getConvictionReadiness(snapshot.trades),
+    convictionReadiness: getConvictionReadiness(
+      snapshot.trades,
+      undefined,
+      snapshot.openingPositions,
+    ),
     dayChange: calculatePortfolioDayChange(holdings),
     holdings,
     latestQuoteAsOf: getLatestQuoteAsOf(holdings),

--- a/src/features/holdings/useHoldings.ts
+++ b/src/features/holdings/useHoldings.ts
@@ -66,6 +66,7 @@ export function useHoldings({
   const holdings = withQuoteMetadata(
     calculateHoldings({
       assets: snapshot.assets,
+      openingPositions: snapshot.openingPositions,
       quoteCache: snapshot.quoteCache,
       trades: snapshot.trades,
     }),

--- a/src/features/openingPositions/AddOpeningPositionForm.tsx
+++ b/src/features/openingPositions/AddOpeningPositionForm.tsx
@@ -1,0 +1,585 @@
+import * as Haptics from "expo-haptics";
+import { useMemo, useState, useSyncExternalStore } from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import type { StoreApi } from "zustand/vanilla";
+
+import {
+  AppButton,
+  AppText,
+  assetClassLabel,
+  CategoryIcon,
+  PremiumCard,
+  ScreenContainer,
+  ScreenHeader,
+  SectionHeader,
+} from "@/src/components/common";
+import { FormTextField } from "@/src/components/forms";
+import { calculateHolding } from "@/src/domain/calculations";
+import { formatINR, formatPercentage } from "@/src/domain/formatters";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import { colors, interaction, radii, spacing } from "@/src/theme";
+import type {
+  Asset,
+  AssetClass,
+  ConvictionScore,
+  OpeningPosition,
+} from "@/src/types";
+import { createId } from "@/src/utils";
+
+import { validateOpeningPositionForm } from "./openingPositionForm";
+
+type AddOpeningPositionFormProps = {
+  store?: StoreApi<PortfolioStoreState>;
+};
+
+type FieldErrors = Partial<Record<string, string>>;
+
+const assetClasses: AssetClass[] = ["stock", "etf", "debt", "crypto"];
+const convictionScores: ConvictionScore[] = [1, 2, 3, 4, 5];
+
+function todayInputValue() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
+  return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+}
+
+function formatSignedINR(value: number) {
+  const amount = formatINR(value);
+
+  return value > 0 ? `+${amount}` : amount;
+}
+
+export function AddOpeningPositionForm({
+  store = getPortfolioStore(),
+}: AddOpeningPositionFormProps) {
+  const snapshot = usePortfolioSnapshot(store);
+  const [selectedAssetId, setSelectedAssetId] = useState("");
+  const [assetClass, setAssetClass] = useState<AssetClass>("stock");
+  const [assetName, setAssetName] = useState("");
+  const [symbol, setSymbol] = useState("");
+  const [ticker, setTicker] = useState("");
+  const [quantity, setQuantity] = useState("");
+  const [averageCostPrice, setAverageCostPrice] = useState("");
+  const [currentPrice, setCurrentPrice] = useState("");
+  const [date, setDate] = useState(todayInputValue());
+  const [conviction, setConviction] = useState("");
+  const [notes, setNotes] = useState("");
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [reviewAsset, setReviewAsset] = useState<Asset | undefined>();
+  const [reviewOpeningPosition, setReviewOpeningPosition] =
+    useState<OpeningPosition | undefined>();
+  const [successMessage, setSuccessMessage] = useState("");
+
+  const selectedAsset = useMemo(
+    () => snapshot.assets.find((asset) => asset.id === selectedAssetId),
+    [selectedAssetId, snapshot.assets],
+  );
+
+  const previewHolding =
+    reviewAsset && reviewOpeningPosition
+      ? calculateHolding({
+          asset: reviewAsset,
+          currentPrice: reviewOpeningPosition.currentPrice ?? 0,
+          openingPositions: [reviewOpeningPosition],
+          trades: [],
+        })
+      : undefined;
+
+  function resetReview() {
+    setReviewAsset(undefined);
+    setReviewOpeningPosition(undefined);
+    setSuccessMessage("");
+  }
+
+  function clearSelectedAsset() {
+    if (selectedAssetId) {
+      setSelectedAssetId("");
+    }
+  }
+
+  function selectAsset(asset: Asset) {
+    const quote = snapshot.quoteCache[asset.id];
+
+    setSelectedAssetId(asset.id);
+    setAssetClass(asset.assetClass);
+    setAssetName(asset.name);
+    setSymbol(asset.symbol);
+    setTicker(asset.ticker);
+    if (quote) {
+      setCurrentPrice(quote.price.toString());
+    }
+    resetReview();
+  }
+
+  function buildManualAsset(id: string): Asset {
+    return {
+      assetClass,
+      currency: "INR",
+      exchange: assetClass === "crypto" ? "CRYPTO" : "NSE",
+      id,
+      name: assetName.trim(),
+      symbol: symbol.trim().toUpperCase(),
+      ticker: ticker.trim().toUpperCase(),
+    };
+  }
+
+  function handleReview() {
+    resetReview();
+    const result = validateOpeningPositionForm({
+      assetClass,
+      assetName,
+      averageCostPrice,
+      conviction,
+      currentPrice,
+      date,
+      notes,
+      quantity,
+      symbol,
+      ticker,
+    });
+
+    if (!result.isValid) {
+      setErrors(result.errors);
+      return;
+    }
+
+    const assetId = selectedAsset?.id ?? createId("asset");
+    const asset = selectedAsset ?? buildManualAsset(assetId);
+
+    setErrors({});
+    setReviewAsset(asset);
+    setReviewOpeningPosition({
+      assetId: asset.id,
+      averageCostPrice: result.value.averageCostPrice,
+      conviction: result.value.conviction,
+      currentPrice: result.value.currentPrice,
+      date: `${result.value.date}T00:00:00.000Z`,
+      id: createId("opening"),
+      notes: result.value.notes,
+      quantity: result.value.quantity,
+    });
+  }
+
+  async function handleConfirm() {
+    if (!reviewAsset || !reviewOpeningPosition) {
+      return;
+    }
+
+    if (!selectedAsset) {
+      store.getState().addAsset(reviewAsset);
+    }
+
+    store.getState().addOpeningPosition(reviewOpeningPosition);
+    store.getState().upsertQuote({
+      asOf: new Date().toISOString(),
+      assetId: reviewAsset.id,
+      currency: "INR",
+      price: reviewOpeningPosition.currentPrice ?? 0,
+      source: "manual",
+    });
+    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    setSuccessMessage("Opening position saved.");
+    setReviewOpeningPosition(undefined);
+  }
+
+  return (
+    <ScreenContainer scroll testID="add-holding-screen">
+      <ScreenHeader title="Add Holding" subtitle="Opening position • local only" />
+
+      {snapshot.assets.length > 0 ? (
+        <PremiumCard>
+          <AppText color="secondary" variant="caption" weight="medium">
+            Existing assets
+          </AppText>
+          <View style={styles.assetGrid}>
+            {snapshot.assets.map((asset) => (
+              <Pressable
+                accessibilityRole="button"
+                key={asset.id}
+                onPress={() => selectAsset(asset)}
+                style={({ pressed }) => [
+                  styles.assetChip,
+                  selectedAssetId === asset.id && styles.assetChipActive,
+                  pressed && styles.pressed,
+                ]}
+              >
+                <CategoryIcon assetClass={asset.assetClass} size={18} />
+                <View style={styles.assetChipCopy}>
+                  <AppText weight="bold">{asset.symbol}</AppText>
+                  <AppText color="secondary" variant="caption">
+                    {asset.name}
+                  </AppText>
+                </View>
+              </Pressable>
+            ))}
+          </View>
+        </PremiumCard>
+      ) : null}
+
+      <PremiumCard>
+        <SectionHeader title="Asset" />
+        <View style={styles.classRow}>
+          {assetClasses.map((currentClass) => {
+            const isSelected = assetClass === currentClass;
+
+            return (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityState={{ selected: isSelected }}
+                key={currentClass}
+                onPress={() => {
+                  setAssetClass(currentClass);
+                  clearSelectedAsset();
+                  resetReview();
+                }}
+                style={({ pressed }) => [
+                  styles.classChip,
+                  isSelected && styles.classChipActive,
+                  pressed && styles.pressed,
+                ]}
+                testID={`asset-class-${currentClass}`}
+              >
+                <CategoryIcon assetClass={currentClass} size={16} />
+                <AppText
+                  color={isSelected ? "primary" : "secondary"}
+                  variant="caption"
+                  weight="bold"
+                >
+                  {assetClassLabel(currentClass)}
+                </AppText>
+              </Pressable>
+            );
+          })}
+        </View>
+        <FormTextField
+          error={errors.assetName}
+          label="Asset name"
+          onChangeText={(value) => {
+            setAssetName(value);
+            clearSelectedAsset();
+            resetReview();
+          }}
+          placeholder="Reliance Industries"
+          testID="asset-input"
+          value={assetName}
+        />
+        <View style={styles.row}>
+          <View style={styles.flex}>
+            <FormTextField
+              error={errors.symbol}
+              label="Symbol"
+              onChangeText={(value) => {
+                setSymbol(value);
+                clearSelectedAsset();
+                resetReview();
+              }}
+              placeholder="RELIANCE"
+              testID="symbol-input"
+              value={symbol}
+            />
+          </View>
+          <View style={styles.flex}>
+            <FormTextField
+              error={errors.ticker}
+              label="Ticker"
+              onChangeText={(value) => {
+                setTicker(value);
+                clearSelectedAsset();
+                resetReview();
+              }}
+              placeholder="RELIANCE.NS"
+              testID="ticker-input"
+              value={ticker}
+            />
+          </View>
+        </View>
+      </PremiumCard>
+
+      <PremiumCard>
+        <SectionHeader title="Position Details" />
+        <View style={styles.row}>
+          <View style={styles.flex}>
+            <FormTextField
+              error={errors.quantity}
+              keyboardType="decimal-pad"
+              label="Quantity"
+              onChangeText={(value) => {
+                setQuantity(value);
+                resetReview();
+              }}
+              placeholder="25"
+              testID="quantity-input"
+              value={quantity}
+            />
+          </View>
+          <View style={styles.flex}>
+            <FormTextField
+              error={errors.averageCostPrice}
+              keyboardType="decimal-pad"
+              label="Average cost"
+              onChangeText={(value) => {
+                setAverageCostPrice(value);
+                resetReview();
+              }}
+              placeholder="1450"
+              testID="average-cost-input"
+              value={averageCostPrice}
+            />
+          </View>
+        </View>
+        <View style={styles.row}>
+          <View style={styles.flex}>
+            <FormTextField
+              error={errors.currentPrice}
+              keyboardType="decimal-pad"
+              label="Current price"
+              onChangeText={(value) => {
+                setCurrentPrice(value);
+                resetReview();
+              }}
+              placeholder="1678.25"
+              testID="price-input"
+              value={currentPrice}
+            />
+          </View>
+          <View style={styles.flex}>
+            <FormTextField
+              error={errors.date}
+              label="Date acquired"
+              onChangeText={(value) => {
+                setDate(value);
+                resetReview();
+              }}
+              placeholder="YYYY-MM-DD"
+              testID="date-input"
+              value={date}
+            />
+          </View>
+        </View>
+        <View style={styles.convictionGroup}>
+          <AppText color="secondary" variant="caption" weight="medium">
+            Conviction optional
+          </AppText>
+          <View style={styles.convictionRow}>
+            {convictionScores.map((score) => {
+              const scoreValue = score.toString();
+              const isSelected = conviction === scoreValue;
+
+              return (
+                <Pressable
+                  accessibilityLabel={`Conviction ${score}`}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: isSelected }}
+                  key={score}
+                  onPress={() => {
+                    setConviction(isSelected ? "" : scoreValue);
+                    resetReview();
+                  }}
+                  style={({ pressed }) => [
+                    styles.convictionChip,
+                    isSelected && styles.convictionChipActive,
+                    pressed && styles.pressed,
+                  ]}
+                  testID={`conviction-${score}`}
+                >
+                  <AppText
+                    color={isSelected ? "inverse" : "secondary"}
+                    weight="bold"
+                  >
+                    {score}
+                  </AppText>
+                </Pressable>
+              );
+            })}
+          </View>
+          {errors.conviction ? (
+            <AppText selectable style={styles.errorText} variant="caption">
+              {errors.conviction}
+            </AppText>
+          ) : null}
+        </View>
+        <FormTextField
+          label="Note"
+          multiline
+          onChangeText={(value) => {
+            setNotes(value);
+            resetReview();
+          }}
+          placeholder="Optional note"
+          value={notes}
+        />
+      </PremiumCard>
+
+      {previewHolding ? (
+        <PremiumCard elevated testID="derived-preview">
+          <SectionHeader title="Derived Preview" />
+          <View style={styles.previewGrid}>
+            <View style={styles.previewCell}>
+              <AppText color="secondary" variant="caption">
+                Invested
+              </AppText>
+              <AppText weight="bold">
+                {formatINR(previewHolding.totalInvested)}
+              </AppText>
+            </View>
+            <View style={styles.previewCell}>
+              <AppText color="secondary" variant="caption">
+                Current
+              </AppText>
+              <AppText weight="bold">
+                {formatINR(previewHolding.currentValue)}
+              </AppText>
+            </View>
+            <View style={styles.previewCell}>
+              <AppText color="secondary" variant="caption">
+                P&L
+              </AppText>
+              <AppText
+                style={[
+                  previewHolding.unrealisedPnL >= 0
+                    ? styles.positiveText
+                    : styles.negativeText,
+                ]}
+                weight="bold"
+              >
+                {formatSignedINR(previewHolding.unrealisedPnL)}
+              </AppText>
+            </View>
+            <View style={styles.previewCell}>
+              <AppText color="secondary" variant="caption">
+                P&L %
+              </AppText>
+              <AppText
+                style={[
+                  previewHolding.unrealisedPnL >= 0
+                    ? styles.positiveText
+                    : styles.negativeText,
+                ]}
+                weight="bold"
+              >
+                {formatPercentage(previewHolding.unrealisedPnLPct)}
+              </AppText>
+            </View>
+          </View>
+        </PremiumCard>
+      ) : null}
+
+      {successMessage ? (
+        <AppText selectable style={styles.successText}>
+          {successMessage}
+        </AppText>
+      ) : null}
+
+      <View style={styles.actions}>
+        <AppButton
+          onPress={handleReview}
+          testID="review-holding-button"
+          title="Review Holding"
+        />
+        <AppButton
+          disabled={!reviewOpeningPosition}
+          onPress={handleConfirm}
+          testID="save-holding-button"
+          title="Save Holding"
+          variant="secondary"
+        />
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  actions: {
+    gap: spacing.sm,
+    paddingBottom: spacing.lg,
+  },
+  assetChip: {
+    alignItems: "center",
+    backgroundColor: colors.surface.elevated,
+    borderRadius: radii.card,
+    flexDirection: "row",
+    gap: spacing.sm,
+    padding: spacing.md,
+    width: "48%",
+  },
+  assetChipActive: {
+    backgroundColor: "rgba(46,125,82,0.24)",
+  },
+  assetChipCopy: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  assetGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.sm,
+  },
+  classChip: {
+    alignItems: "center",
+    backgroundColor: colors.surface.elevated,
+    borderRadius: radii.pill,
+    flexDirection: "row",
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.sm,
+  },
+  classChipActive: {
+    backgroundColor: "rgba(46,125,82,0.24)",
+  },
+  classRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.sm,
+  },
+  convictionChip: {
+    alignItems: "center",
+    backgroundColor: colors.surface.elevated,
+    borderRadius: radii.pill,
+    flex: 1,
+    justifyContent: "center",
+    minHeight: 44,
+  },
+  convictionChipActive: {
+    backgroundColor: colors.primary,
+  },
+  convictionGroup: {
+    gap: spacing.xs,
+  },
+  convictionRow: {
+    flexDirection: "row",
+    gap: spacing.xs,
+  },
+  errorText: {
+    color: colors.loss,
+  },
+  flex: {
+    flex: 1,
+  },
+  negativeText: {
+    color: colors.loss,
+  },
+  positiveText: {
+    color: colors.profit,
+  },
+  pressed: {
+    opacity: interaction.pressedOpacity,
+  },
+  previewCell: {
+    gap: spacing.xs,
+    width: "48%",
+  },
+  previewGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.md,
+  },
+  row: {
+    flexDirection: "row",
+    gap: spacing.sm,
+  },
+  successText: {
+    color: colors.profit,
+  },
+});

--- a/src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
+++ b/src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
@@ -1,0 +1,109 @@
+import * as Haptics from "expo-haptics";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+
+import { AddOpeningPositionForm } from "@/src/features/openingPositions";
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import { createPortfolioStore } from "@/src/store";
+
+jest.mock("expo-haptics", () => ({
+  notificationAsync: jest.fn(),
+  NotificationFeedbackType: {
+    Success: "success",
+  },
+}));
+
+describe("AddOpeningPositionForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates a manual asset and persists a reviewed opening position", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const { getByLabelText, getByTestId, getByText } = render(
+      <AddOpeningPositionForm store={store} />,
+    );
+
+    expect(getByTestId("add-holding-screen")).toBeTruthy();
+    expect(getByTestId("asset-class-stock")).toBeTruthy();
+    expect(getByTestId("asset-input")).toBeTruthy();
+    expect(getByTestId("symbol-input")).toBeTruthy();
+    expect(getByTestId("ticker-input")).toBeTruthy();
+    expect(getByTestId("quantity-input")).toBeTruthy();
+    expect(getByTestId("average-cost-input")).toBeTruthy();
+    expect(getByTestId("price-input")).toBeTruthy();
+    expect(getByTestId("date-input")).toBeTruthy();
+    expect(getByTestId("review-holding-button")).toBeTruthy();
+    expect(getByTestId("save-holding-button")).toBeTruthy();
+
+    fireEvent.changeText(getByLabelText("Asset name"), "Reliance Industries");
+    fireEvent.changeText(getByLabelText("Symbol"), "RELIANCE");
+    fireEvent.changeText(getByLabelText("Ticker"), "RELIANCE.NS");
+    fireEvent.changeText(getByLabelText("Quantity"), "25");
+    fireEvent.changeText(getByLabelText("Average cost"), "1450");
+    fireEvent.changeText(getByLabelText("Current price"), "1678.25");
+    fireEvent.changeText(getByLabelText("Date acquired"), "2026-04-15");
+    fireEvent.press(getByTestId("conviction-4"));
+    fireEvent.changeText(getByLabelText("Note"), "Excel opening position");
+
+    fireEvent.press(getByText("Review Holding"));
+    expect(getByTestId("derived-preview")).toBeTruthy();
+    expect(getByText("₹36,250.00")).toBeTruthy();
+    expect(getByText("₹41,956.25")).toBeTruthy();
+    expect(getByText("+₹5,706.25")).toBeTruthy();
+
+    fireEvent.press(getByText("Save Holding"));
+
+    await waitFor(() => {
+      expect(store.getState().assets).toHaveLength(1);
+      expect(store.getState().openingPositions).toHaveLength(1);
+    });
+
+    expect(store.getState().assets[0]).toMatchObject({
+      assetClass: "stock",
+      name: "Reliance Industries",
+      symbol: "RELIANCE",
+      ticker: "RELIANCE.NS",
+    });
+    expect(store.getState().openingPositions[0]).toMatchObject({
+      assetId: store.getState().assets[0].id,
+      averageCostPrice: 1450,
+      conviction: 4,
+      currentPrice: 1678.25,
+      notes: "Excel opening position",
+      quantity: 25,
+    });
+    expect(store.getState().trades).toEqual([]);
+    expect(store.getState().quoteCache[store.getState().assets[0].id]).toMatchObject({
+      price: 1678.25,
+      source: "manual",
+    });
+    expect(Haptics.notificationAsync).toHaveBeenCalledWith("success");
+    expect(getByText("Opening position saved.")).toBeTruthy();
+  });
+
+  it("creates a debt opening position without trade records", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const { getByLabelText, getByTestId, getByText } = render(
+      <AddOpeningPositionForm store={store} />,
+    );
+
+    fireEvent.press(getByTestId("asset-class-debt"));
+    fireEvent.changeText(getByLabelText("Asset name"), "Sovereign Gold Bond");
+    fireEvent.changeText(getByLabelText("Symbol"), "SGB");
+    fireEvent.changeText(getByLabelText("Ticker"), "SGB");
+    fireEvent.changeText(getByLabelText("Quantity"), "10");
+    fireEvent.changeText(getByLabelText("Average cost"), "5300");
+    fireEvent.changeText(getByLabelText("Current price"), "5711");
+    fireEvent.changeText(getByLabelText("Date acquired"), "2026-04-15");
+
+    fireEvent.press(getByText("Review Holding"));
+    fireEvent.press(getByText("Save Holding"));
+
+    await waitFor(() => {
+      expect(store.getState().openingPositions).toHaveLength(1);
+    });
+
+    expect(store.getState().assets[0]?.assetClass).toBe("debt");
+    expect(store.getState().trades).toEqual([]);
+  });
+});

--- a/src/features/openingPositions/__tests__/openingPositionForm.test.ts
+++ b/src/features/openingPositions/__tests__/openingPositionForm.test.ts
@@ -1,0 +1,60 @@
+import { validateOpeningPositionForm } from "@/src/features/openingPositions";
+
+describe("validateOpeningPositionForm", () => {
+  it("normalizes a valid opening-position form", () => {
+    const result = validateOpeningPositionForm({
+      assetClass: "stock",
+      assetName: " Reliance Industries ",
+      averageCostPrice: "1450",
+      conviction: "4",
+      currentPrice: "1678.25",
+      date: "2026-04-15",
+      notes: " Core holding ",
+      quantity: "25",
+      symbol: " reliance ",
+      ticker: " reliance.ns ",
+    });
+
+    expect(result).toEqual({
+      isValid: true,
+      value: {
+        assetClass: "stock",
+        assetName: "Reliance Industries",
+        averageCostPrice: 1450,
+        conviction: 4,
+        currentPrice: 1678.25,
+        date: "2026-04-15",
+        notes: "Core holding",
+        quantity: 25,
+        symbol: "RELIANCE",
+        ticker: "RELIANCE.NS",
+      },
+    });
+  });
+
+  it("rejects missing identity and non-positive numbers", () => {
+    const result = validateOpeningPositionForm({
+      assetClass: "stock",
+      assetName: "",
+      averageCostPrice: "0",
+      currentPrice: "-1",
+      date: "15-04-2026",
+      quantity: "0",
+      symbol: "",
+      ticker: "",
+    });
+
+    expect(result).toEqual({
+      errors: {
+        assetName: "Asset name is required.",
+        averageCostPrice: "Average cost must be greater than zero.",
+        currentPrice: "Current price must be greater than zero.",
+        date: "Date must use YYYY-MM-DD.",
+        quantity: "Quantity must be greater than zero.",
+        symbol: "Symbol is required.",
+        ticker: "Ticker is required.",
+      },
+      isValid: false,
+    });
+  });
+});

--- a/src/features/openingPositions/index.ts
+++ b/src/features/openingPositions/index.ts
@@ -1,0 +1,6 @@
+export { AddOpeningPositionForm } from "./AddOpeningPositionForm";
+export {
+  validateOpeningPositionForm,
+  type OpeningPositionFormValues,
+  type ValidOpeningPositionForm,
+} from "./openingPositionForm";

--- a/src/features/openingPositions/openingPositionForm.ts
+++ b/src/features/openingPositions/openingPositionForm.ts
@@ -1,0 +1,122 @@
+import type { AssetClass, ConvictionScore } from "@/src/types";
+
+export type OpeningPositionFormValues = {
+  assetClass: AssetClass;
+  assetName: string;
+  averageCostPrice: string;
+  conviction?: string;
+  currentPrice: string;
+  date: string;
+  notes?: string;
+  quantity: string;
+  symbol: string;
+  ticker: string;
+};
+
+export type ValidOpeningPositionForm = {
+  assetClass: AssetClass;
+  assetName: string;
+  averageCostPrice: number;
+  conviction?: ConvictionScore;
+  currentPrice: number;
+  date: string;
+  notes?: string;
+  quantity: number;
+  symbol: string;
+  ticker: string;
+};
+
+export type OpeningPositionFormResult =
+  | {
+      errors: Partial<Record<keyof OpeningPositionFormValues, string>>;
+      isValid: false;
+    }
+  | {
+      isValid: true;
+      value: ValidOpeningPositionForm;
+    };
+
+function parsePositiveNumber(value: string) {
+  const parsed = Number(value);
+
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function isValidDateInput(value: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+
+  return !Number.isNaN(new Date(`${value}T00:00:00.000Z`).getTime());
+}
+
+export function validateOpeningPositionForm(
+  values: OpeningPositionFormValues,
+): OpeningPositionFormResult {
+  const errors: Partial<Record<keyof OpeningPositionFormValues, string>> = {};
+  const quantity = parsePositiveNumber(values.quantity);
+  const averageCostPrice = parsePositiveNumber(values.averageCostPrice);
+  const currentPrice = parsePositiveNumber(values.currentPrice);
+  const conviction =
+    values.conviction && values.conviction.trim().length > 0
+      ? Number(values.conviction)
+      : undefined;
+
+  if (values.assetName.trim().length === 0) {
+    errors.assetName = "Asset name is required.";
+  }
+
+  if (values.symbol.trim().length === 0) {
+    errors.symbol = "Symbol is required.";
+  }
+
+  if (values.ticker.trim().length === 0) {
+    errors.ticker = "Ticker is required.";
+  }
+
+  if (quantity === null) {
+    errors.quantity = "Quantity must be greater than zero.";
+  }
+
+  if (averageCostPrice === null) {
+    errors.averageCostPrice = "Average cost must be greater than zero.";
+  }
+
+  if (currentPrice === null) {
+    errors.currentPrice = "Current price must be greater than zero.";
+  }
+
+  if (!isValidDateInput(values.date)) {
+    errors.date = "Date must use YYYY-MM-DD.";
+  }
+
+  if (
+    conviction !== undefined &&
+    (!Number.isInteger(conviction) || conviction < 1 || conviction > 5)
+  ) {
+    errors.conviction = "Conviction must be between 1 and 5.";
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return {
+      errors,
+      isValid: false,
+    };
+  }
+
+  return {
+    isValid: true,
+    value: {
+      assetClass: values.assetClass,
+      assetName: values.assetName.trim(),
+      averageCostPrice: averageCostPrice as number,
+      conviction: conviction as ConvictionScore | undefined,
+      currentPrice: currentPrice as number,
+      date: values.date,
+      notes: values.notes?.trim() || undefined,
+      quantity: quantity as number,
+      symbol: values.symbol.trim().toUpperCase(),
+      ticker: values.ticker.trim().toUpperCase(),
+    },
+  };
+}

--- a/src/features/progress/ProgressScreen.tsx
+++ b/src/features/progress/ProgressScreen.tsx
@@ -53,6 +53,7 @@ export function ProgressScreen({
   const snapshot = usePortfolioSnapshot(store);
   const holdings = calculateHoldings({
     assets: snapshot.assets,
+    openingPositions: snapshot.openingPositions,
     quoteCache: snapshot.quoteCache,
     trades: snapshot.trades,
   });
@@ -62,9 +63,17 @@ export function ProgressScreen({
     (total, holding) => total + holding.totalInvested,
     0,
   );
-  const monthlyInvestment = snapshot.trades
+  const monthlyTradeInvestment = snapshot.trades
     .filter((trade) => trade.type === "buy" && isCurrentMonth(trade.date))
     .reduce((total, trade) => total + trade.totalValue, 0);
+  const monthlyOpeningInvestment = snapshot.openingPositions
+    .filter((position) => isCurrentMonth(position.date))
+    .reduce(
+      (total, position) =>
+        total + position.quantity * position.averageCostPrice,
+      0,
+    );
+  const monthlyInvestment = monthlyTradeInvestment + monthlyOpeningInvestment;
   const monthlyCashAdded = snapshot.cashEntries
     .filter((entry) => entry.type === "addition" && isCurrentMonth(entry.date))
     .reduce((total, entry) => total + entry.amount, 0);

--- a/src/store/__tests__/portfolioStore.test.ts
+++ b/src/store/__tests__/portfolioStore.test.ts
@@ -5,7 +5,7 @@ import {
   quoteCacheStorageKey,
 } from "@/src/store";
 import { createMemoryJsonStorage } from "@/src/services/storage";
-import type { Asset, CashEntry, Quote, Trade } from "@/src/types";
+import type { Asset, CashEntry, OpeningPosition, Quote, Trade } from "@/src/types";
 
 const asset: Asset = {
   assetClass: "stock",
@@ -35,6 +35,15 @@ const cashEntry: CashEntry = {
   type: "addition",
 };
 
+const openingPosition: OpeningPosition = {
+  assetId: asset.id,
+  averageCostPrice: 1450,
+  currentPrice: 1678.25,
+  date: "2026-04-15T00:00:00.000Z",
+  id: "opening-1",
+  quantity: 25,
+};
+
 const quote: Quote = {
   asOf: "2026-04-26T10:00:00.000Z",
   assetId: asset.id,
@@ -49,6 +58,7 @@ describe("portfolio store", () => {
 
     expect(store.getState().assets).toEqual([]);
     expect(store.getState().trades).toEqual([]);
+    expect(store.getState().openingPositions).toEqual([]);
     expect(store.getState().cashEntries).toEqual([]);
     expect(store.getState().preferences).toEqual(createDefaultPreferences());
   });
@@ -57,20 +67,31 @@ describe("portfolio store", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
 
     store.getState().addAsset(asset);
+    store.getState().addOpeningPosition(openingPosition);
     store.getState().addTrade(trade);
     store.getState().addCashEntry(cashEntry);
     store.getState().updatePreferences({ maskWealthValues: true });
 
     expect(store.getState().assets).toEqual([asset]);
+    expect(store.getState().openingPositions).toEqual([openingPosition]);
     expect(store.getState().trades).toEqual([trade]);
     expect(store.getState().cashEntries).toEqual([cashEntry]);
     expect(store.getState().preferences.maskWealthValues).toBe(true);
 
+    store.getState().updateOpeningPosition({
+      ...openingPosition,
+      quantity: 30,
+    });
+
+    expect(store.getState().openingPositions[0]?.quantity).toBe(30);
+
+    store.getState().removeOpeningPosition(openingPosition.id);
     store.getState().removeTrade(trade.id);
     store.getState().removeCashEntry(cashEntry.id);
     store.getState().removeAsset(asset.id);
 
     expect(store.getState().assets).toEqual([]);
+    expect(store.getState().openingPositions).toEqual([]);
     expect(store.getState().trades).toEqual([]);
     expect(store.getState().cashEntries).toEqual([]);
   });
@@ -80,6 +101,7 @@ describe("portfolio store", () => {
     const store = createPortfolioStore({ storage });
 
     store.getState().addAsset(asset);
+    store.getState().addOpeningPosition(openingPosition);
     store.getState().addTrade(trade);
     store.getState().addCashEntry(cashEntry);
 
@@ -88,8 +110,9 @@ describe("portfolio store", () => {
     expect(persisted).toEqual({
       assets: [asset],
       cashEntries: [cashEntry],
+      openingPositions: [openingPosition],
       preferences: createDefaultPreferences(),
-      schemaVersion: 1,
+      schemaVersion: 2,
       trades: [trade],
     });
     expect(persisted).not.toHaveProperty("holdings");
@@ -115,8 +138,9 @@ describe("portfolio store", () => {
     storage.setItem(portfolioStorageKey, {
       assets: [asset],
       cashEntries: [cashEntry],
+      openingPositions: [openingPosition],
       preferences: { ...createDefaultPreferences(), maskWealthValues: true },
-      schemaVersion: 1,
+      schemaVersion: 2,
       trades: [trade],
     });
     storage.setItem(quoteCacheStorageKey, {
@@ -126,9 +150,28 @@ describe("portfolio store", () => {
     const store = createPortfolioStore({ storage });
 
     expect(store.getState().assets).toEqual([asset]);
+    expect(store.getState().openingPositions).toEqual([openingPosition]);
     expect(store.getState().trades).toEqual([trade]);
     expect(store.getState().cashEntries).toEqual([cashEntry]);
     expect(store.getState().preferences.maskWealthValues).toBe(true);
     expect(store.getState().quoteCache[asset.id]).toEqual(quote);
+  });
+
+  it("migrates V1 persisted snapshots by adding empty opening positions", () => {
+    const storage = createMemoryJsonStorage();
+    storage.setItem(portfolioStorageKey, {
+      assets: [asset],
+      cashEntries: [cashEntry],
+      preferences: createDefaultPreferences(),
+      schemaVersion: 1,
+      trades: [trade],
+    });
+
+    const store = createPortfolioStore({ storage });
+
+    expect(store.getState().assets).toEqual([asset]);
+    expect(store.getState().openingPositions).toEqual([]);
+    expect(store.getState().trades).toEqual([trade]);
+    expect(store.getState().schemaVersion).toBe(2);
   });
 });

--- a/src/store/__tests__/selectors.test.ts
+++ b/src/store/__tests__/selectors.test.ts
@@ -1,10 +1,11 @@
 import {
   selectAssetById,
   selectCashBalance,
+  selectOpeningPositionsForAsset,
   selectQuoteForAsset,
   selectTradesForAsset,
 } from "@/src/store";
-import type { Asset, CashEntry, Quote, Trade } from "@/src/types";
+import type { Asset, CashEntry, OpeningPosition, Quote, Trade } from "@/src/types";
 
 const stock: Asset = {
   assetClass: "stock",
@@ -45,6 +46,25 @@ const trades: Trade[] = [
   },
 ];
 
+const openingPositions: OpeningPosition[] = [
+  {
+    assetId: stock.id,
+    averageCostPrice: 100,
+    currentPrice: 110,
+    date: "2026-04-01T00:00:00.000Z",
+    id: "opening-1",
+    quantity: 2,
+  },
+  {
+    assetId: crypto.id,
+    averageCostPrice: 50000,
+    currentPrice: 55000,
+    date: "2026-04-01T00:00:00.000Z",
+    id: "opening-2",
+    quantity: 0.1,
+  },
+];
+
 const cashEntries: CashEntry[] = [
   {
     amount: 5000,
@@ -74,6 +94,9 @@ describe("portfolio selectors", () => {
   it("selects assets and trades by asset ID", () => {
     expect(selectAssetById([stock, crypto], stock.id)).toEqual(stock);
     expect(selectTradesForAsset(trades, stock.id)).toEqual([trades[0]]);
+    expect(selectOpeningPositionsForAsset(openingPositions, stock.id)).toEqual([
+      openingPositions[0],
+    ]);
   });
 
   it("calculates cash balance from raw cash entries", () => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,6 +5,7 @@ import { createMmkvJsonStorage } from "@/src/services/storage";
 import type {
   Asset,
   CashEntry,
+  OpeningPosition,
   Preferences,
   Quote,
   QuoteCache,
@@ -14,17 +15,19 @@ import type {
 export {
   selectAssetById,
   selectCashBalance,
+  selectOpeningPositionsForAsset,
   selectQuoteForAsset,
   selectTradesForAsset,
 } from "./selectors";
 
 export const portfolioStorageKey = "cogvest:v1:portfolio";
 export const quoteCacheStorageKey = "cogvest:v1:quote-cache";
-export const portfolioSchemaVersion = 1;
+export const portfolioSchemaVersion = 2;
 
 export type RawPortfolioSnapshot = {
   assets: Asset[];
   cashEntries: CashEntry[];
+  openingPositions: OpeningPosition[];
   preferences: Preferences;
   schemaVersion: typeof portfolioSchemaVersion;
   trades: Trade[];
@@ -33,14 +36,17 @@ export type RawPortfolioSnapshot = {
 export type PortfolioStoreState = RawPortfolioSnapshot & {
   addAsset: (asset: Asset) => void;
   addCashEntry: (cashEntry: CashEntry) => void;
+  addOpeningPosition: (openingPosition: OpeningPosition) => void;
   addTrade: (trade: Trade) => void;
   clearQuoteCache: () => void;
   quoteCache: QuoteCache;
   removeAsset: (assetId: string) => void;
   removeCashEntry: (cashEntryId: string) => void;
+  removeOpeningPosition: (openingPositionId: string) => void;
   removeTrade: (tradeId: string) => void;
   updateAsset: (asset: Asset) => void;
   updateCashEntry: (cashEntry: CashEntry) => void;
+  updateOpeningPosition: (openingPosition: OpeningPosition) => void;
   updatePreferences: (preferences: Partial<Preferences>) => void;
   updateTrade: (trade: Trade) => void;
   upsertQuote: (quote: Quote) => void;
@@ -62,24 +68,32 @@ export function createEmptyPortfolioSnapshot(): RawPortfolioSnapshot {
   return {
     assets: [],
     cashEntries: [],
+    openingPositions: [],
     preferences: createDefaultPreferences(),
     schemaVersion: portfolioSchemaVersion,
     trades: [],
   };
 }
 
+type StoredPortfolioSnapshot = Partial<
+  Omit<RawPortfolioSnapshot, "schemaVersion">
+> & {
+  schemaVersion?: number;
+};
+
 function readPortfolioSnapshot(storage: JsonStorage): RawPortfolioSnapshot {
-  const stored = storage.getItem<RawPortfolioSnapshot & JsonValue>(
+  const stored = storage.getItem<StoredPortfolioSnapshot & JsonValue>(
     portfolioStorageKey,
   );
 
-  if (!stored || stored.schemaVersion !== portfolioSchemaVersion) {
+  if (!stored || ![1, portfolioSchemaVersion].includes(stored.schemaVersion ?? 0)) {
     return createEmptyPortfolioSnapshot();
   }
 
   return {
     assets: stored.assets ?? [],
     cashEntries: stored.cashEntries ?? [],
+    openingPositions: stored.openingPositions ?? [],
     preferences: {
       ...createDefaultPreferences(),
       ...stored.preferences,
@@ -99,6 +113,7 @@ function selectRawSnapshot(
   return {
     assets: state.assets,
     cashEntries: state.cashEntries,
+    openingPositions: state.openingPositions,
     preferences: state.preferences,
     schemaVersion: portfolioSchemaVersion,
     trades: state.trades,
@@ -132,6 +147,12 @@ export function createPortfolioStore({
       set((state) => ({ cashEntries: [...state.cashEntries, cashEntry] }));
       persistPortfolio(storage, get());
     },
+    addOpeningPosition: (openingPosition) => {
+      set((state) => ({
+        openingPositions: [...state.openingPositions, openingPosition],
+      }));
+      persistPortfolio(storage, get());
+    },
     addTrade: (trade) => {
       set((state) => ({ trades: [...state.trades, trade] }));
       persistPortfolio(storage, get());
@@ -155,6 +176,14 @@ export function createPortfolioStore({
       }));
       persistPortfolio(storage, get());
     },
+    removeOpeningPosition: (openingPositionId) => {
+      set((state) => ({
+        openingPositions: state.openingPositions.filter(
+          (openingPosition) => openingPosition.id !== openingPositionId,
+        ),
+      }));
+      persistPortfolio(storage, get());
+    },
     removeTrade: (tradeId) => {
       set((state) => ({
         trades: state.trades.filter((trade) => trade.id !== tradeId),
@@ -174,6 +203,16 @@ export function createPortfolioStore({
       set((state) => ({
         cashEntries: state.cashEntries.map((currentEntry) =>
           currentEntry.id === cashEntry.id ? cashEntry : currentEntry,
+        ),
+      }));
+      persistPortfolio(storage, get());
+    },
+    updateOpeningPosition: (openingPosition) => {
+      set((state) => ({
+        openingPositions: state.openingPositions.map((currentPosition) =>
+          currentPosition.id === openingPosition.id
+            ? openingPosition
+            : currentPosition,
         ),
       }));
       persistPortfolio(storage, get());

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -1,4 +1,10 @@
-import type { Asset, CashEntry, QuoteCache, Trade } from "@/src/types";
+import type {
+  Asset,
+  CashEntry,
+  OpeningPosition,
+  QuoteCache,
+  Trade,
+} from "@/src/types";
 
 export function selectAssetById(assets: Asset[], assetId: string) {
   return assets.find((asset) => asset.id === assetId) ?? null;
@@ -6,6 +12,13 @@ export function selectAssetById(assets: Asset[], assetId: string) {
 
 export function selectTradesForAsset(trades: Trade[], assetId: string) {
   return trades.filter((trade) => trade.assetId === assetId);
+}
+
+export function selectOpeningPositionsForAsset(
+  openingPositions: OpeningPosition[],
+  assetId: string,
+) {
+  return openingPositions.filter((position) => position.assetId === assetId);
 }
 
 export function selectCashBalance(cashEntries: CashEntry[]) {

--- a/src/types/asset.ts
+++ b/src/types/asset.ts
@@ -1,4 +1,4 @@
-export type AssetClass = "crypto" | "stock" | "etf" | "cash";
+export type AssetClass = "crypto" | "debt" | "stock" | "etf" | "cash";
 
 export type Currency = "INR" | "USD";
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export type { Asset, AssetClass, AssetExchange, Currency } from "./asset";
 export type { CashEntry, CashEntryType } from "./cash";
 export type { Holding } from "./holding";
+export type { OpeningPosition } from "./openingPosition";
 export type { ChartRange, Preferences } from "./preferences";
 export type { Quote, QuoteCache, QuoteSource } from "./quote";
 export type { ConvictionScore, Trade, TradeType } from "./trade";

--- a/src/types/openingPosition.ts
+++ b/src/types/openingPosition.ts
@@ -1,0 +1,12 @@
+import type { ConvictionScore } from "./trade";
+
+export type OpeningPosition = {
+  assetId: string;
+  averageCostPrice: number;
+  conviction?: ConvictionScore;
+  currentPrice?: number;
+  date: string;
+  id: string;
+  notes?: string;
+  quantity: number;
+};


### PR DESCRIPTION
## Summary
- Add raw opening-position records with schema migration and persistence actions
- Derive holdings/dashboard/progress/allocation from opening positions plus trades
- Replace secondary Add Holding route with an opening-position form and derived preview

## Verification
- npm run typecheck
- npm test
- npm run doctor
- git diff --check

Closes #61