### PR TITLE
[V1] Align Cash ledger metrics and transfer mode

### DIFF
--- a/docs/superpowers/plans/2026-05-16-issue-82-cash-ledger-alignment.md
+++ b/docs/superpowers/plans/2026-05-16-issue-82-cash-ledger-alignment.md
@@ -1,0 +1,43 @@
+# Issue #82 Cash Ledger Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align Cash Ledger with Figma V1 and Excel parity metrics without changing raw storage semantics.
+
+**Architecture:** Extend `useCash` with derived monthly metrics from store data. Keep `CashScreen` responsible for entry mode UI and map Investment Transfer to a stored withdrawal.
+
+**Tech Stack:** Expo SDK 54, React Native, TypeScript, Zustand vanilla store, Jest/RNTL.
+
+---
+
+### Task 1: Cash Hook Metrics
+
+**Files:**
+- Modify: `src/features/cash/useCash.ts`
+- Test: `src/features/cash/__tests__/useCash.test.tsx`
+
+- [x] Add `monthlyMetrics` with added, invested, available, and savings rate.
+- [x] Derive invested from current-month buy trades and opening positions.
+- [x] Add tests for metrics and not-enough-data savings state.
+
+### Task 2: Cash Screen Entry Modes And Metrics
+
+**Files:**
+- Modify: `src/features/cash/CashScreen.tsx`
+- Test: `src/features/cash/__tests__/CashScreen.test.tsx`
+
+- [x] Add Deposit, Withdraw, and Investment Transfer segmented controls.
+- [x] Map Investment Transfer to stored withdrawal entries.
+- [x] Replace the existing metric strip with Added, Invested, Available, Savings.
+- [x] Add a masked-preview line near the hero balance.
+- [x] Improve recent ledger card copy and keep masked amounts.
+- [x] Test deposit, withdrawal, transfer, metrics, and masking.
+
+### Task 3: Verification And PR
+
+- [x] Run focused Cash tests.
+- [x] Run `npm run typecheck`.
+- [x] Run `npm test`.
+- [x] Run `npm run doctor`.
+- [x] Run Android smoke if an emulator is connected.
+- [ ] Commit and create PR with `Closes #82`.

--- a/docs/superpowers/specs/2026-05-16-issue-82-cash-ledger-alignment.md
+++ b/docs/superpowers/specs/2026-05-16-issue-82-cash-ledger-alignment.md
@@ -1,0 +1,55 @@
+# Issue #82 Cash Ledger Alignment Spec
+
+## Goal
+
+Align the V1 Cash Ledger with the approved Figma direction and Excel parity:
+cash balance, monthly cash context, savings rate, and clear ledger entries.
+
+## Scope
+
+- Keep `CashEntry` raw storage as `addition` or `withdrawal`.
+- Add an `Investment Transfer` UI mode that stores as a withdrawal, because in
+  V1 it represents cash leaving available cash for investments.
+- Show Figma-aligned metrics: Added, Invested, Available, Savings.
+- Derive monthly added cash from current-month cash additions.
+- Derive invested amount from current-month buy trades plus opening positions.
+- Derive savings rate as current-month invested divided by current-month added
+  cash when added cash exists; otherwise show `Not enough data`.
+- Preserve value masking for cash balance, available cash, and ledger amounts.
+- Improve recent ledger grouping and copy without changing storage semantics.
+
+## Non-Goals
+
+- No new cash entry database type or schema migration.
+- No portfolio accounting engine for transfer matching.
+- No import/export.
+- No historical charting.
+- No fake savings values.
+
+## Data Rules
+
+- Deposit maps to `CashEntry.type = "addition"`.
+- Withdraw maps to `CashEntry.type = "withdrawal"`.
+- Investment Transfer maps to `CashEntry.type = "withdrawal"` with the user's
+  label and optional note preserved.
+- Available cash is the current cash balance.
+- Monthly invested comes from stored trades and opening positions, not from
+  hardcoded UI values.
+- Savings is `Not enough data` when current-month added cash is zero.
+
+## UX Rules
+
+- Entry modes are `Deposit`, `Withdraw`, and `Investment Transfer`.
+- Ledger rows must show positive and negative movement clearly.
+- Hero cash balance includes a masked-preview line so masking behavior is
+  explicit.
+- Cash remains local-first and low-noise.
+
+## Acceptance Checklist
+
+- Cash supports Deposit, Withdraw, and Investment Transfer.
+- Metrics are derived from stored data.
+- Savings is correct or explicitly unavailable.
+- Ledger rows show movement direction clearly.
+- Masking covers cash values.
+- Tests cover deposit, withdrawal, transfer, metrics, and masking.

