### PR TITLE
[V1] Build consolidated portfolio rollups

### DIFF
--- a/docs/superpowers/plans/2026-05-10-issue-64-consolidated-rollups.md
+++ b/docs/superpowers/plans/2026-05-10-issue-64-consolidated-rollups.md
@@ -1,0 +1,61 @@
+# Issue 64 Consolidated Rollups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Derive consolidated portfolio rows and allocation details equivalent to the useful parts of Excel `All`.
+
+**Architecture:** Add pure rollup helpers in domain calculations, expose them through dashboard/holdings hooks, and render compact premium summary cards. Keep persistence unchanged.
+
+**Tech Stack:** TypeScript, Expo React Native, Zustand vanilla store, Jest, React Native Testing Library.
+
+---
+
+### Task 1: Domain Consolidated Rows
+
+**Files:**
+- Modify: `src/domain/calculations/holdings.ts`
+- Modify: `src/domain/calculations/index.ts`
+- Test: `src/domain/calculations/__tests__/holdings.test.ts`
+
+- [x] Add `ConsolidatedHoldingRow` and `PortfolioRollupTotals`.
+- [x] Add `calculateConsolidatedHoldingRows(holdings)`.
+- [x] Add `calculatePortfolioRollupTotals(rows, cashBalance?)`.
+- [x] Test invested/current/P&L/P&L % and initial/current allocation.
+
+### Task 2: Hook Wiring
+
+**Files:**
+- Modify: `src/features/dashboard/useDashboard.ts`
+- Modify: `src/features/holdings/useHoldings.ts`
+- Test: `src/features/dashboard/__tests__/useDashboard.test.tsx`
+- Test: `src/features/holdings/__tests__/useHoldings.test.tsx`
+
+- [x] Expose consolidated rows and rollup totals from dashboard.
+- [x] Expose consolidated rows and totals from holdings.
+- [x] Keep existing API fields compatible where tests depend on them.
+
+### Task 3: UI Summaries
+
+**Files:**
+- Modify: `src/features/dashboard/DashboardScreen.tsx`
+- Modify: `src/features/holdings/HoldingsScreen.tsx`
+- Modify: `src/components/cards/HoldingCard.tsx`
+- Test: `src/features/dashboard/__tests__/DashboardScreen.test.tsx`
+- Test: `src/features/holdings/__tests__/HoldingsScreen.test.tsx`
+
+- [x] Dashboard uses rollup totals for invested/P&L/P&L %.
+- [x] Dashboard shows compact sector/instrument snapshots when available.
+- [x] Holding cards show invested value, current allocation, and initial allocation.
+- [x] Holdings summary includes P&L % without adding a table.
+
+### Task 4: Verification And Delivery
+
+**Commands:**
+- `npm run typecheck`
+- `npm test`
+- `npm run doctor`
+- `git diff --check`
+
+- [x] Verify all commands.
+- [ ] Commit on `v1/issue-64-consolidated-rollups`.
+- [ ] Push and open PR with `Closes #64`.

--- a/docs/superpowers/specs/2026-05-10-issue-64-consolidated-rollups.md
+++ b/docs/superpowers/specs/2026-05-10-issue-64-consolidated-rollups.md
@@ -1,0 +1,19 @@
+# Issue 64 Consolidated Rollups Design
+
+## Goal
+Add Excel `All` sheet parity through derived consolidated portfolio rows and totals without adding a spreadsheet grid.
+
+## Domain Model
+Create pure calculation helpers that derive a `ConsolidatedHoldingRow` per holding. Each row includes invested value, current value, P&L, P&L %, initial allocation, current allocation, asset class, instrument type, and sector type.
+
+Create portfolio totals from those rows: total invested, total current value, P&L, P&L %, plus cash-inclusive current value where needed.
+
+## UI
+Dashboard should use consolidated totals for the hero metric group and show lightweight sector/instrument snapshots. Holdings should show both invested/current allocation values through the existing card list, not a dense table.
+
+## Persistence
+No rollups or allocation totals are persisted. Raw assets, opening positions, trades, cash, and quote/manual prices remain the only source data.
+
+## Testing
+Cover consolidated row calculations, initial/current allocation percentages, metadata grouping, and screen rendering of the new summary values.
+

--- a/src/components/cards/HoldingCard.tsx
+++ b/src/components/cards/HoldingCard.tsx
@@ -9,6 +9,7 @@ import { AppText, MaskedValue } from "../common";
 
 type HoldingCardProps = {
   allocationPct?: number;
+  initialAllocationPct?: number;
   holding: Holding;
   masked?: boolean;
 };
