### PR TITLE
[V1] Align Settings local-first trust model

### DIFF
--- a/docs/superpowers/plans/2026-05-16-issue-83-settings-trust-model.md
+++ b/docs/superpowers/plans/2026-05-16-issue-83-settings-trust-model.md
@@ -1,0 +1,42 @@
+# Issue #83 Settings Trust Model Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align Settings with V1 local-first trust, real quote status, and explicit deferred/destructive states.
+
+**Architecture:** Extend `useSettings` to derive a small settings status view model from the store. Keep `SettingsScreen` focused on rendering classified rows and the existing value masking control.
+
+**Tech Stack:** Expo SDK 54, React Native, TypeScript, Zustand vanilla store, Jest/RNTL.
+
+---
+
+### Task 1: Settings Status Model
+
+**Files:**
+- Modify: `src/features/settings/useSettings.ts`
+- Test: `src/features/settings/__tests__/useSettings.test.tsx`
+
+- [x] Add quote status fields derived from `quoteCache`.
+- [x] Cover empty quote cache, live quote cache, and manual fallback count.
+- [x] Keep value masking toggle behavior unchanged.
+
+### Task 2: Settings Screen Classification
+
+**Files:**
+- Modify: `src/features/settings/SettingsScreen.tsx`
+- Test: `src/features/settings/__tests__/SettingsScreen.test.tsx`
+
+- [x] Render Privacy rows as explicit local-first statuses.
+- [x] Render Quotes rows using real quote status from `useSettings`.
+- [x] Mark Display and Data rows as V1 deferred/locked where unsupported.
+- [x] Ensure Clear local data is not pressable and is labelled deferred.
+- [x] Keep V2/V3 controls out of V1 Settings.
+
+### Task 3: Verification And PR
+
+- [x] Run focused Settings tests.
+- [x] Run `npm run typecheck`.
+- [x] Run `npm test`.
+- [x] Run `npm run doctor`.
+- [x] Run Android smoke if an emulator is connected.
+- [ ] Commit and create PR with `Closes #83`.

