### PR TITLE
[V1] Align Dashboard with Figma V1 direction

### DIFF
--- a/docs/superpowers/plans/2026-05-16-issue-80-dashboard-alignment.md
+++ b/docs/superpowers/plans/2026-05-16-issue-80-dashboard-alignment.md
@@ -1,0 +1,49 @@
+# Issue #80 Dashboard Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align the V1 Dashboard with the approved Figma direction by wiring actions and correcting monthly metric semantics.
+
+**Architecture:** Keep raw data in the store and extend `useDashboard` with derived monthly metrics plus quote refresh actions. Keep `DashboardScreen` presentational, using existing common components.
+
+**Tech Stack:** Expo SDK 54, React Native, TypeScript, Zustand vanilla store, Jest/RNTL.
+
+---
+
+### Task 1: Dashboard Hook Data And Actions
+
+**Files:**
+- Modify: `src/features/dashboard/useDashboard.ts`
+- Test: `src/features/dashboard/__tests__/useDashboard.test.tsx`
+
+- [ ] Add a `refreshQuotes` dependency, `isRefreshing`, `quoteFailures`, `refresh`, `toggleMaskWealthValues`, and `monthlyMetrics` to `useDashboard`.
+- [ ] Reuse the existing quote refresh service signature from `src/features/holdings/useHoldings.ts`.
+- [ ] Derive monthly investment from current-month buy trades and opening positions.
+- [ ] Derive monthly cash change from current-month cash entries.
+- [ ] Derive savings rate only when monthly additions are greater than zero.
+- [ ] Add hook tests for monthly metrics, value-mask toggling, and quote refresh persistence.
+
+### Task 2: Dashboard Screen Wiring
+
+**Files:**
+- Modify: `src/features/dashboard/DashboardScreen.tsx`
+- Test: `src/features/dashboard/__tests__/DashboardScreen.test.tsx`
+
+- [ ] Pass optional `refreshQuotes` into `useDashboard` for tests.
+- [ ] Wire the eye header icon to `toggleMaskWealthValues`.
+- [ ] Wire the refresh header icon to `refresh`.
+- [ ] Keep Add Holding CTA visible when `onAddTrade` is available.
+- [ ] Change `This Month` metrics to `Invested`, `Savings`, and `Cash change`.
+- [ ] Change quote status copy to describe fresh quote, fallback, refreshing, and failure states.
+- [ ] Add screen tests for Add Holding, masking, refresh action, and monthly labels.
+
+### Task 3: Verification And PR
+
+**Files:**
+- Modify: none expected beyond Tasks 1-2.
+
+- [ ] Run `npm run typecheck`.
+- [ ] Run `npm test`.
+- [ ] Run `npm run doctor`.
+- [ ] Run a focused Android smoke only if the emulator is already available and the app is installed.
+- [ ] Commit with a focused message and open a PR containing `Closes #80`.

--- a/docs/superpowers/specs/2026-05-16-issue-80-dashboard-alignment.md
+++ b/docs/superpowers/specs/2026-05-16-issue-80-dashboard-alignment.md
@@ -1,0 +1,59 @@
+# Issue #80 Dashboard Alignment Spec
+
+## Goal
+
+Align the V1 Dashboard with the approved premium Figma direction while preserving
+Excel parity data and removing inactive-looking controls.
+
+## Scope
+
+- Wire the Dashboard value-mask action to the persisted `maskWealthValues`
+  preference.
+- Wire Dashboard quote refresh to the existing quote refresh service and persist
+  refreshed quotes into the portfolio store.
+- Keep Add Holding reachable from Dashboard in filled and empty states.
+- Replace mislabeled lifetime values in the `This Month` card with current-month
+  investment, current-month cash change, and a savings-rate value when enough
+  cash data exists.
+- Keep allocation readable and low-noise with equity/debt/crypto/cash rows using
+  existing derived allocation data.
+- Preserve existing rollup and conviction information where useful, but avoid
+  making the Dashboard feel denser than the Figma direction.
+
+## Non-Goals
+
+- No new historical charting.
+- No new Minimal Mode or LTCG UI.
+- No fake demo portfolio values.
+- No broad redesign outside `src/features/dashboard`.
+- No changes to quote provider behavior beyond invoking the existing service.
+
+## Data Rules
+
+- Persist raw portfolio data only; derived values remain selectors/hook output.
+- Monthly investment is the sum of current-month buy trades plus current-month
+  opening-position invested value.
+- Monthly cash change is current-month cash additions minus withdrawals.
+- Savings rate is shown only when current-month cash additions are greater than
+  zero; otherwise show `Not enough data`.
+- Quote status distinguishes fresh quotes from manual fallback or no priced
+  holdings without creating alarm.
+
+## UX Rules
+
+- Header controls must either perform an action or be removed.
+- Value masking uses the eye icon and updates the store immediately.
+- Refresh quotes uses the refresh icon and disabled/refreshing state should be
+  clear through accessible labels and quote status text.
+- Dashboard Add Holding remains a clear CTA.
+- Copy stays local-first and calm.
+
+## Acceptance Checklist
+
+- Dashboard has no dead controls.
+- Add Holding is reachable from Dashboard.
+- Header value masking toggles persisted masking.
+- Header refresh quotes persists refreshed quote cache.
+- This Month uses monthly semantics or explicit not-enough-data text.
+- Tests cover header actions and monthly labeling.
+- `npm run typecheck`, `npm test`, and `npm run doctor` pass.

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -17,13 +17,19 @@ import {
   CategoryIcon,
 } from "@/src/components/common";
 import { formatDate, formatINR, formatPercentage } from "@/src/domain/formatters";