--- a/src/domain/calculations/holdings.ts
+++ b/src/domain/calculations/holdings.ts
@@ -73,6 +73,13 @@ export type MonthlyProgressSummary = {
   snapshot: MonthlySnapshot;
 };
 
+export type CashMonthlyMetrics = {
+  added: number;
+  available: number;
+  invested: number;
+  savingsRate: number | null;
+};
+
 export type PortfolioDayChange = {
   absolute: number;
   percentage: number;
@@ -209,6 +216,49 @@ export function calculateCashBalance(cashEntries: CashEntry[]) {
 
     return balance + entry.amount;
   }, 0);
+}
+
+function isSameMonth(isoDate: string, now: Date) {
+  const date = new Date(isoDate);
+
+  return (
+    date.getUTCFullYear() === now.getUTCFullYear() &&
+    date.getUTCMonth() === now.getUTCMonth()
+  );
+}
+
+export function calculateCashMonthlyMetrics({
+  cashEntries,
+  now = new Date(),
+  openingPositions,
+  trades,
+}: {
+  cashEntries: CashEntry[];
+  now?: Date;
+  openingPositions: OpeningPosition[];
+  trades: Trade[];
+}): CashMonthlyMetrics {
+  const added = cashEntries
+    .filter((entry) => entry.type === "addition" && isSameMonth(entry.date, now))
+    .reduce((total, entry) => total + entry.amount, 0);
+  const tradeInvested = trades
+    .filter((trade) => trade.type === "buy" && isSameMonth(trade.date, now))
+    .reduce((total, trade) => total + trade.totalValue, 0);
+  const openingInvested = openingPositions
+    .filter((position) => isSameMonth(position.date, now))
+    .reduce(
+      (total, position) =>
+        total + position.quantity * position.averageCostPrice,
+      0,
+    );
+  const invested = tradeInvested + openingInvested;
+
+  return {
+    added,
+    available: calculateCashBalance(cashEntries),
+    invested,
+    savingsRate: added > 0 ? round((invested / added) * 100) : null,
+  };
 }
 
 export function calculatePortfolioTotal(

--- a/src/domain/calculations/index.ts
+++ b/src/domain/calculations/index.ts
@@ -1,6 +1,7 @@
 export {
   calculateAllocation,
   calculateCashBalance,
+  calculateCashMonthlyMetrics,
   calculateConsolidatedHoldingRows,
   calculateHolding,
   calculateHoldings,
@@ -16,6 +17,7 @@ export {
 } from "./holdings";
 export type {
   AllocationItem,
+  CashMonthlyMetrics,
   ConsolidatedHoldingRow,
   ConvictionReadiness,
   MonthlyAssetSnapshotItem,

--- a/src/features/cash/CashScreen.tsx
+++ b/src/features/cash/CashScreen.tsx
@@ -24,10 +24,12 @@ import type { CashEntryType } from "@/src/types";
 import { useCash } from "./useCash";
 
 type CashScreenProps = {
+  now?: Date;
   store?: StoreApi<PortfolioStoreState>;
 };
 
 type FieldErrors = Partial<Record<"amount" | "date" | "label", string>>;
+type CashEntryMode = CashEntryType | "transfer";
 
 function validateCashEntry({
   amount,
@@ -64,9 +66,45 @@ function validateCashEntry({
   };
 }
 
-export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
-  const { addEntry, balance, entries, maskWealthValues } = useCash({ store });
-  const [type, setType] = useState<CashEntryType>("addition");
+function getStoredEntryType(mode: CashEntryMode): CashEntryType {
+  return mode === "addition" ? "addition" : "withdrawal";
+}
+
+function getCashEntryModeLabel(mode: CashEntryMode) {
+  if (mode === "addition") {
+    return "Deposit";
+  }
+
+  if (mode === "transfer") {
+    return "Investment Transfer";
+  }
+
+  return "Withdraw";
+}
+
+function getCashEntryPlaceholder(mode: CashEntryMode) {
+  if (mode === "addition") {
+    return "Broker cash";
+  }
+
+  if (mode === "transfer") {
+    return "SIP transfer";
+  }
+
+  return "Withdrawal";
+}
+
+function formatSavingsRate(savingsRate: number | null) {
+  return savingsRate === null ? "Not enough data" : `${savingsRate.toFixed(2)}%`;
+}
+
+export function CashScreen({
+  now,
+  store = getPortfolioStore(),
+}: CashScreenProps) {
+  const { addEntry, balance, entries, maskWealthValues, monthlyMetrics } =
+    useCash({ now, store });
+  const [mode, setMode] = useState<CashEntryMode>("addition");
   const [amount, setAmount] = useState("");
   const [label, setLabel] = useState("");
   const [date, setDate] = useState("");
@@ -98,7 +136,7 @@ export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
       date: date.trim(),
       label: label.trim(),
       notes,
-      type,
+      type: getStoredEntryType(mode),
     });
     resetForm();
   }
@@ -119,41 +157,58 @@ export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
         <MetricGroup
           metrics={[
             {
-              label: "Entries",
-              value: entries.length.toString(),
+              label: "Added",
+              masked: maskWealthValues,
+              value: formatINR(monthlyMetrics.added),
+            },
+            {
+              label: "Invested",
+              masked: maskWealthValues,
+              value: formatINR(monthlyMetrics.invested),
             },
             {
               label: "Available",
               masked: maskWealthValues,
-              value: formatINR(balance),
+              value: formatINR(monthlyMetrics.available),
             },
             {
               label: "Savings",
-              value: "Not enough data",
+              value: formatSavingsRate(monthlyMetrics.savingsRate),
             },
           ]}
         />
 
+        {maskWealthValues ? (
+          <PremiumCard>
+            <SectionHeader title="Masked preview" />
+            <MaskedValue masked value={formatINR(balance)} />
+            <AppText color="secondary" variant="caption">
+              Value masking hides cash values using the same preview pattern as
+              portfolio totals.
+            </AppText>
+          </PremiumCard>
+        ) : null}
+
         <View style={styles.segmentedControl}>
-          {(["addition", "withdrawal"] as const).map((entryType) => (
+          {(["addition", "withdrawal", "transfer"] as const).map((entryMode) => (
             <Pressable
               accessibilityRole="button"
-              key={entryType}
+              key={entryMode}
               onPress={() => {
-                setType(entryType);
+                setMode(entryMode);
                 setErrors({});
               }}
               style={({ pressed }) => [
                 styles.segment,
-                type === entryType && styles.segmentActive,
+                mode === entryMode && styles.segmentActive,
                 pressed && styles.pressed,
               ]}
             >
               <AppText
-                color={type === entryType ? "inverse" : "secondary"}
+                color={mode === entryMode ? "inverse" : "secondary"}
                 weight="bold"
               >
-                {entryType === "addition" ? "Deposit" : "Withdraw"}
+                {getCashEntryModeLabel(entryMode)}
               </AppText>
             </Pressable>
           ))}
@@ -174,7 +229,7 @@ export function CashScreen({ store = getPortfolioStore() }: CashScreenProps) {
             error={errors.label}
             label="Label"
             onChangeText={setLabel}
-            placeholder={type === "addition" ? "Broker cash" : "Withdrawal"}
+            placeholder={getCashEntryPlaceholder(mode)}
             testID="cash-label-input"
             value={label}
           />

--- a/src/features/cash/__tests__/CashScreen.test.tsx
+++ b/src/features/cash/__tests__/CashScreen.test.tsx
@@ -49,6 +49,64 @@ describe("CashScreen", () => {
     });
   });
 
+  it("records an investment transfer as a withdrawal and shows monthly metrics", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset({
+      assetClass: "stock",
+      currency: "INR",
+      id: "asset-reliance",
+      name: "Reliance Industries",
+      symbol: "RELIANCE",
+      ticker: "RELIANCE.NS",
+    });
+    store.getState().addCashEntry({
+      amount: 100000,
+      date: "2026-05-01",
+      id: "cash-salary",
+      label: "Salary",
+      type: "addition",
+    });
+    store.getState().addTrade({
+      assetId: "asset-reliance",
+      date: "2026-05-10",
+      id: "trade-buy",
+      pricePerUnit: 100,
+      quantity: 200,
+      totalValue: 20000,
+      type: "buy",
+    });
+
+    const { getAllByText, getByLabelText, getByText } = render(
+      <CashScreen
+        now={new Date("2026-05-16T00:00:00.000Z")}
+        store={store}
+      />,
+    );
+
+    expect(getByText("Added")).toBeTruthy();
+    expect(getByText("Invested")).toBeTruthy();
+    expect(getByText("Available")).toBeTruthy();
+    expect(getByText("Savings")).toBeTruthy();
+    expect(getByText("20.00%")).toBeTruthy();
+
+    fireEvent.press(getByText("Investment Transfer"));
+    fireEvent.changeText(getByLabelText("Amount"), "20000");
+    fireEvent.changeText(getByLabelText("Label"), "SIP transfer");
+    fireEvent.changeText(getByLabelText("Date"), "2026-05-11");
+    fireEvent.press(getByText("Save Cash Entry"));
+
+    await waitFor(() => {
+      expect(getAllByText("₹80,000.00").length).toBeGreaterThan(0);
+      expect(getByText("SIP transfer")).toBeTruthy();
+      expect(getByText("-₹20,000.00")).toBeTruthy();
+    });
+    expect(store.getState().cashEntries.at(-1)).toMatchObject({
+      amount: 20000,
+      label: "SIP transfer",
+      type: "withdrawal",
+    });
+  });
+
   it("shows validation errors for invalid cash entries", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     const { getByText } = render(<CashScreen store={store} />);
@@ -76,6 +134,7 @@ describe("CashScreen", () => {
     );
 
     expect(getAllByText(MASKED_INR_VALUE).length).toBeGreaterThan(0);
+    expect(getByText("Masked preview")).toBeTruthy();
     expect(getByText("Broker cash")).toBeTruthy();
     expect(queryByText("₹1,000.00")).toBeNull();
   });

--- a/src/features/cash/__tests__/useCash.test.tsx
+++ b/src/features/cash/__tests__/useCash.test.tsx
@@ -77,4 +77,81 @@ describe("useCash", () => {
       type: "addition",
     });
   });
+
+  it("derives monthly cash metrics from stored cash and investment records", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset({
+      assetClass: "stock",
+      currency: "INR",
+      id: "asset-reliance",
+      name: "Reliance Industries",
+      symbol: "RELIANCE",
+      ticker: "RELIANCE.NS",
+    });
+    store.getState().addCashEntry({
+      amount: 100000,
+      date: "2026-05-01",
+      id: "cash-salary",
+      label: "Salary",
+      type: "addition",
+    });
+    store.getState().addCashEntry({
+      amount: 20000,
+      date: "2026-05-10",
+      id: "cash-transfer",
+      label: "SIP transfer",
+      type: "withdrawal",
+    });
+    store.getState().addTrade({
+      assetId: "asset-reliance",
+      date: "2026-05-10",
+      id: "trade-buy",
+      pricePerUnit: 100,
+      quantity: 200,
+      totalValue: 20000,
+      type: "buy",
+    });
+
+    const { result } = renderHook(() =>
+      useCash({ now: new Date("2026-05-16T00:00:00.000Z"), store }),
+    );
+
+    expect(result.current.monthlyMetrics).toEqual({
+      added: 100000,
+      available: 80000,
+      invested: 20000,
+      savingsRate: 20,
+    });
+  });
+
+  it("marks savings rate unavailable when current-month added cash is missing", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset({
+      assetClass: "stock",
+      currency: "INR",
+      id: "asset-reliance",
+      name: "Reliance Industries",
+      symbol: "RELIANCE",
+      ticker: "RELIANCE.NS",
+    });
+    store.getState().addTrade({
+      assetId: "asset-reliance",
+      date: "2026-05-10",
+      id: "trade-buy",
+      pricePerUnit: 100,
+      quantity: 200,
+      totalValue: 20000,
+      type: "buy",
+    });
+
+    const { result } = renderHook(() =>
+      useCash({ now: new Date("2026-05-16T00:00:00.000Z"), store }),
+    );
+
+    expect(result.current.monthlyMetrics).toMatchObject({
+      added: 0,
+      invested: 20000,
+      savingsRate: null,
+    });
+  });
 });

