### PR TITLE
[V1] Normalize Progress route naming

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -9,7 +9,7 @@ type TabIconName = keyof typeof Ionicons.glyphMap;
 const tabIcons: Record<string, TabIconName> = {
   dashboard: "home-outline",
   holdings: "pie-chart-outline",
-  history: "analytics-outline",
+  progress: "analytics-outline",
   cash: "wallet-outline",
   settings: "settings-outline",
 };
@@ -54,7 +54,7 @@ export default function TabLayout() {
         options={{ tabBarButtonTestID: "tab-holdings", title: "Holdings" }}
       />
       <Tabs.Screen
-        name="history"
+        name="progress"
         options={{ tabBarButtonTestID: "tab-progress", title: "Progress" }}
       />
       <Tabs.Screen

--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -1,5 +1,0 @@
-import { ProgressScreen } from "@/src/features/progress";
-
-export default function HistoryScreen() {
-  return <ProgressScreen />;
-}

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -1,5 +1,5 @@
 import { ProgressScreen } from "@/src/features/progress";
 
-export default function ProgressRoute() {
+export default function ProgressTabScreen() {
   return <ProgressScreen />;
 }

--- a/docs/housekeeping/code-review-findings.md
+++ b/docs/housekeeping/code-review-findings.md
@@ -46,30 +46,20 @@ Android PC verification requirements.
 - Impact: #65 is not complete and the Excel `Progression` sheet is not yet
   replaced.
 
-### Important: Dashboard action icons appear interactive but have no behavior
+### Resolved: Dashboard action icons appear interactive but have no behavior
 
-- Evidence: `src/features/dashboard/DashboardScreen.tsx` renders value-visibility
-  and refresh `IconButton`s without `onPress`.
-- Evidence: `src/components/common/Premium.tsx` always renders `IconButton` as a
-  button-like `Pressable`.
-- Impact: Users can tap visible controls that do nothing. This should either be
-  wired to masking/quote refresh or rendered as non-interactive status affordance.
+- Later update: #75 was verified and closed after `DashboardScreen` wired
+  value masking and quote refresh actions with test coverage.
 
-### Important: Settings exposes unavailable or non-functional controls
+### Resolved: Settings exposes unavailable or non-functional controls
 
-- Evidence: `src/features/settings/SettingsScreen.tsx` should be reviewed before
-  V1 dev-complete for any rows that look toggleable but are only static.
-- Impact: Settings is supposed to build local-first trust. Unsupported controls
-  should be explicitly marked unavailable, locked, or informational.
+- Later update: #83 aligned Settings rows with real controls, real status, and
+  explicit V1-deferred states.
 
-### Moderate: Route naming is inconsistent for Progress
+### Resolved: Route naming is inconsistent for Progress
 
-- Evidence: `app/(tabs)/history.tsx` renders `ProgressScreen`, while the tab title
-  and test ID are `Progress`.
-- Evidence: `app/progress.tsx` also renders `ProgressScreen` outside the tab
-  group.
-- Impact: The UI says Progress, but the tab route remains `history`. This can
-  confuse E2E, docs, deep links, and future implementation work.
+- Later update: #76 normalized the tab route to `app/(tabs)/progress.tsx` and
+  removed the duplicate root `app/progress.tsx` route.
 
 ### Moderate: Add Holding still stores trade-shaped records
 

--- a/docs/housekeeping/current-app-state.md
+++ b/docs/housekeeping/current-app-state.md
@@ -30,7 +30,7 @@ lightweight asset lookup/autofill, and complete V1 E2E verification.
 | Holdings | `app/(tabs)/holdings.tsx` | `src/features/holdings` | Implemented. Shows derived holdings, filters, refresh, quote failures, invested/current/P&L/allocation details. |
 | Add Holding | `app/add-holding.tsx` | `src/features/trades` | Implemented as an Add Holding UI backed by trade/opening-entry storage. Supports buy/sell, manual asset creation, review, save, conviction, and manual quote upsert. |
 | Cash | `app/(tabs)/cash.tsx` | `src/features/cash` | Implemented. Supports additions and withdrawals, balance, recent ledger, masking. |
-| Monthly Progress | `app/(tabs)/history.tsx` and `app/progress.tsx` | `src/features/progress` | Partial. Current-month derived summary exists; persistent monthly snapshots are not implemented. |
+| Monthly Progress | `app/(tabs)/progress.tsx` | `src/features/progress` | Partial. Current-month derived summary exists; persistent monthly snapshots are not implemented. Route naming normalized by #76. |
 | Settings | `app/(tabs)/settings.tsx` | `src/features/settings` | Implemented. Supports local-first status and value masking toggle. |
 
 ## Implemented Data and Domain Areas

--- a/docs/housekeeping/issue-triage.md
+++ b/docs/housekeeping/issue-triage.md
@@ -60,7 +60,8 @@ Suggested acceptance criteria:
 - Refresh icon triggers quote refresh or is removed.
 - Tests cover the chosen behavior.
 
-Status: Created as https://github.com/abdul-shaikh-dev/CogVest/issues/75
+Status: Verified and closed after Dashboard value masking and quote refresh
+actions were wired and covered by tests.
 
 ### #76 [V1] Normalize Progress route naming
 
@@ -77,7 +78,9 @@ Suggested acceptance criteria:
 - Maestro navigation continues to target stable `tab-progress` and
   `progress-screen` IDs.
 
-Status: Created as https://github.com/abdul-shaikh-dev/CogVest/issues/76
+Status: Implemented by normalizing the tab route to
+`app/(tabs)/progress.tsx`, preserving `tab-progress` and `progress-screen`, and
+removing the duplicate root `app/progress.tsx` route.
 
 ## Issue Creation Status
 

--- a/docs/superpowers/plans/2026-05-16-issue-76-progress-route-naming.md
+++ b/docs/superpowers/plans/2026-05-16-issue-76-progress-route-naming.md
@@ -1,0 +1,43 @@
+# Issue #76 Progress Route Naming Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Normalize Expo Router Progress naming without changing user-facing behavior.
+
+**Architecture:** Keep `ProgressScreen` unchanged. Update only route files, tab layout route names, and tests that assert file-based routing.
+
+**Tech Stack:** Expo Router, React Native, TypeScript, Jest/RNTL, Maestro YAML IDs.
+
+---
+
+### Task 1: Route Test
+
+**Files:**
+- Modify: `src/__tests__/rootLayout.test.tsx`
+- Modify: `src/__tests__/rootRoute.test.ts`
+
+- [x] Add/update assertions that the tab route is named `progress`.
+- [x] Assert stale `history` route code is not required by tests.
+- [x] Run route tests and verify they fail before the route rename.
+
+### Task 2: Rename Progress Tab Route
+
+**Files:**
+- Move: `app/(tabs)/history.tsx` to `app/(tabs)/progress.tsx`
+- Delete: `app/progress.tsx`
+- Modify: `app/(tabs)/_layout.tsx`
+
+- [x] Rename the route component from `HistoryScreen` to `ProgressTabScreen`.
+- [x] Change tab icon map key from `history` to `progress`.
+- [x] Change `<Tabs.Screen name="history">` to `<Tabs.Screen name="progress">`.
+- [x] Preserve `tabBarButtonTestID: "tab-progress"` and title `Progress`.
+- [x] Remove duplicate root `app/progress.tsx`.
+
+### Task 3: Verification And PR
+
+- [x] Run focused route and Progress tests.
+- [x] Run `npm run typecheck`.
+- [x] Run `npm test`.
+- [x] Run `npm run doctor`.
+- [x] Run Android smoke if an emulator is connected.
+- [ ] Commit and create PR with `Closes #76`.

--- a/docs/superpowers/specs/2026-05-16-issue-76-progress-route-naming.md
+++ b/docs/superpowers/specs/2026-05-16-issue-76-progress-route-naming.md
@@ -1,0 +1,29 @@
+# Issue #76 Progress Route Naming Spec
+
+## Goal
+
+Normalize the V1 Progress route so file-based Expo Router names match the
+user-facing Progress / Monthly Progress language.
+
+## Scope
+
+- Rename the tab route from `history` to `progress`.
+- Keep the tab label `Progress`.
+- Keep stable automation IDs: `tab-progress` and `progress-screen`.
+- Remove the duplicate root-level Progress route unless tests prove it is
+  required.
+- Do not change Monthly Progress product behavior or UI layout.
+
+## Non-Goals
+
+- No Progress screen redesign.
+- No monthly snapshot logic changes.
+- No changes to Maestro IDs or user-facing labels.
+
+## Acceptance Checklist
+
+- The tab route file is `app/(tabs)/progress.tsx`.
+- The tab layout registers `name="progress"`.
+- The tab icon mapping uses `progress`, not `history`.
+- `history` route references are removed from app code.
+- Existing Progress screen tests and route tests pass.

--- a/src/__tests__/rootRoute.test.ts
+++ b/src/__tests__/rootRoute.test.ts
@@ -1,9 +1,17 @@
 import IndexRoute from "../../app/index";
+import ProgressTabRoute from "../../app/(tabs)/progress";
+import { ProgressScreen } from "../features/progress";
 
 describe("root route", () => {
   it("redirects launcher cold starts to the dashboard tab", () => {
     const redirectElement = IndexRoute() as { props: { href: string } };
 
     expect(redirectElement.props.href).toBe("/(tabs)/dashboard");
+  });
+
+  it("exposes the Progress tab route as a named file-based route", () => {
+    const routeElement = ProgressTabRoute() as { type: unknown };
+
+    expect(routeElement.type).toBe(ProgressScreen);
   });
 });

--- a/src/__tests__/tabLayout.test.tsx
+++ b/src/__tests__/tabLayout.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+
+import TabLayout from "../../app/(tabs)/_layout";
+
+jest.mock("expo-router", () => {
+  const React = require("react");
+
+  const Tabs = ({
+    children,
+    screenOptions,
+  }: {
+    children: React.ReactNode;
+    screenOptions?: unknown;
+  }) => React.createElement("Tabs", { screenOptions }, children);
+  Tabs.Screen = ({
+    name,
+    options,
+  }: {
+    name: string;
+    options?: Record<string, unknown>;
+  }) => React.createElement("Tabs.Screen", { name, options });
+
+  return { Tabs };
+});
+
+type TestElement = React.ReactElement<{
+  children?: React.ReactNode;
+  name?: string;
+  options?: Record<string, unknown>;
+}>;
+
+function isElement(node: unknown): node is TestElement {
+  return React.isValidElement(node);
+}
+
+function collectScreens(node: unknown): TestElement[] {
+  if (!isElement(node)) {
+    return [];
+  }
+
+  const ownScreen = node.props.name ? [node] : [];
+  const childScreens = React.Children.toArray(node.props.children).flatMap(
+    collectScreens,
+  );
+
+  return [...ownScreen, ...childScreens];
+}
+
+describe("TabLayout", () => {
+  it("registers Progress as the tab route name with stable automation ID", () => {
+    const layout = TabLayout();
+    const screens = collectScreens(layout);
+    const progress = screens.find((screen) => screen.props.name === "progress");
+
+    expect(progress?.props.options).toMatchObject({
+      tabBarButtonTestID: "tab-progress",
+      title: "Progress",
+    });
+    expect(screens.some((screen) => screen.props.name === "history")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Rename the Progress tab route from history to progress while preserving tab-progress and progress-screen automation IDs.
- Remove the duplicate root-level app/progress route.
- Add route/layout tests and update housekeeping docs for #75/#76/#83 state.

## Verification
- npm test -- src/features/dashboard/__tests__/DashboardScreen.test.tsx
- npm test -- src/__tests__/rootRoute.test.ts src/__tests__/tabLayout.test.tsx src/features/progress/__tests__/ProgressScreen.test.tsx
- npm run typecheck
- npm test
- npm run doctor
- npm run android:smoke
- git diff --check

Closes #76