+import type { RefreshQuotesInput, QuoteRefreshResult } from "@/src/services/quotes";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
 import { spacing } from "@/src/theme";
 
 import { useDashboard } from "./useDashboard";
 
+type RefreshQuotes = (
+  input: RefreshQuotesInput,
+) => Promise<QuoteRefreshResult>;
+
 type DashboardScreenProps = {
   onAddTrade?: () => void;
+  refreshQuotes?: RefreshQuotes;
   store?: StoreApi<PortfolioStoreState>;
 };
 
@@ -39,9 +45,10 @@ function formatUnsignedPercentage(value: number) {
 
 export function DashboardScreen({
   onAddTrade,
+  refreshQuotes,
   store = getPortfolioStore(),
 }: DashboardScreenProps) {
-  const dashboard = useDashboard({ store });
+  const dashboard = useDashboard({ refreshQuotes, store });
   const hasAllocation = dashboard.allocation.length > 0;
   const dayChangeAmount = formatSignedINR(dashboard.dayChange.absolute);
   const totalInvested = dashboard.rollupTotals.totalInvested;
@@ -49,6 +56,12 @@ export function DashboardScreen({
   const totalPnLPct = dashboard.rollupTotals.pnlPct;
   const sectorSnapshot = dashboard.sectorAllocation.slice(0, 3);
   const instrumentSnapshot = dashboard.instrumentAllocation.slice(0, 3);
+  const quoteStatus = getQuoteStatus({
+    isRefreshing: dashboard.isRefreshing,
+    latestQuoteAsOf: dashboard.latestQuoteAsOf,
+    latestQuoteSource: dashboard.latestQuoteSource,
+    quoteFailures: dashboard.quoteFailures.length,
+  });
 
   return (
     <ScreenContainer scroll testID="dashboard-screen">
@@ -58,8 +71,22 @@ export function DashboardScreen({
           subtitle="Local portfolio • latest snapshot"
           action={
             <>
-              <IconButton accessibilityLabel="Toggle value visibility" icon="eye-outline" />
-              <IconButton accessibilityLabel="Refresh quotes" icon="refresh-outline" />
+              <IconButton
+                accessibilityLabel={
+                  dashboard.maskWealthValues ? "Show values" : "Mask values"
+                }
+                icon={dashboard.maskWealthValues ? "eye-off-outline" : "eye-outline"}
+                onPress={dashboard.toggleMaskWealthValues}
+                testID="dashboard-mask-toggle"
+              />
+              <IconButton
+                accessibilityLabel="Refresh quotes"
+                icon="refresh-outline"
+                onPress={() => {
+                  void dashboard.refresh();
+                }}
+                testID="dashboard-refresh-quotes"
+              />
             </>
           }
         />
@@ -93,6 +120,14 @@ export function DashboardScreen({
             },
           ]}
         />
+
+        {onAddTrade && hasAllocation ? (
+          <AppButton
+            title="Add Holding"
+            testID="add-trade-button"
+            onPress={onAddTrade}
+          />
+        ) : null}
 
         {sectorSnapshot.length > 0 || instrumentSnapshot.length > 0 ? (
           <PremiumCard>
@@ -142,14 +177,6 @@ export function DashboardScreen({
           </PremiumCard>
         ) : null}
 
-        {onAddTrade && hasAllocation ? (
-          <AppButton
-            title="Add Holding"
-            testID="add-trade-button"
-            onPress={onAddTrade}
-          />
-        ) : null}
-
         {hasAllocation ? (
           <PremiumCard>
             <SectionHeader title="Allocation" actionLabel="View details" />
@@ -192,16 +219,19 @@ export function DashboardScreen({
               {
                 label: "Invested",
                 masked: dashboard.maskWealthValues,
-                value: formatINR(totalInvested),
+                value: formatINR(dashboard.monthlyMetrics.investment),
               },
               {
-                label: "Cash balance",
+                label: "Savings",
+                value:
+                  dashboard.monthlyMetrics.savingsRate === null
+                    ? "Not enough data"
+                    : formatPercentage(dashboard.monthlyMetrics.savingsRate),
+              },
+              {
+                label: "Cash change",
                 masked: dashboard.maskWealthValues,
-                value: formatINR(dashboard.cashBalance),
-              },
-              {
-                label: "Holdings",
-                value: dashboard.holdings.length.toString(),
+                value: formatSignedINR(dashboard.monthlyMetrics.cashChange),
               },
             ]}
           />
@@ -209,11 +239,7 @@ export function DashboardScreen({
 
         <PremiumCard>
           <SectionHeader title="Quote Status" />
-          <AppText color="secondary">
-            {dashboard.latestQuoteAsOf
-              ? `Quotes updated ${formatDate(dashboard.latestQuoteAsOf)}`
-              : "Quotes will appear after your first priced holding."}
-          </AppText>
+          <AppText color="secondary">{quoteStatus}</AppText>
         </PremiumCard>
 
         <PremiumCard>
@@ -234,6 +260,35 @@ export function DashboardScreen({
       </View>
     </ScreenContainer>
   );
+}
+
+function getQuoteStatus({
+  isRefreshing,
+  latestQuoteAsOf,
+  latestQuoteSource,
+  quoteFailures,
+}: {
+  isRefreshing: boolean;
+  latestQuoteAsOf?: string;
+  latestQuoteSource?: string;
+  quoteFailures: number;
+}) {
+  if (isRefreshing) {
+    return "Refreshing quotes...";
+  }
+
+  if (quoteFailures > 0) {
+    return "Some quotes could not refresh. Manual fallback ready.";
+  }
+
+  if (!latestQuoteAsOf) {
+    return "Quotes will appear after your first priced holding.";
+  }
+
+  const mode =
+    latestQuoteSource === "manual" ? "Manual fallback ready" : "Live refresh available";
+
+  return `Quotes updated ${formatDate(latestQuoteAsOf)} • ${mode}`;
 }
 
 const styles = StyleSheet.create({

--- a/src/features/dashboard/__tests__/DashboardScreen.test.tsx
+++ b/src/features/dashboard/__tests__/DashboardScreen.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react-native";
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native";
 
 import { MASKED_INR_VALUE } from "@/src/components/common";
 import { DashboardScreen } from "@/src/features/dashboard";
@@ -48,7 +48,46 @@ describe("DashboardScreen", () => {
     expect(onAddTrade).toHaveBeenCalledTimes(1);
   });
 
-  it("shows portfolio totals, allocation, quote freshness, and conviction guidance", () => {
+  it("wires Dashboard header value masking and quote refresh actions", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset(asset);
+    store.getState().addTrade(buyTrade);
+    const refreshQuotes = jest.fn().mockResolvedValue({
+      failures: [],
+      quoteCache: {
+        [asset.id]: {
+          asOf: "2026-05-16T10:00:00.000Z",
+          assetId: asset.id,
+          currency: "INR",
+          price: 175,
+          source: "yahoo",
+        },
+      },
+    });
+
+    const { getByLabelText, getByText } = render(
+      <DashboardScreen
+        refreshQuotes={refreshQuotes}
+        store={store}
+      />,
+    );
+
+    fireEvent.press(getByLabelText("Mask values"));
+    expect(store.getState().preferences.maskWealthValues).toBe(true);
+
+    await act(async () => {
+      fireEvent.press(getByLabelText("Refresh quotes"));
+    });
+
+    await waitFor(() => {
+      expect(refreshQuotes).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      getByText("Quotes updated 16 May 2026 • Live refresh available"),
+    ).toBeTruthy();
+  });
+
+  it("shows portfolio totals, allocation, quote freshness, monthly metrics, and conviction guidance", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     store.getState().addAsset(asset);
     store.getState().addTrade({ ...buyTrade, conviction: 4 });
@@ -58,6 +97,13 @@ describe("DashboardScreen", () => {
       id: "cash-1",
       label: "Broker cash",
       type: "addition",
+    });
+    store.getState().addCashEntry({
+      amount: 20,
+      date: "2026-05-05",
+      id: "cash-2",
+      label: "Withdrawal",
+      type: "withdrawal",
     });
     store.getState().upsertQuote({
       asOf: "2026-04-22T10:00:00.000Z",
@@ -70,16 +116,21 @@ describe("DashboardScreen", () => {
 
     const { getByText, queryByText } = render(<DashboardScreen store={store} />);
 
-    expect(getByText("₹350.00")).toBeTruthy();
+    expect(getByText("₹330.00")).toBeTruthy();
     expect(getByText("Portfolio Rollups")).toBeTruthy();
     expect(getByText("Top sectors")).toBeTruthy();
     expect(getByText("Top instruments")).toBeTruthy();
     expect(getByText("+₹27.27 (+10.00%) today")).toBeTruthy();
     expect(getByText("Equity")).toBeTruthy();
-    expect(getByText("85.71%")).toBeTruthy();
+    expect(getByText("90.91%")).toBeTruthy();
     expect(getByText("Cash")).toBeTruthy();
-    expect(getByText("14.29%")).toBeTruthy();
-    expect(getByText("Quotes updated 22 Apr 2026")).toBeTruthy();
+    expect(getByText("9.09%")).toBeTruthy();
+    expect(getByText("Quotes updated 22 Apr 2026 • Live refresh available")).toBeTruthy();
+    expect(getByText("This Month")).toBeTruthy();
+    expect(getByText("Cash change")).toBeTruthy();
+    expect(getByText("Not enough data")).toBeTruthy();
+    expect(queryByText("Cash balance")).toBeNull();
+    expect(queryByText("Holdings")).toBeNull();
     expect(getByText("Conviction data needs more trades")).toBeTruthy();
     expect(getByText("1 of 5 trades rated. Keep conviction optional, but useful.")).toBeTruthy();
     expect(queryByText(/LTCG/i)).toBeNull();

--- a/src/features/dashboard/__tests__/useDashboard.test.tsx
+++ b/src/features/dashboard/__tests__/useDashboard.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-native";
+import { act, renderHook } from "@testing-library/react-native";
 
 import { useDashboard } from "@/src/features/dashboard/useDashboard";
 import { createMemoryJsonStorage } from "@/src/services/storage";
@@ -212,5 +212,101 @@ describe("useDashboard", () => {
       { label: "digitalAsset", percentage: 54.55, value: 120000 },
       { label: "fixedIncome", percentage: 45.45, value: 100000 },
     ]);
+  });
+
+  it("derives current-month investment, cash change, and savings rate", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset(stockAsset);
+    store.getState().addTrade({
+      ...buyStock,
+      date: "2026-05-05",
+      totalValue: 200,
+    });
+    store.getState().addTrade({
+      ...buyEtf,
+      assetId: stockAsset.id,
+      date: "2026-04-21",
+      id: "trade-old",
+      totalValue: 1000,
+    });
+    store.getState().addCashEntry({
+      amount: 1000,
+      date: "2026-05-01",
+      id: "cash-addition",
+      label: "Salary",
+      type: "addition",
+    });
+    store.getState().addCashEntry({
+      amount: 250,
+      date: "2026-05-10",
+      id: "cash-withdrawal",
+      label: "Transfer",
+      type: "withdrawal",
+    });
+    store.getState().addOpeningPosition({
+      assetId: stockAsset.id,
+      averageCostPrice: 50,
+      currentPrice: 60,
+      date: "2026-05-12",
+      id: "opening-current-month",
+      quantity: 4,
+    });
+
+    const { result } = renderHook(() =>
+      useDashboard({ now: new Date("2026-05-16T00:00:00.000Z"), store }),
+    );
+
+    expect(result.current.monthlyMetrics).toEqual({
+      cashAdded: 1000,
+      cashChange: 750,
+      investment: 400,
+      savingsRate: 40,
+    });
+  });
+
+  it("toggles value masking through the dashboard hook", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const { result } = renderHook(() => useDashboard({ store }));
+
+    expect(result.current.maskWealthValues).toBe(false);
+
+    act(() => {
+      result.current.toggleMaskWealthValues();
+    });
+
+    expect(store.getState().preferences.maskWealthValues).toBe(true);
+  });
+
+  it("refreshes quotes and persists refreshed quote cache", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset(stockAsset);
+    const refreshQuotes = jest.fn().mockResolvedValue({
+      failures: [],
+      quoteCache: {
+        [stockAsset.id]: {
+          asOf: "2026-05-16T10:00:00.000Z",
+          assetId: stockAsset.id,
+          currency: "INR",
+          price: 175,
+          source: "yahoo",
+        },
+      },
+    });
+    const { result } = renderHook(() =>
+      useDashboard({ refreshQuotes, store }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(refreshQuotes).toHaveBeenCalledWith({
+      assets: [expect.objectContaining(stockAsset)],
+      manualPrices: {},
+    });
+    expect(store.getState().quoteCache[stockAsset.id]).toMatchObject({
+      price: 175,
+      source: "yahoo",
+    });
   });
 });

--- a/src/features/dashboard/useDashboard.ts
+++ b/src/features/dashboard/useDashboard.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from "react";
+import { useState, useSyncExternalStore } from "react";
 import type { StoreApi } from "zustand/vanilla";
 
 import {
@@ -19,11 +19,34 @@ import {
   type PortfolioDayChange,
   type PortfolioRollupTotals,
 } from "@/src/domain/calculations";
+import {
+  refreshQuotes as defaultRefreshQuotes,
+  type QuoteRefreshFailure,
+  type QuoteRefreshResult,
+  type RefreshQuotesInput,
+} from "@/src/services/quotes";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
 import type { Holding } from "@/src/types";
 
+type RefreshQuotes = (
+  input: RefreshQuotesInput,
+) => Promise<QuoteRefreshResult>;
+
+type DashboardHolding = Holding & {
+  quoteSource?: string;
+};
+
 type UseDashboardInput = {
+  now?: Date;
+  refreshQuotes?: RefreshQuotes;
   store?: StoreApi<PortfolioStoreState>;
+};
+
+export type DashboardMonthlyMetrics = {
+  cashAdded: number;
+  cashChange: number;
+  investment: number;
+  savingsRate: number | null;
 };
 
 export type DashboardState = {
@@ -33,11 +56,17 @@ export type DashboardState = {
   dayChange: PortfolioDayChange;
   holdings: Holding[];
   instrumentAllocation: MetadataAllocationItem[];
+  isRefreshing: boolean;
   latestQuoteAsOf?: string;
+  latestQuoteSource?: string;
   maskWealthValues: boolean;
+  monthlyMetrics: DashboardMonthlyMetrics;
+  quoteFailures: QuoteRefreshFailure[];
+  refresh: () => Promise<QuoteRefreshResult>;
   rollupRows: ConsolidatedHoldingRow[];
   rollupTotals: PortfolioRollupTotals;
   sectorAllocation: MetadataAllocationItem[];
+  toggleMaskWealthValues: () => void;
   totalValue: number;
 };
 
@@ -48,7 +77,7 @@ function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
 function withQuoteMetadata(
   holdings: Holding[],
   quoteCache: PortfolioStoreState["quoteCache"],
-) {
+): DashboardHolding[] {
   return holdings.map((holding) => {
     const quote = quoteCache[holding.asset.id];
 
@@ -56,21 +85,89 @@ function withQuoteMetadata(
       ...holding,
       dayChangePct: quote?.dayChangePct,
       lastUpdated: quote?.asOf,
+      quoteSource: quote?.source,
     };
   });
 }
 
-function getLatestQuoteAsOf(holdings: Holding[]) {
+function getLatestQuote(holdings: DashboardHolding[]) {
   return holdings
-    .map((holding) => holding.lastUpdated)
-    .filter((value): value is string => Boolean(value))
-    .sort((left, right) => new Date(right).getTime() - new Date(left).getTime())[0];
+    .map((holding) => {
+      if (!holding.lastUpdated) {
+        return null;
+      }
+
+      return {
+        asOf: holding.lastUpdated,
+        source: holding.quoteSource,
+      };
+    })
+    .filter((value): value is { asOf: string; source: string } => Boolean(value))
+    .sort(
+      (left, right) =>
+        new Date(right.asOf).getTime() - new Date(left.asOf).getTime(),
+    )[0];
+}
+
+function isSameMonth(isoDate: string, now: Date) {
+  const date = new Date(isoDate);
+
+  return (
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth()
+  );
+}
+
+function selectManualPrices(state: PortfolioStoreState) {
+  return Object.fromEntries(
+    Object.entries(state.quoteCache).map(([assetId, quote]) => [
+      assetId,
+      quote.price,
+    ]),
+  );
+}
+
+function calculateMonthlyMetrics(
+  state: PortfolioStoreState,
+  now: Date,
+): DashboardMonthlyMetrics {
+  const tradeInvestment = state.trades
+    .filter((trade) => trade.type === "buy" && isSameMonth(trade.date, now))
+    .reduce((total, trade) => total + trade.totalValue, 0);
+  const openingInvestment = state.openingPositions
+    .filter((position) => isSameMonth(position.date, now))
+    .reduce(
+      (total, position) =>
+        total + position.quantity * position.averageCostPrice,
+      0,
+    );
+  const cashAdded = state.cashEntries
+    .filter((entry) => entry.type === "addition" && isSameMonth(entry.date, now))
+    .reduce((total, entry) => total + entry.amount, 0);
+  const cashWithdrawn = state.cashEntries
+    .filter((entry) => entry.type === "withdrawal" && isSameMonth(entry.date, now))
+    .reduce((total, entry) => total + entry.amount, 0);
+  const investment = tradeInvestment + openingInvestment;
+
+  return {
+    cashAdded,
+    cashChange: cashAdded - cashWithdrawn,
+    investment,
+    savingsRate:
+      cashAdded > 0
+        ? Number(((investment / cashAdded) * 100).toFixed(2))
+        : null,
+  };
 }
 
 export function useDashboard({
+  now = new Date(),
+  refreshQuotes = defaultRefreshQuotes,
   store = getPortfolioStore(),
 }: UseDashboardInput = {}): DashboardState {
   const snapshot = usePortfolioSnapshot(store);
+  const [quoteFailures, setQuoteFailures] = useState<QuoteRefreshFailure[]>([]);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const holdings = withQuoteMetadata(
     calculateHoldings({
       assets: snapshot.assets,
@@ -83,6 +180,35 @@ export function useDashboard({
   const cashBalance = calculateCashBalance(snapshot.cashEntries);
   const rollupRows = calculateConsolidatedHoldingRows(holdings);
   const rollupTotals = calculatePortfolioRollupTotals(rollupRows, cashBalance);
+  const latestQuote = getLatestQuote(holdings);
+
+  async function refresh() {
+    setIsRefreshing(true);
+
+    try {
+      const currentState = store.getState();
+      const result = await refreshQuotes({
+        assets: currentState.assets,
+        manualPrices: selectManualPrices(currentState),
+      });
+
+      for (const quote of Object.values(result.quoteCache)) {
+        store.getState().upsertQuote(quote);
+      }
+
+      setQuoteFailures(result.failures);
+
+      return result;
+    } finally {
+      setIsRefreshing(false);
+    }
+  }
+
+  function toggleMaskWealthValues() {
+    store.getState().updatePreferences({
+      maskWealthValues: !store.getState().preferences.maskWealthValues,
+    });
+  }
 
   return {
     allocation: calculateAllocation({
@@ -98,11 +224,17 @@ export function useDashboard({
     dayChange: calculatePortfolioDayChange(holdings),
     holdings,
     instrumentAllocation: calculateInstrumentAllocation(holdings),
-    latestQuoteAsOf: getLatestQuoteAsOf(holdings),
+    isRefreshing,
+    latestQuoteAsOf: latestQuote?.asOf,
+    latestQuoteSource: latestQuote?.source,
     maskWealthValues: snapshot.preferences.maskWealthValues,
+    monthlyMetrics: calculateMonthlyMetrics(snapshot, now),
+    quoteFailures,
+    refresh,
     rollupRows,
     rollupTotals,
     sectorAllocation: calculateSectorAllocation(holdings),
+    toggleMaskWealthValues,
     totalValue: calculatePortfolioTotal(holdings, snapshot.cashEntries),
   };
 }


### PR DESCRIPTION
## Summary
- wire Dashboard value masking and quote refresh header actions
- replace mislabeled lifetime values in This Month with monthly invested, savings, and cash-change metrics
- add issue #80 spec/plan and coverage for Dashboard actions/monthly labels

## Verification
- npm run typecheck
- npm test
- npm run doctor
- npm run android:smoke (adb found; warning: no emulator/device in device state)

Closes #80