--- a/src/features/cash/useCash.ts
+++ b/src/features/cash/useCash.ts
@@ -1,12 +1,17 @@
 import { useSyncExternalStore } from "react";
 import type { StoreApi } from "zustand/vanilla";
 
-import { calculateCashBalance } from "@/src/domain/calculations";
+import {
+  calculateCashBalance,
+  calculateCashMonthlyMetrics,
+  type CashMonthlyMetrics,
+} from "@/src/domain/calculations";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
 import type { CashEntry, CashEntryType } from "@/src/types";
 import { createId } from "@/src/utils";
 
 type UseCashInput = {
+  now?: Date;
   store?: StoreApi<PortfolioStoreState>;
 };
 
@@ -23,6 +28,7 @@ export type UseCashResult = {
   balance: number;
   entries: CashEntry[];
   maskWealthValues: boolean;
+  monthlyMetrics: CashMonthlyMetrics;
 };
 
 function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
@@ -36,6 +42,7 @@ function sortCashEntries(entries: CashEntry[]) {
 }
 
 export function useCash({
+  now = new Date(),
   store = getPortfolioStore(),
 }: UseCashInput = {}): UseCashResult {
   const snapshot = usePortfolioSnapshot(store);
@@ -57,5 +64,11 @@ export function useCash({
     balance: calculateCashBalance(snapshot.cashEntries),
     entries: sortCashEntries(snapshot.cashEntries),
     maskWealthValues: snapshot.preferences.maskWealthValues,
+    monthlyMetrics: calculateCashMonthlyMetrics({
+      cashEntries: snapshot.cashEntries,
+      now,
+      openingPositions: snapshot.openingPositions,
+      trades: snapshot.trades,
+    }),
   };
 }


### PR DESCRIPTION
## Summary
- Add a pure cash monthly metric derivation for Added, Invested, Available, and Savings.
- Align Cash Ledger UI with V1 parity metrics and add Investment Transfer mode mapped to stored withdrawals.
- Add tests for monthly metrics, unavailable savings, transfer mapping, and masking copy.

## Verification
- npm test -- src/features/cash/__tests__/useCash.test.tsx src/features/cash/__tests__/CashScreen.test.tsx
- npm run typecheck
- npm test
- npm run doctor
- npm run android:smoke
- git diff --check

Closes #82