### PR TITLE
[V1] Add asset lookup autofill

### DIFF
--- a/docs/superpowers/plans/2026-05-10-issue-84-asset-lookup-autofill.md
+++ b/docs/superpowers/plans/2026-05-10-issue-84-asset-lookup-autofill.md
@@ -1,0 +1,49 @@
+# Issue 84 Asset Lookup Autofill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add lightweight asset lookup and current-price autofill to Add Holding while preserving manual entry fallback.
+
+**Architecture:** Create a focused `src/services/assetLookup/` service that normalizes Yahoo Finance and CoinGecko search responses. Inject lookup and quote dependencies into `AddOpeningPositionForm` so UI behavior is testable without live network calls.
+
+**Tech Stack:** React Native, Expo Router, TypeScript, Jest, React Native Testing Library, existing quote resolver.
+
+---
+
+### Task 1: Asset Lookup Service
+
+**Files:**
+- Create: `src/services/assetLookup/index.ts`
+- Create: `src/services/assetLookup/__tests__/assetLookup.test.ts`
+
+- [x] Define `AssetLookupResult`, provider response types, and URL builders for Yahoo search and CoinGecko search.
+- [x] Write tests for mapping NSE stock, ETF, crypto coin, and provider failure.
+- [x] Implement provider-specific mapping and `searchAssetLookupResults`.
+- [x] Export the service from `src/services/assetLookup/index.ts`.
+
+### Task 2: Add Holding Dependency Injection And Autofill
+
+**Files:**
+- Modify: `src/features/openingPositions/AddOpeningPositionForm.tsx`
+- Modify: `src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx`
+
+- [x] Extend form props with optional lookup and quote resolver functions.
+- [x] Add debounced lookup state and result rendering.
+- [x] On result selection, fill asset metadata and fetch one live quote.
+- [x] Show non-blocking status text for lookup and quote success/failure.
+- [x] Add tests for successful lookup+price autofill and quote failure manual fallback.
+- [x] Re-run existing manual asset tests to confirm no regression.
+
+### Task 3: Verification And Delivery
+
+**Commands:**
+- `npm test -- --runTestsByPath src/services/assetLookup/__tests__/assetLookup.test.ts src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx`
+- `npm run typecheck`
+- `npm test`
+- `npm run doctor`
+- `git diff --check`
+
+- [x] Verify focused tests.
+- [x] Verify full static/test/doctor suite.
+- [ ] Commit on `v1/issue-84-asset-lookup-autofill`.
+- [ ] Push and open PR with `Closes #84`.