--- a/docs/superpowers/specs/2026-05-16-issue-83-settings-trust-model.md
+++ b/docs/superpowers/specs/2026-05-16-issue-83-settings-trust-model.md
@@ -1,0 +1,50 @@
+# Issue #83 Settings Trust Model Spec
+
+## Goal
+
+Align V1 Settings with the local-first trust model so every row is either a
+real control, a real status, or an explicit V1-deferred item.
+
+## Scope
+
+- Keep value masking as the only interactive Settings control in this slice.
+- Derive quote status from stored quote cache data.
+- Show local-first privacy guarantees clearly: local storage active, no account,
+  no cloud sync, no analytics.
+- Mark unsupported V1 items as locked or deferred instead of making them look
+  configurable.
+- Keep clear-local-data non-interactive until a confirmation/reset flow is
+  implemented.
+
+## Settings Row Classification
+
+- Real control: Value masking toggle.
+- Real status: local storage, account/cloud/analytics status, quote count,
+  latest quote refresh, provider mix, manual fallback count, base currency.
+- Deferred: display density changes, export/backup, clear local data.
+- Hidden from V1 Settings: Minimal Mode, LTCG, cloud sync, auth, analytics.
+
+## Quote Status Rules
+
+- If quote cache is empty, show quote freshness as `No quotes yet`.
+- If quote cache has entries, show latest quote date from the newest `asOf`
+  value.
+- Provider status is derived from quote sources:
+  - no quotes: `Waiting for holdings`
+  - at least one live source: `Live available`
+  - only manual quotes: `Manual only`
+- Manual fallback status shows the number of manual cached quotes.
+
+## Data Safety Rules
+
+- Do not implement destructive clearing in this issue.
+- Clear local data must be visibly disabled/deferred and must not be pressable.
+- Do not add fake settings values or V2/V3 controls.
+
+## Acceptance Checklist
+
+- Settings has no misleading controls.
+- Value masking remains functional and tested.
+- Quote rows reflect real quote cache state.
+- Clear local data is clearly unavailable in V1.
+- Local-first status is obvious and trustworthy.

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -22,7 +22,9 @@ type SettingsScreenProps = {
 export function SettingsScreen({
   store = getPortfolioStore(),
 }: SettingsScreenProps) {
-  const { maskWealthValues, toggleMaskWealthValues } = useSettings({ store });
+  const { maskWealthValues, quoteStatus, toggleMaskWealthValues } = useSettings({
+    store,
+  });
 
   async function handleToggleMasking() {
     toggleMaskWealthValues();
@@ -73,9 +75,27 @@ export function SettingsScreen({
           <SectionHeader title="Privacy" />
           <GroupedListRow
             icon="lock-closed-outline"
-            title="Local-first privacy"
-            meta="No backend, auth, analytics, or cloud sync is enabled in V1."
+            title="Local storage active"
+            meta="Portfolio data stays on this Android device."
             value="Active"
+          />
+          <GroupedListRow
+            icon="person-circle-outline"
+            title="No account"
+            meta="CogVest V1 has no sign-in or remote profile."
+            value="Local"
+          />
+          <GroupedListRow
+            icon="cloud-offline-outline"
+            title="No cloud sync"
+            meta="No portfolio data is sent to a backend."
+            value="Off"
+          />
+          <GroupedListRow
+            icon="analytics-outline"
+            title="No analytics"
+            meta="No product telemetry is enabled in V1."
+            value="Off"
           />
           <GroupedListRow
             icon="phone-portrait-outline"
@@ -88,14 +108,27 @@ export function SettingsScreen({
           <SectionHeader title="Quotes" />
           <GroupedListRow
             icon="refresh-outline"
-            title="Quote refresh"
-            meta="Dashboard and Holdings refresh current quotes on demand."
-            value="Manual fallback"
+            title="Latest quote refresh"
+            meta={`${quoteStatus.quoteCount} cached quote${
+              quoteStatus.quoteCount === 1 ? "" : "s"
+            } from holdings and opening positions.`}
+            value={quoteStatus.latestQuoteLabel}
+          />
+          <GroupedListRow
+            icon="pulse-outline"
+            title="Provider status"
+            meta={`${quoteStatus.liveQuoteCount} live quote${
+              quoteStatus.liveQuoteCount === 1 ? "" : "s"
+            } cached.`}
+            value={quoteStatus.providerStatus}
           />
           <GroupedListRow
             icon="cloud-offline-outline"
-            title="Provider fallback"
+            title="Manual fallback"
             meta="Manual prices remain available when quote APIs fail."
+            value={`${quoteStatus.manualFallbackCount} manual quote${
+              quoteStatus.manualFallbackCount === 1 ? "" : "s"
+            }`}
           />
         </PremiumCard>
 
@@ -108,7 +141,12 @@ export function SettingsScreen({
 
         <PremiumCard>
           <SectionHeader title="Display & App Info" />
-          <GroupedListRow title="Density" value="Standard (V1)" />
+          <GroupedListRow
+            icon="resize-outline"
+            title="Density changes"
+            meta="Standard density is fixed for V1."
+            value="V1 locked"
+          />
           <GroupedListRow title="App version 1.0.0" value="Preview" />
         </PremiumCard>
 
@@ -118,7 +156,8 @@ export function SettingsScreen({
             destructive
             icon="trash-outline"
             title="Clear local data"
-            meta="Destructive action. Keep disabled until implemented."
+            meta="Disabled until a confirmation flow is implemented."
+            value="Deferred"
           />
         </PremiumCard>
       </View>

--- a/src/features/settings/__tests__/SettingsScreen.test.tsx
+++ b/src/features/settings/__tests__/SettingsScreen.test.tsx
@@ -24,14 +24,50 @@ describe("SettingsScreen", () => {
     expect(getByText("Settings")).toBeTruthy();
     expect(getByText("Value masking")).toBeTruthy();
     expect(getByText("Values visible")).toBeTruthy();
-    expect(getByText("Local-first privacy")).toBeTruthy();
+    expect(getByText("Local storage active")).toBeTruthy();
+    expect(getByText("No account")).toBeTruthy();
+    expect(getByText("No cloud sync")).toBeTruthy();
+    expect(getByText("No analytics")).toBeTruthy();
     expect(getByText("App version 1.0.0")).toBeTruthy();
     expect(queryByText(/Minimal Mode/i)).toBeNull();
+    expect(queryByText(/LTCG/i)).toBeNull();
 
     fireEvent.press(getByLabelText("Toggle value masking"));
 
     expect(store.getState().preferences.maskWealthValues).toBe(true);
     expect(getByText("Values masked")).toBeTruthy();
     expect(Haptics.selectionAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows real quote status and marks unsupported rows as deferred", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().upsertQuote({
+      assetId: "asset-live",
+      asOf: "2026-05-15T10:00:00.000Z",
+      currency: "INR",
+      price: 100,
+      source: "yahoo",
+    });
+    store.getState().upsertQuote({
+      assetId: "asset-manual",
+      asOf: "2026-05-16T10:00:00.000Z",
+      currency: "INR",
+      price: 200,
+      source: "manual",
+    });
+
+    const { getByText, queryByTestId } = render(<SettingsScreen store={store} />);
+
+    expect(getByText("Latest quote refresh")).toBeTruthy();
+    expect(getByText("16 May 2026")).toBeTruthy();
+    expect(getByText("Provider status")).toBeTruthy();
+    expect(getByText("Live available")).toBeTruthy();
+    expect(getByText("Manual fallback")).toBeTruthy();
+    expect(getByText("1 manual quote")).toBeTruthy();
+    expect(getByText("Density changes")).toBeTruthy();
+    expect(getByText("V1 locked")).toBeTruthy();
+    expect(getByText("Clear local data")).toBeTruthy();
+    expect(getByText("Deferred")).toBeTruthy();
+    expect(queryByTestId("clear-local-data-button")).toBeNull();
   });
 });

--- a/src/features/settings/__tests__/useSettings.test.tsx
+++ b/src/features/settings/__tests__/useSettings.test.tsx
@@ -22,4 +22,47 @@ describe("useSettings", () => {
 
     expect(secondStore.getState().preferences.maskWealthValues).toBe(true);
   });
+
+  it("derives empty quote status without pretending live quotes exist", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const { result } = renderHook(() => useSettings({ store }));
+
+    expect(result.current.quoteStatus).toEqual({
+      latestQuoteAsOf: null,
+      latestQuoteLabel: "No quotes yet",
+      liveQuoteCount: 0,
+      manualFallbackCount: 0,
+      providerStatus: "Waiting for holdings",
+      quoteCount: 0,
+    });
+  });
+
+  it("derives quote freshness and manual fallback status from stored quotes", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().upsertQuote({
+      assetId: "asset-live",
+      asOf: "2026-05-15T10:00:00.000Z",
+      currency: "INR",
+      price: 100,
+      source: "yahoo",
+    });
+    store.getState().upsertQuote({
+      assetId: "asset-manual",
+      asOf: "2026-05-16T10:00:00.000Z",
+      currency: "INR",
+      price: 200,
+      source: "manual",
+    });
+
+    const { result } = renderHook(() => useSettings({ store }));
+
+    expect(result.current.quoteStatus).toEqual({
+      latestQuoteAsOf: "2026-05-16T10:00:00.000Z",
+      latestQuoteLabel: "16 May 2026",
+      liveQuoteCount: 1,
+      manualFallbackCount: 1,
+      providerStatus: "Live available",
+      quoteCount: 2,
+    });
+  });
 });

--- a/src/features/settings/useSettings.ts
+++ b/src/features/settings/useSettings.ts
@@ -1,7 +1,9 @@
 import { useSyncExternalStore } from "react";
 import type { StoreApi } from "zustand/vanilla";
 
+import { formatDate } from "@/src/domain/formatters";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import type { Quote } from "@/src/types";
 
 type UseSettingsInput = {
   store?: StoreApi<PortfolioStoreState>;
@@ -9,11 +11,54 @@ type UseSettingsInput = {
 
 export type UseSettingsResult = {
   maskWealthValues: boolean;
+  quoteStatus: SettingsQuoteStatus;
   toggleMaskWealthValues: () => void;
+};
+
+export type SettingsQuoteStatus = {
+  latestQuoteAsOf: string | null;
+  latestQuoteLabel: string;
+  liveQuoteCount: number;
+  manualFallbackCount: number;
+  providerStatus: "Live available" | "Manual only" | "Waiting for holdings";
+  quoteCount: number;
 };
 
 function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
   return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+}
+
+function getLatestQuote(quotes: Quote[]) {
+  return quotes
+    .filter((quote) => !Number.isNaN(new Date(quote.asOf).getTime()))
+    .sort(
+      (left, right) =>
+        new Date(right.asOf).getTime() - new Date(left.asOf).getTime(),
+    )[0];
+}
+
+function deriveQuoteStatus(quoteCache: PortfolioStoreState["quoteCache"]) {
+  const quotes = Object.values(quoteCache);
+  const manualFallbackCount = quotes.filter(
+    (quote) => quote.source === "manual",
+  ).length;
+  const liveQuoteCount = quotes.length - manualFallbackCount;
+  const latestQuote = getLatestQuote(quotes);
+  const providerStatus =
+    quotes.length === 0
+      ? "Waiting for holdings"
+      : liveQuoteCount > 0
+        ? "Live available"
+        : "Manual only";
+
+  return {
+    latestQuoteAsOf: latestQuote?.asOf ?? null,
+    latestQuoteLabel: latestQuote ? formatDate(latestQuote.asOf) : "No quotes yet",
+    liveQuoteCount,
+    manualFallbackCount,
+    providerStatus,
+    quoteCount: quotes.length,
+  } satisfies SettingsQuoteStatus;
 }
 
 export function useSettings({
@@ -29,6 +74,7 @@ export function useSettings({
 
   return {
     maskWealthValues: snapshot.preferences.maskWealthValues,
+    quoteStatus: deriveQuoteStatus(snapshot.quoteCache),
     toggleMaskWealthValues,
   };
 }


### PR DESCRIPTION
## Summary
- Add a Settings quote status view model derived from stored quote cache state.
- Rework Settings rows into real controls, real local-first statuses, and explicit V1 deferred rows.
- Keep value masking functional and make clear-local-data visibly deferred/non-interactive.

## Verification
- npm test -- src/features/settings/__tests__/useSettings.test.tsx src/features/settings/__tests__/SettingsScreen.test.tsx
- npm run typecheck
- npm test
- npm run doctor
- npm run android:smoke
- git diff --check

Closes #83