@@ -25,6 +26,7 @@ function formatPnLAmount(holding: Holding) {
 
 export function HoldingCard({
   allocationPct,
+  initialAllocationPct,
   holding,
   masked = false,
 }: HoldingCardProps) {
@@ -76,6 +78,14 @@ export function HoldingCard({
 
       <View style={styles.metrics}>
         <AppText color="secondary">Qty {formatQuantity(holding.totalUnits)}</AppText>
+        <AppText color="secondary">
+          Invested {formatINR(holding.totalInvested)}
+        </AppText>
+        {initialAllocationPct !== undefined ? (
+          <AppText color="secondary">
+            Initial {formatPercentage(initialAllocationPct).replace("+", "")}
+          </AppText>
+        ) : null}
         <AppText color="secondary">
           Avg {formatINR(holding.averageCostPrice)}
         </AppText>

--- a/src/domain/calculations/__tests__/holdings.test.ts
+++ b/src/domain/calculations/__tests__/holdings.test.ts
@@ -1,10 +1,12 @@
 import {
   calculateAllocation,
   calculateCashBalance,
+  calculateConsolidatedHoldingRows,
   calculateHolding,
   calculateHoldings,
   calculateInstrumentAllocation,
   calculatePortfolioDayChange,
+  calculatePortfolioRollupTotals,
   calculatePortfolioTotal,
   calculateSectorAllocation,
   daysHeld,
@@ -406,6 +408,65 @@ describe("portfolio calculations", () => {
       { label: "digitalAsset", percentage: 80.65, value: 5000 },
       { label: "energy", percentage: 19.35, value: 1200 },
     ]);
+  });
+
+  it("derives consolidated rows and rollup totals without persisting them", () => {
+    const stockHolding = calculateHolding({
+      asset: reliance,
+      currentPrice: 120,
+      trades: [trade({ quantity: 10, totalValue: 1000 })],
+    });
+    const debtHolding = calculateHolding({
+      asset: ppf,
+      currentPrice: 1000,
+      openingPositions: [
+        openingPosition({
+          assetId: ppf.id,
+          averageCostPrice: 950,
+          quantity: 2,
+        }),
+      ],
+      trades: [],
+    });
+
+    const rows = calculateConsolidatedHoldingRows([stockHolding, debtHolding]);
+
+    expect(rows).toEqual([
+      {
+        asset: ppf,
+        assetClass: "debt",
+        currentAllocationPct: 62.5,
+        currentValue: 2000,
+        initialAllocationPct: 65.52,
+        instrumentType: "ppf",
+        investedValue: 1900,
+        pnl: 100,
+        pnlPct: 5.26,
+        sectorType: "fixedIncome",
+        units: 2,
+      },
+      {
+        asset: reliance,
+        assetClass: "stock",
+        currentAllocationPct: 37.5,
+        currentValue: 1200,
+        initialAllocationPct: 34.48,
+        instrumentType: "stock",
+        investedValue: 1000,
+        pnl: 200,
+        pnlPct: 20,
+        sectorType: "energy",
+        units: 10,
+      },
+    ]);
+    expect(calculatePortfolioRollupTotals(rows, 300)).toEqual({
+      cashBalance: 300,
+      holdingsCurrentValue: 3200,
+      pnl: 300,
+      pnlPct: 10.34,
+      totalCurrentValue: 3500,
+      totalInvested: 2900,
+    });
   });
 });
 

--- a/src/domain/calculations/holdings.ts
+++ b/src/domain/calculations/holdings.ts
@@ -34,6 +34,29 @@ export type MetadataAllocationItem = {
   value: number;
 };
 
+export type ConsolidatedHoldingRow = {
+  asset: Asset;
+  assetClass: AssetClass;
+  currentAllocationPct: number;
+  currentValue: number;
+  initialAllocationPct: number;
+  instrumentType?: Asset["instrumentType"];
+  investedValue: number;
+  pnl: number;
+  pnlPct: number;
+  sectorType?: Asset["sectorType"];
+  units: number;
+};
+
+export type PortfolioRollupTotals = {
+  cashBalance: number;
+  holdingsCurrentValue: number;
+  pnl: number;
+  pnlPct: number;
+  totalCurrentValue: number;
+  totalInvested: number;
+};
+
 export type PortfolioDayChange = {
   absolute: number;
   percentage: number;
@@ -242,6 +265,65 @@ export function calculateAllocation({
       value,
     }))
     .sort((left, right) => right.value - left.value);
+}
+
+export function calculateConsolidatedHoldingRows(
+  holdings: Holding[],
+): ConsolidatedHoldingRow[] {
+  const totalInvested = holdings.reduce(
+    (total, holding) => total + holding.totalInvested,
+    0,
+  );
+  const totalCurrentValue = holdings.reduce(
+    (total, holding) => total + holding.currentValue,
+    0,
+  );
+
+  return holdings
+    .map((holding) => ({
+      asset: holding.asset,
+      assetClass: holding.asset.assetClass,
+      currentAllocationPct:
+        totalCurrentValue === 0
+          ? 0
+          : round((holding.currentValue / totalCurrentValue) * 100),
+      currentValue: holding.currentValue,
+      initialAllocationPct:
+        totalInvested === 0
+          ? 0
+          : round((holding.totalInvested / totalInvested) * 100),
+      instrumentType: holding.asset.instrumentType,
+      investedValue: holding.totalInvested,
+      pnl: holding.unrealisedPnL,
+      pnlPct: round(holding.unrealisedPnLPct),
+      sectorType: holding.asset.sectorType,
+      units: holding.totalUnits,
+    }))
+    .sort((left, right) => right.currentValue - left.currentValue);
+}
+
+export function calculatePortfolioRollupTotals(
+  rows: ConsolidatedHoldingRow[],
+  cashBalance = 0,
+): PortfolioRollupTotals {
+  const totalInvested = rows.reduce(
+    (total, row) => total + row.investedValue,
+    0,
+  );
+  const holdingsCurrentValue = rows.reduce(
+    (total, row) => total + row.currentValue,
+    0,
+  );
+  const pnl = holdingsCurrentValue - totalInvested;
+
+  return {
+    cashBalance,
+    holdingsCurrentValue,
+    pnl,
+    pnlPct: totalInvested === 0 ? 0 : round((pnl / totalInvested) * 100),
+    totalCurrentValue: holdingsCurrentValue + cashBalance,
+    totalInvested,
+  };
 }
 
 export function calculateMetadataAllocation(

--- a/src/domain/calculations/index.ts
+++ b/src/domain/calculations/index.ts
@@ -1,10 +1,12 @@
 export {
   calculateAllocation,
   calculateCashBalance,
+  calculateConsolidatedHoldingRows,
   calculateHolding,
   calculateHoldings,
   calculateInstrumentAllocation,
   calculateMetadataAllocation,
+  calculatePortfolioRollupTotals,
   calculatePortfolioDayChange,
   calculatePortfolioTotal,
   calculateSectorAllocation,
@@ -13,7 +15,9 @@ export {
 } from "./holdings";
 export type {
   AllocationItem,
+  ConsolidatedHoldingRow,
   ConvictionReadiness,
   MetadataAllocationItem,
+  PortfolioRollupTotals,
   PortfolioDayChange,
 } from "./holdings";

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -44,15 +44,11 @@ export function DashboardScreen({
   const dashboard = useDashboard({ store });
   const hasAllocation = dashboard.allocation.length > 0;
   const dayChangeAmount = formatSignedINR(dashboard.dayChange.absolute);
-  const totalInvested = dashboard.holdings.reduce(
-    (total, holding) => total + holding.totalInvested,
-    0,
-  );
-  const totalPnL = dashboard.holdings.reduce(
-    (total, holding) => total + holding.unrealisedPnL,
-    0,
-  );
-  const totalPnLPct = totalInvested === 0 ? 0 : (totalPnL / totalInvested) * 100;
+  const totalInvested = dashboard.rollupTotals.totalInvested;
+  const totalPnL = dashboard.rollupTotals.pnl;
+  const totalPnLPct = dashboard.rollupTotals.pnlPct;
+  const sectorSnapshot = dashboard.sectorAllocation.slice(0, 3);
+  const instrumentSnapshot = dashboard.instrumentAllocation.slice(0, 3);
 
   return (
     <ScreenContainer scroll testID="dashboard-screen">
@@ -97,6 +93,54 @@ export function DashboardScreen({
             },
           ]}
         />
+
+        {sectorSnapshot.length > 0 || instrumentSnapshot.length > 0 ? (
+          <PremiumCard>
+            <SectionHeader title="Portfolio Rollups" />
+            {sectorSnapshot.length > 0 ? (
+              <View style={styles.rollupGroup}>
+                <AppText color="secondary" variant="caption" weight="medium">
+                  Top sectors
+                </AppText>
+                {sectorSnapshot.map((item) => (
+                  <View key={item.label} style={styles.rollupRow}>
+                    <AppText weight="bold">{item.label}</AppText>
+                    <MaskedValue
+                      align="right"
+                      color="secondary"
+                      masked={dashboard.maskWealthValues}
+                      value={`${formatINR(item.value)} · ${formatUnsignedPercentage(
+                        item.percentage,
+                      )}`}
+                      variant="caption"
+                    />
+                  </View>
+                ))}
+              </View>
+            ) : null}
+            {instrumentSnapshot.length > 0 ? (
+              <View style={styles.rollupGroup}>
+                <AppText color="secondary" variant="caption" weight="medium">
+                  Top instruments
+                </AppText>
+                {instrumentSnapshot.map((item) => (
+                  <View key={item.label} style={styles.rollupRow}>
+                    <AppText weight="bold">{item.label}</AppText>
+                    <MaskedValue
+                      align="right"
+                      color="secondary"
+                      masked={dashboard.maskWealthValues}
+                      value={`${formatINR(item.value)} · ${formatUnsignedPercentage(
+                        item.percentage,
+                      )}`}
+                      variant="caption"
+                    />
+                  </View>
+                ))}
+              </View>
+            ) : null}
+          </PremiumCard>
+        ) : null}
 
         {onAddTrade && hasAllocation ? (
           <AppButton
@@ -212,5 +256,14 @@ const styles = StyleSheet.create({
     gap: spacing.cardGap,
     paddingBottom: spacing.lg,
     paddingTop: spacing.md,
+  },
+  rollupGroup: {
+    gap: spacing.sm,
+  },
+  rollupRow: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: spacing.md,
+    justifyContent: "space-between",
   },
 });

--- a/src/features/dashboard/__tests__/DashboardScreen.test.tsx
+++ b/src/features/dashboard/__tests__/DashboardScreen.test.tsx
@@ -71,6 +71,9 @@ describe("DashboardScreen", () => {
     const { getByText, queryByText } = render(<DashboardScreen store={store} />);
 
     expect(getByText("₹350.00")).toBeTruthy();
+    expect(getByText("Portfolio Rollups")).toBeTruthy();
+    expect(getByText("Top sectors")).toBeTruthy();
+    expect(getByText("Top instruments")).toBeTruthy();
     expect(getByText("+₹27.27 (+10.00%) today")).toBeTruthy();
     expect(getByText("Equity")).toBeTruthy();
     expect(getByText("85.71%")).toBeTruthy();

--- a/src/features/dashboard/__tests__/useDashboard.test.tsx
+++ b/src/features/dashboard/__tests__/useDashboard.test.tsx
@@ -80,6 +80,14 @@ describe("useDashboard", () => {
     const { result } = renderHook(() => useDashboard({ store }));
 
     expect(result.current.totalValue).toBe(550);
+    expect(result.current.rollupTotals).toEqual({
+      cashBalance: 50,
+      holdingsCurrentValue: 500,
+      pnl: 200,
+      pnlPct: 66.67,
+      totalCurrentValue: 550,
+      totalInvested: 300,
+    });
     expect(result.current.cashBalance).toBe(50);
     expect(result.current.dayChange).toEqual({
       absolute: 16.75,
@@ -108,6 +116,26 @@ describe("useDashboard", () => {
       ratedTradeCount: 1,
       requiredTradeCount: 5,
     });
+    expect(result.current.rollupRows).toMatchObject([
+      {
+        asset: stockAsset,
+        currentAllocationPct: 60,
+        currentValue: 300,
+        initialAllocationPct: 66.67,
+        investedValue: 200,
+        pnl: 100,
+        pnlPct: 50,
+      },
+      {
+        asset: etfAsset,
+        currentAllocationPct: 40,
+        currentValue: 200,
+        initialAllocationPct: 33.33,
+        investedValue: 100,
+        pnl: 100,
+        pnlPct: 100,
+      },
+    ]);
   });
 
   it("includes debt and crypto opening positions in consolidated allocation", () => {
@@ -175,6 +203,14 @@ describe("useDashboard", () => {
       { assetClass: "crypto", percentage: 48, value: 120000 },
       { assetClass: "debt", percentage: 40, value: 100000 },
       { assetClass: "cash", percentage: 12, value: 30000 },
+    ]);
+    expect(result.current.instrumentAllocation).toEqual([
+      { label: "crypto", percentage: 54.55, value: 120000 },
+      { label: "ppf", percentage: 45.45, value: 100000 },
+    ]);
+    expect(result.current.sectorAllocation).toEqual([
+      { label: "digitalAsset", percentage: 54.55, value: 120000 },
+      { label: "fixedIncome", percentage: 45.45, value: 100000 },
     ]);
   });
 });

--- a/src/features/dashboard/useDashboard.ts
+++ b/src/features/dashboard/useDashboard.ts
@@ -4,13 +4,20 @@ import type { StoreApi } from "zustand/vanilla";
 import {
   calculateAllocation,
   calculateCashBalance,
+  calculateConsolidatedHoldingRows,
   calculateHoldings,
+  calculateInstrumentAllocation,
   calculatePortfolioDayChange,
+  calculatePortfolioRollupTotals,
   calculatePortfolioTotal,
+  calculateSectorAllocation,
   getConvictionReadiness,
   type AllocationItem,
+  type ConsolidatedHoldingRow,
   type ConvictionReadiness,
+  type MetadataAllocationItem,
   type PortfolioDayChange,
+  type PortfolioRollupTotals,
 } from "@/src/domain/calculations";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
 import type { Holding } from "@/src/types";
@@ -25,8 +32,12 @@ export type DashboardState = {
   convictionReadiness: ConvictionReadiness;
   dayChange: PortfolioDayChange;
   holdings: Holding[];
+  instrumentAllocation: MetadataAllocationItem[];
   latestQuoteAsOf?: string;
   maskWealthValues: boolean;
+  rollupRows: ConsolidatedHoldingRow[];
+  rollupTotals: PortfolioRollupTotals;
+  sectorAllocation: MetadataAllocationItem[];
   totalValue: number;
 };
 
@@ -70,6 +81,8 @@ export function useDashboard({
     snapshot.quoteCache,
   );
   const cashBalance = calculateCashBalance(snapshot.cashEntries);
+  const rollupRows = calculateConsolidatedHoldingRows(holdings);
+  const rollupTotals = calculatePortfolioRollupTotals(rollupRows, cashBalance);
 
   return {
     allocation: calculateAllocation({
@@ -84,8 +97,12 @@ export function useDashboard({
     ),
     dayChange: calculatePortfolioDayChange(holdings),
     holdings,
+    instrumentAllocation: calculateInstrumentAllocation(holdings),
     latestQuoteAsOf: getLatestQuoteAsOf(holdings),
     maskWealthValues: snapshot.preferences.maskWealthValues,
+    rollupRows,
+    rollupTotals,
+    sectorAllocation: calculateSectorAllocation(holdings),
     totalValue: calculatePortfolioTotal(holdings, snapshot.cashEntries),
   };
 }

--- a/src/features/holdings/HoldingsScreen.tsx
+++ b/src/features/holdings/HoldingsScreen.tsx
@@ -34,18 +34,22 @@ export function HoldingsScreen({
   refreshQuotes,
   store = getPortfolioStore(),
 }: HoldingsScreenProps) {
-  const { failures, holdings, isRefreshing, maskWealthValues, refresh } = useHoldings({
+  const {
+    failures,
+    holdings,
+    isRefreshing,
+    maskWealthValues,
+    refresh,
+    rollupRows,
+    rollupTotals,
+  } = useHoldings({
     refreshQuotes,
     store,
   });
-  const totalCurrentValue = holdings.reduce(
-    (total, holding) => total + holding.currentValue,
-    0,
-  );
-  const totalInvested = holdings.reduce(
-    (total, holding) => total + holding.totalInvested,
-    0,
-  );
+
+  function getRollupRow(assetId: string) {
+    return rollupRows.find((row) => row.asset.id === assetId);
+  }
 
   return (
     <ScreenContainer
@@ -81,17 +85,21 @@ export function HoldingsScreen({
               {
                 label: "Current",
                 masked: maskWealthValues,
-                value: formatINR(totalCurrentValue),
+                value: formatINR(rollupTotals.holdingsCurrentValue),
               },
               {
                 label: "Invested",
                 masked: maskWealthValues,
-                value: formatINR(totalInvested),
+                value: formatINR(rollupTotals.totalInvested),
               },
               {
                 label: "P&L",
                 masked: maskWealthValues,
-                value: formatINR(totalCurrentValue - totalInvested),
+                value: formatINR(rollupTotals.pnl),
+              },
+              {
+                label: "P&L %",
+                value: `${rollupTotals.pnlPct.toFixed(2)}%`,
               },
             ]}
           />
@@ -137,11 +145,12 @@ export function HoldingsScreen({
               <HoldingCard
                 key={holding.asset.id}
                 allocationPct={
-                  totalCurrentValue === 0
-                    ? 0
-                    : (holding.currentValue / totalCurrentValue) * 100
+                  getRollupRow(holding.asset.id)?.currentAllocationPct ?? 0
                 }
                 holding={holding}
+                initialAllocationPct={
+                  getRollupRow(holding.asset.id)?.initialAllocationPct ?? 0
+                }
                 masked={maskWealthValues}
               />
             ))}

--- a/src/features/holdings/__tests__/HoldingsScreen.test.tsx
+++ b/src/features/holdings/__tests__/HoldingsScreen.test.tsx
@@ -65,6 +65,8 @@ describe("HoldingsScreen", () => {
     expect(getByText("Reliance Industries")).toBeTruthy();
     expect(getByText("RELIANCE")).toBeTruthy();
     expect(getByText("Qty 2")).toBeTruthy();
+    expect(getByText("Invested ₹200.00")).toBeTruthy();
+    expect(getByText("Initial 100.00%")).toBeTruthy();
     expect(getByText("Avg ₹100.00")).toBeTruthy();
     expect(getAllByText("₹250.00").length).toBeGreaterThan(0);
     expect(getByText("+₹50.00")).toBeTruthy();

--- a/src/features/holdings/__tests__/useHoldings.test.tsx
+++ b/src/features/holdings/__tests__/useHoldings.test.tsx
@@ -60,6 +60,22 @@ describe("useHoldings", () => {
       unrealisedPnL: 50,
       unrealisedPnLPct: 25,
     });
+    expect(result.current.rollupTotals).toEqual({
+      cashBalance: 0,
+      holdingsCurrentValue: 250,
+      pnl: 50,
+      pnlPct: 25,
+      totalCurrentValue: 250,
+      totalInvested: 200,
+    });
+    expect(result.current.rollupRows[0]).toMatchObject({
+      currentAllocationPct: 100,
+      currentValue: 250,
+      initialAllocationPct: 100,
+      investedValue: 200,
+      pnl: 50,
+      pnlPct: 25,
+    });
   });
 
   it("refreshes quotes and persists the updated values into the store", async () => {

--- a/src/features/holdings/useHoldings.ts
+++ b/src/features/holdings/useHoldings.ts
@@ -1,7 +1,13 @@
 import { useState, useSyncExternalStore } from "react";
 import type { StoreApi } from "zustand/vanilla";
 
-import { calculateHoldings } from "@/src/domain/calculations";
+import {
+  calculateConsolidatedHoldingRows,
+  calculateHoldings,
+  calculatePortfolioRollupTotals,
+  type ConsolidatedHoldingRow,
+  type PortfolioRollupTotals,
+} from "@/src/domain/calculations";
 import {
   refreshQuotes as defaultRefreshQuotes,
   type QuoteRefreshFailure,
@@ -26,6 +32,8 @@ export type UseHoldingsResult = {
   isRefreshing: boolean;
   maskWealthValues: boolean;
   refresh: () => Promise<QuoteRefreshResult>;
+  rollupRows: ConsolidatedHoldingRow[];
+  rollupTotals: PortfolioRollupTotals;
 };
 
 function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
@@ -72,6 +80,8 @@ export function useHoldings({
     }),
     snapshot.quoteCache,
   );
+  const rollupRows = calculateConsolidatedHoldingRows(holdings);
+  const rollupTotals = calculatePortfolioRollupTotals(rollupRows);
 
   async function refresh() {
     setIsRefreshing(true);
@@ -101,5 +111,7 @@ export function useHoldings({
     isRefreshing,
     maskWealthValues: snapshot.preferences.maskWealthValues,
     refresh,
+    rollupRows,
+    rollupTotals,
   };
 }


### PR DESCRIPTION
## Summary
- add pure consolidated holding row and portfolio rollup calculations
- expose rollup totals, sector allocation, and instrument allocation through dashboard and holdings hooks
- surface invested, P&L, current allocation, initial allocation, and compact rollup summaries in V1 screens

## Verification
- npm run typecheck
- npm test
- npm run doctor
- git diff --check (line-ending warnings only)

Closes #64