--- a/docs/superpowers/specs/2026-05-10-issue-84-asset-lookup-autofill.md
+++ b/docs/superpowers/specs/2026-05-10-issue-84-asset-lookup-autofill.md
@@ -1,0 +1,64 @@
+# Issue 84 Asset Lookup And Price Autofill Design
+
+## Goal
+Reduce Add Holding friction by letting users search for assets by familiar names or symbols, select a result, and autofill the technical fields CogVest needs for quote fetching.
+
+## Scope
+This issue improves the current Add Holding screen only. It does not implement the broader multi-phase Add Holding redesign from issue #79.
+
+In scope:
+- Search public asset metadata from Yahoo Finance and CoinGecko.
+- Show concise result rows with provider, name, symbol/ticker, and asset class.
+- Autofill asset name, symbol, ticker, quote source ID, asset class, exchange, currency, instrument type, and sector defaults when a result is selected.
+- Try fetching the current price for the selected result.
+- Populate current price when quote fetching succeeds.
+- Keep manual entry and manual current-price fallback fully available.
+- Debounce remote lookup input.
+- Avoid sending local portfolio holdings, quantities, costs, cash, notes, or conviction data to lookup providers.
+
+Out of scope:
+- Logos.
+- Advanced ranking.
+- Exchange picker.
+- Import/export.
+- Full V3 advanced asset search.
+- Replacing the current Add Holding layout with the issue #79 multi-phase flow.
+
+## Data Flow
+`AddOpeningPositionForm` owns the UI state. It calls a new lookup service with only the search query. The lookup service returns normalized `AssetLookupResult` objects. When the user selects a result, the form builds a temporary `Asset`, fills form fields from that metadata, and calls the existing quote resolver to fetch one current price.
+
+The app persists nothing until the user reviews and saves the holding. Existing manual save behavior remains unchanged.
+
+## Lookup Providers
+Yahoo Finance search is used for stocks and ETFs. NSE `.NS` and BSE `.BO` symbols map to INR assets and known exchanges. ETF quote types map to ETF metadata; other equity-like results map to stock metadata.
+
+CoinGecko search is used for crypto assets. CoinGecko coin IDs are preserved as `quoteSourceId` so existing CoinGecko simple-price quote fetching works.
+
+Provider failures are non-fatal. If one provider fails, the other provider can still return results. If both fail, the UI shows a calm warning and manual entry remains available.
+
+## UI Behavior
+Add Holding gets an asset lookup field above manual asset fields:
+- Empty query: no network call.
+- Fewer than two characters: prompt to keep typing.
+- Debounced query: show loading copy and result rows.
+- Select result: fill metadata, attempt current price, and show whether live price autofill succeeded or manual price is still needed.
+
+Manual fields stay editable after selection. Editing manual metadata clears the selected existing asset/review state as it does today.
+
+## Testing
+Add unit tests for:
+- Yahoo result mapping for NSE stock and ETF-like results.
+- CoinGecko result mapping.
+- Partial provider failure.
+- Selected lookup result autofills Add Holding fields.
+- Successful quote lookup autofills current price.
+- Quote failure leaves manual price entry available.
+- Existing manual Add Holding path still works.
+
+## Acceptance Criteria
+- Users can search assets without knowing exact provider identifiers.
+- Selecting a result autofills the key Add Holding metadata fields.
+- Current price autofills when the quote provider returns a price.
+- Manual fallback still works when search or quote fetching fails.
+- No production portfolio data is sent to lookup services.
+- Typecheck and tests pass.

--- a/src/features/openingPositions/AddOpeningPositionForm.tsx
+++ b/src/features/openingPositions/AddOpeningPositionForm.tsx
@@ -1,5 +1,5 @@
 import * as Haptics from "expo-haptics";
-import { useMemo, useState, useSyncExternalStore } from "react";
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { Pressable, StyleSheet, View } from "react-native";
 import type { StoreApi } from "zustand/vanilla";
 
@@ -17,6 +17,16 @@ import { FormTextField } from "@/src/components/forms";
 import { getDefaultAssetMetadata } from "@/src/domain/assets";
 import { calculateHolding } from "@/src/domain/calculations";
 import { formatINR, formatPercentage } from "@/src/domain/formatters";
+import {
+  searchAssetLookupResults as defaultSearchAssetLookupResults,
+  type AssetLookupResult,
+  type AssetLookupSearchResult,
+} from "@/src/services/assetLookup";
+import {
+  resolveQuote as defaultResolveQuote,
+  type QuoteResult,
+  type ResolveQuoteInput,
+} from "@/src/services/quotes";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
 import { colors, interaction, radii, spacing } from "@/src/theme";
 import type {
@@ -32,6 +42,10 @@ import { createId } from "@/src/utils";
 import { validateOpeningPositionForm } from "./openingPositionForm";
 
 type AddOpeningPositionFormProps = {
+  resolveQuote?: (input: ResolveQuoteInput) => Promise<QuoteResult>;
+  searchAssetLookupResults?: (input: {
+    query: string;
+  }) => Promise<AssetLookupSearchResult>;
   store?: StoreApi<PortfolioStoreState>;
 };
 
@@ -55,9 +69,16 @@ function formatSignedINR(value: number) {
 }
 
 export function AddOpeningPositionForm({
+  resolveQuote = defaultResolveQuote,
+  searchAssetLookupResults = defaultSearchAssetLookupResults,
   store = getPortfolioStore(),
 }: AddOpeningPositionFormProps) {
   const snapshot = usePortfolioSnapshot(store);
+  const [lookupQuery, setLookupQuery] = useState("");
+  const [lookupResults, setLookupResults] = useState<AssetLookupResult[]>([]);
+  const [isLookupSearching, setIsLookupSearching] = useState(false);
+  const [lookupStatus, setLookupStatus] = useState("");
+  const [quoteStatus, setQuoteStatus] = useState("");
   const [selectedAssetId, setSelectedAssetId] = useState("");
   const [assetClass, setAssetClass] = useState<AssetClass>("stock");
   const [assetName, setAssetName] = useState("");
@@ -99,6 +120,64 @@ export function AddOpeningPositionForm({
     setSuccessMessage("");
   }
 
+  useEffect(() => {
+    const trimmedQuery = lookupQuery.trim();
+
+    if (trimmedQuery.length === 0) {
+      setLookupResults([]);
+      setLookupStatus("");
+      setIsLookupSearching(false);
+      return undefined;
+    }
+
+    if (trimmedQuery.length < 2) {
+      setLookupResults([]);
+      setLookupStatus("Type at least 2 characters to search.");
+      setIsLookupSearching(false);
+      return undefined;
+    }
+
+    let isCancelled = false;
+
+    setIsLookupSearching(true);
+    setLookupStatus("Searching public asset directories...");
+
+    const timeout = setTimeout(async () => {
+      try {
+        const result = await searchAssetLookupResults({ query: trimmedQuery });
+
+        if (isCancelled) {
+          return;
+        }
+
+        setLookupResults(result.results);
+        setLookupStatus(
+          result.results.length > 0
+            ? "Select a result to autofill asset details."
+            : "No public result found. You can enter details manually.",
+        );
+
+        if (result.failures.length > 0 && result.results.length === 0) {
+          setLookupStatus("Lookup unavailable. You can enter details manually.");
+        }
+      } catch {
+        if (!isCancelled) {
+          setLookupResults([]);
+          setLookupStatus("Lookup unavailable. You can enter details manually.");
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsLookupSearching(false);
+        }
+      }
+    }, 350);
+
+    return () => {
+      isCancelled = true;
+      clearTimeout(timeout);
+    };
+  }, [lookupQuery, searchAssetLookupResults]);
+
   function clearSelectedAsset() {
     if (selectedAssetId) {
       setSelectedAssetId("");
@@ -137,6 +216,45 @@ export function AddOpeningPositionForm({
       symbol: symbol.trim().toUpperCase(),
       ticker: assetClass === "crypto" ? trimmedTicker : trimmedTicker.toUpperCase(),
     };
+  }
+
+  function buildLookupAsset(result: AssetLookupResult): Asset {
+    return {
+      assetClass: result.assetClass,
+      currency: result.currency,
+      exchange: result.exchange,
+      id: createId("asset"),
+      instrumentType: result.instrumentType,
+      name: result.name,
+      quoteSourceId: result.quoteSourceId,
+      sectorType: result.sectorType,
+      symbol: result.symbol,
+      ticker: result.ticker,
+    };
+  }
+
+  async function selectLookupResult(result: AssetLookupResult) {
+    setSelectedAssetId("");
+    setAssetClass(result.assetClass);
+    setAssetName(result.name);
+    setInstrumentType(result.instrumentType);
+    setQuoteSourceId(result.quoteSourceId);
+    setSectorType(result.sectorType);
+    setSymbol(result.symbol);
+    setTicker(result.ticker);
+    setQuoteStatus("Fetching live current price...");
+    resetReview();
+
+    const quoteResult = await resolveQuote({ asset: buildLookupAsset(result) });
+
+    if (quoteResult.ok) {
+      setCurrentPrice(quoteResult.quote.price.toString());
+      setQuoteStatus(`Live price autofilled from ${result.sourceLabel}.`);
+      return;
+    }
+
+    setCurrentPrice("");
+    setQuoteStatus("Live price unavailable. Enter current price manually.");
   }
 
   function updateAssetClass(nextAssetClass: AssetClass) {
@@ -247,6 +365,55 @@ export function AddOpeningPositionForm({
 
       <PremiumCard>
         <SectionHeader title="Asset" />
+        <FormTextField
+          label="Search asset"
+          onChangeText={(value) => {
+            setLookupQuery(value);
+            setQuoteStatus("");
+          }}
+          placeholder="Search HDFC Bank, NIFTYBEES, Bitcoin..."
+          testID="asset-lookup-input"
+          value={lookupQuery}
+        />
+        {lookupStatus ? (
+          <AppText color="secondary" variant="caption">
+            {isLookupSearching ? "Searching..." : lookupStatus}
+          </AppText>
+        ) : null}
+        {lookupResults.length > 0 ? (
+          <View style={styles.lookupResults}>
+            {lookupResults.map((result) => (
+              <Pressable
+                accessibilityRole="button"
+                key={result.id}
+                onPress={() => {
+                  void selectLookupResult(result);
+                }}
+                style={({ pressed }) => [
+                  styles.lookupResult,
+                  pressed && styles.pressed,
+                ]}
+                testID={`asset-lookup-result-${result.id}`}
+              >
+                <CategoryIcon assetClass={result.assetClass} size={18} />
+                <View style={styles.lookupResultCopy}>
+                  <AppText weight="bold">{result.name}</AppText>
+                  <AppText color="secondary" variant="caption">
+                    {result.symbol} • {result.ticker} • {result.sourceLabel}
+                  </AppText>
+                </View>
+                <AppText color="secondary" variant="caption" weight="bold">
+                  {assetClassLabel(result.assetClass)}
+                </AppText>
+              </Pressable>
+            ))}
+          </View>
+        ) : null}
+        {quoteStatus ? (
+          <AppText color="secondary" variant="caption">
+            {quoteStatus}
+          </AppText>
+        ) : null}
         <View style={styles.classRow}>
           {assetClasses.map((currentClass) => {
             const isSelected = assetClass === currentClass;
@@ -620,6 +787,21 @@ const styles = StyleSheet.create({
   },
   flex: {
     flex: 1,
+  },
+  lookupResult: {
+    alignItems: "center",
+    backgroundColor: colors.surface.elevated,
+    borderRadius: radii.card,
+    flexDirection: "row",
+    gap: spacing.sm,
+    padding: spacing.sm,
+  },
+  lookupResultCopy: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  lookupResults: {
+    gap: spacing.sm,
   },
   negativeText: {
     color: colors.loss,

--- a/src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
+++ b/src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
@@ -1,7 +1,8 @@
 import * as Haptics from "expo-haptics";
-import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native";
 
 import { AddOpeningPositionForm } from "@/src/features/openingPositions";
+import type { AssetLookupResult } from "@/src/services/assetLookup";
 import { createMemoryJsonStorage } from "@/src/services/storage";
 import { createPortfolioStore } from "@/src/store";
 
@@ -15,6 +16,10 @@ jest.mock("expo-haptics", () => ({
 describe("AddOpeningPositionForm", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it("creates a manual asset and persists a reviewed opening position", async () => {
@@ -150,5 +155,126 @@ describe("AddOpeningPositionForm", () => {
       sectorType: "digitalAsset",
       ticker: "bitcoin",
     });
+  });
+
+  it("autofills asset metadata and current price from a selected lookup result", async () => {
+    jest.useFakeTimers();
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const lookupResult: AssetLookupResult = {
+      assetClass: "stock",
+      currency: "INR",
+      exchange: "NSE",
+      id: "yahoo:HDFCBANK.NS",
+      instrumentType: "stock",
+      name: "HDFC Bank Limited",
+      provider: "yahoo",
+      quoteSourceId: "HDFCBANK.NS",
+      sectorType: "financialServices",
+      sourceLabel: "Yahoo Finance",
+      symbol: "HDFCBANK",
+      ticker: "HDFCBANK.NS",
+    };
+    const searchAssetLookupResults = jest.fn().mockResolvedValue({
+      failures: [],
+      results: [lookupResult],
+    });
+    const resolveQuote = jest.fn().mockImplementation(({ asset }) =>
+      Promise.resolve({
+        ok: true,
+        quote: {
+          assetId: asset.id,
+          asOf: "2026-05-10T10:00:00.000Z",
+          currency: "INR",
+          price: 1678.25,
+          source: "yahoo",
+        },
+      }),
+    );
+    const { getByLabelText, getByText } = render(
+      <AddOpeningPositionForm
+        resolveQuote={resolveQuote}
+        searchAssetLookupResults={searchAssetLookupResults}
+        store={store}
+      />,
+    );
+
+    fireEvent.changeText(getByLabelText("Search asset"), "hdfc bank");
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+
+    await waitFor(() => {
+      expect(getByText("HDFC Bank Limited")).toBeTruthy();
+    });
+
+    fireEvent.press(getByText("HDFC Bank Limited"));
+
+    await waitFor(() => {
+      expect(getByLabelText("Asset name")).toHaveProp(
+        "value",
+        "HDFC Bank Limited",
+      );
+      expect(getByLabelText("Current price")).toHaveProp("value", "1678.25");
+    });
+    expect(getByLabelText("Symbol")).toHaveProp("value", "HDFCBANK");
+    expect(getByLabelText("Ticker")).toHaveProp("value", "HDFCBANK.NS");
+    expect(getByLabelText("Quote source ID")).toHaveProp(
+      "value",
+      "HDFCBANK.NS",
+    );
+    expect(getByText("Live price autofilled from Yahoo Finance.")).toBeTruthy();
+  });
+
+  it("keeps manual price fallback available when selected lookup quote fails", async () => {
+    jest.useFakeTimers();
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const lookupResult: AssetLookupResult = {
+      assetClass: "crypto",
+      currency: "INR",
+      exchange: "CRYPTO",
+      id: "coingecko:bitcoin",
+      instrumentType: "crypto",
+      name: "Bitcoin",
+      provider: "coingecko",
+      quoteSourceId: "bitcoin",
+      sectorType: "digitalAsset",
+      sourceLabel: "CoinGecko",
+      symbol: "BTC",
+      ticker: "bitcoin",
+    };
+    const searchAssetLookupResults = jest.fn().mockResolvedValue({
+      failures: [],
+      results: [lookupResult],
+    });
+    const resolveQuote = jest.fn().mockResolvedValue({
+      error: "CoinGecko quote response did not include an INR price.",
+      ok: false,
+    });
+    const { getByLabelText, getByText } = render(
+      <AddOpeningPositionForm
+        resolveQuote={resolveQuote}
+        searchAssetLookupResults={searchAssetLookupResults}
+        store={store}
+      />,
+    );
+
+    fireEvent.changeText(getByLabelText("Search asset"), "bitcoin");
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+
+    await waitFor(() => {
+      expect(getByText("Bitcoin")).toBeTruthy();
+    });
+
+    fireEvent.press(getByText("Bitcoin"));
+
+    await waitFor(() => {
+      expect(getByLabelText("Asset name")).toHaveProp("value", "Bitcoin");
+      expect(
+        getByText("Live price unavailable. Enter current price manually."),
+      ).toBeTruthy();
+    });
+    expect(getByLabelText("Current price")).toHaveProp("value", "");
   });
 });

--- a/src/services/assetLookup/__tests__/assetLookup.test.ts
+++ b/src/services/assetLookup/__tests__/assetLookup.test.ts
@@ -1,0 +1,119 @@
+import {
+  buildCoinGeckoSearchUrl,
+  buildYahooSearchUrl,
+  mapCoinGeckoCoinToLookupResult,
+  mapYahooQuoteToLookupResult,
+  searchAssetLookupResults,
+} from "@/src/services/assetLookup";
+
+function response(payload: unknown, ok = true): Response {
+  return {
+    json: jest.fn().mockResolvedValue(payload),
+    ok,
+    status: ok ? 200 : 500,
+  } as unknown as Response;
+}
+
+describe("asset lookup service", () => {
+  it("builds provider search URLs", () => {
+    expect(buildYahooSearchUrl("hdfc bank")).toBe(
+      "https://query2.finance.yahoo.com/v1/finance/search?q=hdfc+bank&quotesCount=8&newsCount=0",
+    );
+    expect(buildCoinGeckoSearchUrl("bitcoin")).toBe(
+      "https://api.coingecko.com/api/v3/search?query=bitcoin",
+    );
+  });
+
+  it("maps NSE Yahoo equity search results to INR stock metadata", () => {
+    expect(
+      mapYahooQuoteToLookupResult({
+        exchange: "NSI",
+        longname: "HDFC Bank Limited",
+        quoteType: "EQUITY",
+        shortname: "HDFC Bank",
+        symbol: "HDFCBANK.NS",
+      }),
+    ).toEqual({
+      assetClass: "stock",
+      currency: "INR",
+      exchange: "NSE",
+      id: "yahoo:HDFCBANK.NS",
+      instrumentType: "stock",
+      name: "HDFC Bank Limited",
+      provider: "yahoo",
+      quoteSourceId: "HDFCBANK.NS",
+      sectorType: "financialServices",
+      sourceLabel: "Yahoo Finance",
+      symbol: "HDFCBANK",
+      ticker: "HDFCBANK.NS",
+    });
+  });
+
+  it("maps ETF-like Yahoo search results to ETF metadata", () => {
+    expect(
+      mapYahooQuoteToLookupResult({
+        exchange: "NSI",
+        quoteType: "ETF",
+        shortname: "Nippon India ETF Nifty Bees",
+        symbol: "NIFTYBEES.NS",
+      }),
+    ).toMatchObject({
+      assetClass: "etf",
+      instrumentType: "etf",
+      sectorType: "diversified",
+      symbol: "NIFTYBEES",
+      ticker: "NIFTYBEES.NS",
+    });
+  });
+
+  it("maps CoinGecko coins to crypto metadata with coin ID as quote source", () => {
+    expect(
+      mapCoinGeckoCoinToLookupResult({
+        id: "bitcoin",
+        name: "Bitcoin",
+        symbol: "btc",
+      }),
+    ).toEqual({
+      assetClass: "crypto",
+      currency: "INR",
+      exchange: "CRYPTO",
+      id: "coingecko:bitcoin",
+      instrumentType: "crypto",
+      name: "Bitcoin",
+      provider: "coingecko",
+      quoteSourceId: "bitcoin",
+      sectorType: "digitalAsset",
+      sourceLabel: "CoinGecko",
+      symbol: "BTC",
+      ticker: "bitcoin",
+    });
+  });
+
+  it("returns partial results when one provider fails", async () => {
+    const fetcher = jest
+      .fn()
+      .mockResolvedValueOnce(response({}, false))
+      .mockResolvedValueOnce(
+        response({
+          coins: [
+            {
+              id: "bitcoin",
+              name: "Bitcoin",
+              symbol: "btc",
+            },
+          ],
+        }),
+      );
+
+    const result = await searchAssetLookupResults({ fetcher, query: "bitcoin" });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({
+      provider: "coingecko",
+      quoteSourceId: "bitcoin",
+    });
+    expect(result.failures).toEqual([
+      "Yahoo lookup request failed with status 500.",
+    ]);
+  });
+});

--- a/src/services/assetLookup/index.ts
+++ b/src/services/assetLookup/index.ts
@@ -1,0 +1,235 @@
+import { getDefaultAssetMetadata } from "@/src/domain/assets";
+import type {
+  AssetClass,
+  AssetExchange,
+  Currency,
+  InstrumentType,
+  SectorType,
+} from "@/src/types";
+
+import type { QuoteFetcher } from "@/src/services/quotes";
+import { getDefaultFetcher } from "@/src/services/quotes/utils";
+
+export type AssetLookupProvider = "coingecko" | "yahoo";
+
+export type AssetLookupResult = {
+  assetClass: AssetClass;
+  currency: Currency;
+  exchange?: AssetExchange;
+  id: string;
+  instrumentType: InstrumentType;
+  name: string;
+  provider: AssetLookupProvider;
+  quoteSourceId: string;
+  sectorType: SectorType;
+  sourceLabel: string;
+  symbol: string;
+  ticker: string;
+};
+
+export type AssetLookupSearchResult = {
+  failures: string[];
+  results: AssetLookupResult[];
+};
+
+export type YahooSearchQuote = {
+  exchange?: string;
+  longname?: string;
+  quoteType?: string;
+  shortname?: string;
+  symbol?: string;
+};
+
+type YahooSearchResponse = {
+  quotes?: YahooSearchQuote[];
+};
+
+export type CoinGeckoSearchCoin = {
+  id?: string;
+  name?: string;
+  symbol?: string;
+};
+
+type CoinGeckoSearchResponse = {
+  coins?: CoinGeckoSearchCoin[];
+};
+
+export function buildYahooSearchUrl(query: string) {
+  const params = new URLSearchParams({
+    q: query,
+    quotesCount: "8",
+    newsCount: "0",
+  });
+
+  return `https://query2.finance.yahoo.com/v1/finance/search?${params.toString()}`;
+}
+
+export function buildCoinGeckoSearchUrl(query: string) {
+  const params = new URLSearchParams({
+    query,
+  });
+
+  return `https://api.coingecko.com/api/v3/search?${params.toString()}`;
+}
+
+function inferYahooExchange(symbol: string): AssetExchange | undefined {
+  if (symbol.endsWith(".NS")) {
+    return "NSE";
+  }
+
+  if (symbol.endsWith(".BO")) {
+    return "BSE";
+  }
+
+  return undefined;
+}
+
+function inferYahooCurrency(symbol: string): Currency {
+  return symbol.endsWith(".NS") || symbol.endsWith(".BO") ? "INR" : "USD";
+}
+
+function normalizeYahooSymbol(symbol: string) {
+  return symbol.replace(/\.(NS|BO)$/u, "").toUpperCase();
+}
+
+function inferYahooAssetClass(quoteType?: string): AssetClass {
+  return quoteType?.toUpperCase() === "ETF" ? "etf" : "stock";
+}
+
+export function mapYahooQuoteToLookupResult(
+  quote: YahooSearchQuote,
+): AssetLookupResult | undefined {
+  const ticker = quote.symbol?.trim();
+
+  if (!ticker) {
+    return undefined;
+  }
+
+  const assetClass = inferYahooAssetClass(quote.quoteType);
+  const defaults = getDefaultAssetMetadata(assetClass);
+
+  return {
+    assetClass,
+    currency: inferYahooCurrency(ticker),
+    exchange: inferYahooExchange(ticker),
+    id: `yahoo:${ticker}`,
+    instrumentType: defaults.instrumentType,
+    name: quote.longname?.trim() || quote.shortname?.trim() || ticker,
+    provider: "yahoo",
+    quoteSourceId: ticker,
+    sectorType: defaults.sectorType,
+    sourceLabel: "Yahoo Finance",
+    symbol: normalizeYahooSymbol(ticker),
+    ticker,
+  };
+}
+
+export function mapCoinGeckoCoinToLookupResult(
+  coin: CoinGeckoSearchCoin,
+): AssetLookupResult | undefined {
+  const coinId = coin.id?.trim();
+  const symbol = coin.symbol?.trim();
+
+  if (!coinId || !symbol) {
+    return undefined;
+  }
+
+  const defaults = getDefaultAssetMetadata("crypto");
+
+  return {
+    assetClass: "crypto",
+    currency: "INR",
+    exchange: "CRYPTO",
+    id: `coingecko:${coinId}`,
+    instrumentType: defaults.instrumentType,
+    name: coin.name?.trim() || symbol.toUpperCase(),
+    provider: "coingecko",
+    quoteSourceId: coinId,
+    sectorType: defaults.sectorType,
+    sourceLabel: "CoinGecko",
+    symbol: symbol.toUpperCase(),
+    ticker: coinId,
+  };
+}
+
+async function searchYahoo({
+  fetcher,
+  query,
+}: {
+  fetcher: QuoteFetcher;
+  query: string;
+}) {
+  const response = await fetcher(buildYahooSearchUrl(query));
+
+  if (!response.ok) {
+    throw new Error(`Yahoo lookup request failed with status ${response.status}.`);
+  }
+
+  const payload = (await response.json()) as YahooSearchResponse;
+
+  return (payload.quotes ?? [])
+    .map(mapYahooQuoteToLookupResult)
+    .filter((result): result is AssetLookupResult => result !== undefined);
+}
+
+async function searchCoinGecko({
+  fetcher,
+  query,
+}: {
+  fetcher: QuoteFetcher;
+  query: string;
+}) {
+  const response = await fetcher(buildCoinGeckoSearchUrl(query));
+
+  if (!response.ok) {
+    throw new Error(
+      `CoinGecko lookup request failed with status ${response.status}.`,
+    );
+  }
+
+  const payload = (await response.json()) as CoinGeckoSearchResponse;
+
+  return (payload.coins ?? [])
+    .map(mapCoinGeckoCoinToLookupResult)
+    .filter((result): result is AssetLookupResult => result !== undefined);
+}
+
+export async function searchAssetLookupResults({
+  fetcher = getDefaultFetcher(),
+  query,
+}: {
+  fetcher?: QuoteFetcher;
+  query: string;
+}): Promise<AssetLookupSearchResult> {
+  const trimmedQuery = query.trim();
+
+  if (trimmedQuery.length < 2) {
+    return { failures: [], results: [] };
+  }
+
+  const settledResults = await Promise.allSettled([
+    searchYahoo({ fetcher, query: trimmedQuery }),
+    searchCoinGecko({ fetcher, query: trimmedQuery }),
+  ]);
+
+  const results: AssetLookupResult[] = [];
+  const failures: string[] = [];
+
+  for (const settledResult of settledResults) {
+    if (settledResult.status === "fulfilled") {
+      results.push(...settledResult.value);
+      continue;
+    }
+
+    failures.push(
+      settledResult.reason instanceof Error
+        ? settledResult.reason.message
+        : "Asset lookup request failed.",
+    );
+  }
+
+  return {
+    failures,
+    results,
+  };
+}


### PR DESCRIPTION
## Summary
- Add lightweight Yahoo Finance and CoinGecko asset lookup normalization
- Add debounced Add Holding search with metadata autofill and live current-price attempt
- Preserve manual entry/manual current-price fallback when lookup or quote fetching fails
- Add issue #84 spec/plan and tests for lookup, autofill, and fallback paths

## Verification
- npm test -- --runTestsByPath src/services/assetLookup/__tests__/assetLookup.test.ts src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
- npm run typecheck
- npm test
- npm run doctor
- git diff --check

Closes #84