### PR TITLE
[V1] Record Excel parity closeout evidence

### DIFF
--- a/docs/housekeeping/code-review-findings.md
+++ b/docs/housekeeping/code-review-findings.md
@@ -2,8 +2,8 @@
 
 Date: 2026-05-06
 
-Status: historical review snapshot. Findings that cite #72 predate PR #78 and
-must be re-verified before being treated as current defects.
+Status: historical review snapshot. For current V1 Excel parity closeout
+evidence, see `docs/testing/excel-parity-verification-2026-05-19.md`.
 
 Review mode: current-state review against V1 MVP, issue #60 Excel parity, and
 Android PC verification requirements.
@@ -20,31 +20,17 @@ Android PC verification requirements.
 - Impact: re-run the Maestro navigation/core-flow suite before deciding whether
   any runtime blocker remains.
 
-### Important: Asset metadata is too narrow for Excel parity
+### Resolved: Asset metadata is too narrow for Excel parity
 
-- Evidence: `src/types/asset.ts` defines `AssetClass` as
-  `crypto | stock | etf | cash`.
-- Evidence: `src/features/trades/add-trade-form.tsx` manual asset creation
-  defaults every new asset to `assetClass: "stock"`, `currency: "INR"`, and
-  `exchange: "NSE"`.
-- Impact: #62 cannot close. The app cannot capture instrument type, sector type,
-  quote source identifier, or user-selected category without code changes.
+- Later update: #62 expanded V1 asset metadata for tracker parity and closed.
 
-### Important: Debt is not first-class
+### Resolved: Debt is not first-class
 
-- Evidence: `src/types/asset.ts` has no `debt` asset class.
-- Evidence: `src/components/common/Premium.tsx` labels `etf` as `Debt`, which
-  conflates ETF/funds with debt instruments.
-- Impact: #63 and the #60 equity/debt/crypto/cash gate remain incomplete.
+- Later update: #63 added debt and crypto tracker parity and closed.
 
-### Important: Monthly Progress is derived-current-month only
+### Resolved: Monthly Progress is derived-current-month only
 
-- Evidence: `src/features/progress/ProgressScreen.tsx` computes current-month
-  investment and cash from trades/cash entries.
-- Missing: persisted monthly snapshot model, salary/income, expense rate, monthly
-  gain/gain percentage, editable monthly records.
-- Impact: #65 is not complete and the Excel `Progression` sheet is not yet
-  replaced.
+- Later update: #65 added monthly progression snapshots and closed.
 
 ### Resolved: Dashboard action icons appear interactive but have no behavior
 
@@ -61,25 +47,18 @@ Android PC verification requirements.
 - Later update: #76 normalized the tab route to `app/(tabs)/progress.tsx` and
   removed the duplicate root `app/progress.tsx` route.
 
-### Moderate: Add Holding still stores trade-shaped records
+### Resolved: Add Holding still stores trade-shaped records
 
-- Evidence: Add Holding uses `Trade` and `addTrade`, with a manual quote upsert.
-- Impact: This may be acceptable as an implementation bridge, but #61 asks for
-  opening-position semantics. The next implementation should decide whether an
-  opening position is a first-class source record or a typed trade variant.
+- Later update: #61 and #79 implemented opening-position semantics and the
+  multi-phase Add Holding flow.
 
-### Moderate: Tests are broad but not enough for Excel parity
+### Resolved: Tests are broad but not enough for Excel parity
 
-- Evidence: Jest has good coverage across current screens/domain/services.
-- Gap: No tests for instrument/sector metadata, debt manual assets, monthly
-  snapshot persistence, salary/expense rate, or the full Excel parity checklist.
-- Impact: #66 remains necessary.
+- Later update: #66 added `docs/testing/excel-parity-checklist.md`, and #60
+  closeout evidence records the V1 PC gate.
 
 ## Recommended Priority
 
-1. Fix #72.
-2. Add asset metadata and debt category (#62/#63).
-3. Make Add Holding explicitly support opening-position fields (#61).
-4. Add consolidated rollups and allocation details (#64).
-5. Add monthly snapshots (#65).
-6. Add Excel parity checklist and tests (#66).
+1. Merge the #60 closeout evidence PR if CI passes.
+2. Re-run local release/APK verification before V1 dev-complete.
+3. Keep V2/V3 issues as future placeholders until V1 closeout is accepted.

--- a/docs/housekeeping/current-app-state.md
+++ b/docs/housekeeping/current-app-state.md
@@ -3,6 +3,8 @@
 Date: 2026-05-06
 
 Status: historical review snapshot, updated by later housekeeping where noted.
+For current V1 Excel parity closeout evidence, see
+`docs/testing/excel-parity-verification-2026-05-19.md`.
 
 Base commit reviewed: `bcbeeed Merge pull request #73 from abdul-shaikh-dev/docs/superpowers-workflow-agents`
 
@@ -18,9 +20,10 @@ CogVest has a working V1 app shell with local-first portfolio data, derived
 holdings, dashboard summaries, cash tracking, quote refresh plumbing, value
 masking, Android PC harness scripts, and Maestro flows.
 
-It is not yet Excel-parity complete. The biggest product gaps are the
-Excel-style metadata model, first-class debt support, monthly snapshots,
-lightweight asset lookup/autofill, and complete V1 E2E verification.
+Later V1 work closed the Excel parity slices for metadata, debt/crypto support,
+monthly snapshots, asset lookup/autofill, rollups, and the parity gate. Treat
+the detailed findings below as historical unless they are still reproduced on
+current `main`.
 
 ## Implemented Screens
 
@@ -30,7 +33,7 @@ lightweight asset lookup/autofill, and complete V1 E2E verification.
 | Holdings | `app/(tabs)/holdings.tsx` | `src/features/holdings` | Implemented. Shows derived holdings, filters, refresh, quote failures, invested/current/P&L/allocation details. |
 | Add Holding | `app/add-holding.tsx` | `src/features/trades` | Implemented as an Add Holding UI backed by trade/opening-entry storage. Supports buy/sell, manual asset creation, review, save, conviction, and manual quote upsert. |
 | Cash | `app/(tabs)/cash.tsx` | `src/features/cash` | Implemented. Supports additions and withdrawals, balance, recent ledger, masking. |
-| Monthly Progress | `app/(tabs)/progress.tsx` | `src/features/progress` | Partial. Current-month derived summary exists; persistent monthly snapshots are not implemented. Route naming normalized by #76. |
+| Monthly Progress | `app/(tabs)/progress.tsx` | `src/features/progress` | Implemented for V1 snapshots and route naming; see #65 and #76 closeout. |
 | Settings | `app/(tabs)/settings.tsx` | `src/features/settings` | Implemented. Supports local-first status and value masking toggle. |
 
 ## Implemented Data and Domain Areas
@@ -41,45 +44,42 @@ lightweight asset lookup/autofill, and complete V1 E2E verification.
 | Derived holdings | `src/domain/calculations/holdings.ts` derives holdings from assets, trades, and quotes. | Implemented. |
 | Cash balance | `calculateCashBalance` and `useCash` derive balance from cash entries. | Implemented. |
 | Portfolio total | `calculatePortfolioTotal` combines holdings current value and cash. | Implemented. |
-| Allocation | `calculateAllocation` groups by current `AssetClass`. | Partial: groups stock/etf/crypto/cash, but no first-class debt class. |
+| Allocation | `calculateAllocation` groups by current `AssetClass`. | Implemented for V1 equity/debt/crypto/cash parity. |
 | Quote refresh | `src/services/quotes/quoteResolver.ts` supports Yahoo/CoinGecko and manual fallback. | Implemented for supported asset classes. |
 | Value masking | Settings preference flows into Dashboard, Holdings, Cash, and Progress. | Implemented in core value displays. |
 | Conviction | Optional conviction is accepted on Add Holding and dashboard readiness is derived. | Lightweight V1 state implemented. |
-| Monthly snapshots | No persisted monthly snapshot model found. | Missing; issue #65 remains open. |
+| Monthly snapshots | `src/store/index.ts` persists monthly snapshots and `calculateMonthlyProgressSummaries` derives summaries. | Implemented by #65. |
 
 ## Excel Parity Gate Status
 
 | Question from #60 | Current status | Evidence / gap |
 | --- | --- | --- |
-| What do I own? | Partial | Holdings screen derives current holdings from stored assets/trades. Opening position entry exists, but asset metadata is narrow. |
-| How much did I invest? | Partial | Dashboard/Holdings derive invested value. Needs consolidated rollup hardening under #64. |
-| What is it worth now? | Partial | Current value derives from quote cache/manual quote. Live/manual fallback exists, but unsupported/debt instruments need better handling. |
-| What is my P&L and P&L %? | Partial | Holding and dashboard P&L exist. Consolidated tests/rollup issue #64 remains open. |
-| How is my portfolio allocated? | Partial | Asset-class allocation exists. No sector/instrument allocation; debt class missing. |
-| How much is in equity, debt, crypto, and cash? | Partial | Equity/crypto/cash can be represented. Debt is not first-class; `etf` is currently labelled as Debt in UI config. |
-| What changed this month? | Partial | Progress screen derives current-month investment/cash, but no monthly snapshot model or monthly gain persistence. |
-| How much did I invest this month? | Partial | Progress screen derives current-month buy totals from trades. |
-| What is my savings/investment rate? | Partial | Progress screen computes investment/cash-added percentage if cash was added. Salary/expense rate fields are missing. |
-| Can I continue daily tracking without opening Excel? | Not yet | Core data entry exists, but #61-#66 and #72 block the parity gate. |
+| What do I own? | Pass in closeout evidence | Holdings and Add Holding opening-position flow cover stored assets and quantities. |
+| How much did I invest? | Pass in closeout evidence | Dashboard, Holdings, Monthly Progress, and calculations tests cover invested values. |
+| What is it worth now? | Pass in closeout evidence | Quote/manual prices drive Dashboard and Holdings current values. |
+| What is my P&L and P&L %? | Pass in closeout evidence | Dashboard, Holdings, and calculations tests cover P&L amount and percentage. |
+| How is my portfolio allocated? | Pass in closeout evidence | Dashboard/Holdings allocation and rollups are covered by #64 and later UI alignment. |
+| How much is in equity, debt, crypto, and cash? | Pass in closeout evidence | Asset metadata, debt/crypto parity, cash, and Progress snapshots are covered. |
+| What changed this month? | Pass in closeout evidence | Monthly Progress snapshots cover monthly gain and gain %. |
+| How much did I invest this month? | Pass in closeout evidence | Monthly Progress and Cash Ledger metrics cover monthly investment context. |
+| What is my savings/investment rate? | Pass in closeout evidence | Monthly Progress and Cash Ledger metrics cover savings/investment rate context. |
+| Can I continue daily tracking without opening Excel? | Pass in closeout evidence | #61-#66 are closed and `docs/testing/excel-parity-verification-2026-05-19.md` records the V1 PC gate. |
 
 ## GitHub Issue Alignment
 
 | Issue | Review result |
 | --- | --- |
-| #60 Excel tracker parity MVP | Keep open. Parent issue is not complete. |
-| #61 Opening positions | Partial. Add Holding can create a holding, but it is still trade-shaped and lacks required metadata/current-position semantics. |
-| #62 Asset metadata | Not complete. Asset model lacks instrument type, sector type, quote source identifier, and debt category. |
-| #63 Debt and crypto parity | Partial. Crypto path exists; debt path is missing as a first-class category. |
-| #64 Consolidated rollups | Partial. Totals/allocation exist but sector/instrument grouping and allocation details are missing. |
-| #65 Monthly snapshots | Not complete. Current progress screen is derived-current-month only. |
-| #66 Excel parity gate docs/tests | Not complete. Existing testing docs mention V1 flows but do not provide a full Excel parity checklist. |
+| #60 Excel tracker parity MVP | Closeout PR pending. See `docs/testing/excel-parity-verification-2026-05-19.md`. |
+| #61 Opening positions | Closed. |
+| #62 Asset metadata | Closed. |
+| #63 Debt and crypto parity | Closed. |
+| #64 Consolidated rollups | Closed. |
+| #65 Monthly snapshots | Closed. |
+| #66 Excel parity gate docs/tests | Closed. |
 | #72 Android release APK navigation | Historical finding. Addressed by PR #78; re-run Maestro before relying on current status. |
 
 ## Next Recommended Order
 
-1. Implement #62 before expanding the UI further; metadata is the base for #63 and #64.
-2. Implement #84 so Add Holding can lookup/autofill common asset metadata and prices.
-3. Implement #61/#79 with explicit multi-phase opening-position semantics after the metadata model is settled.
-4. Implement #63 and #64 together or back-to-back because debt support and rollups share the same model boundary.
-5. Implement #65 monthly snapshots.
-6. Complete #66 and then evaluate #60 for closure.
+1. Merge the #60 closeout evidence PR if CI passes.
+2. Re-run local release/APK verification before V1 dev-complete.
+3. Keep V2/V3 issues as future placeholders until V1 closeout is accepted.

--- a/docs/housekeeping/issue-triage.md
+++ b/docs/housekeeping/issue-triage.md
@@ -2,8 +2,8 @@
 
 Date: 2026-05-06
 
-Status: historical issue-triage snapshot. #72 was later addressed by PR #78,
-and later issues #79-#84 were created after this report.
+Status: historical issue-triage snapshot. For current V1 Excel parity closeout
+evidence, see `docs/testing/excel-parity-verification-2026-05-19.md`.
 
 ## Repository State
 
@@ -17,13 +17,13 @@ and later issues #79-#84 were created after this report.
 | Issue | State | Recommendation |
 | --- | --- | --- |
 | #72 Android release APK bottom navigation bug | Historical: later addressed by PR #78 | Re-run Maestro before treating this as current. |
-| #60 Excel tracker parity MVP | Open | Keep open. Parent cannot close until #61-#66 are complete and verified. |
-| #61 Opening positions | Open | Keep open. Current Add Holding is partial but does not satisfy all acceptance criteria. |
-| #62 Asset metadata | Open | Keep open and do next after #72. Required for debt/sector/instrument parity. |
-| #63 Debt and crypto parity | Open | Keep open. Crypto is partial; debt is missing as first-class category. |
-| #64 Consolidated rollups | Open | Keep open. Core totals exist; richer rollups/allocation details remain. |
-| #65 Monthly progression snapshots | Open | Keep open. Current Progress screen does not persist monthly snapshots. |
-| #66 Excel parity gate docs/tests | Open | Keep open. Existing docs do not yet provide the full parity checklist. |
+| #60 Excel tracker parity MVP | Closeout PR pending | See `docs/testing/excel-parity-verification-2026-05-19.md`. |
+| #61 Opening positions | Closed | Implemented by V1 opening-position work. |
+| #62 Asset metadata | Closed | Implemented by V1 metadata work. |
+| #63 Debt and crypto parity | Closed | Implemented by V1 debt/crypto parity work. |
+| #64 Consolidated rollups | Closed | Implemented by V1 consolidated rollup work. |
+| #65 Monthly progression snapshots | Closed | Implemented by V1 monthly snapshot work. |
+| #66 Excel parity gate docs/tests | Closed | Implemented through `docs/testing/excel-parity-checklist.md`. |
 | #17-#21 V2 issues | Open | Leave open as future placeholders. Do not expand until V1 parity is validated. |
 | #22-#26 V3 issues | Open | Leave open as future placeholders. Do not expand until V1/V2 are validated. |
 

--- a/docs/superpowers/plans/2026-05-19-issue-60-excel-parity-closeout.md
+++ b/docs/superpowers/plans/2026-05-19-issue-60-excel-parity-closeout.md
@@ -1,0 +1,42 @@
+# Issue #60 Excel Parity Closeout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce evidence that V1 Excel tracker parity can be closed without adding new feature scope.
+
+**Architecture:** Docs/evidence-only closeout. Use existing app tests, Android PC harness scripts, and parity checklist as the source of truth.
+
+**Tech Stack:** Expo SDK 54, Jest/RNTL, Expo doctor, adb Android Emulator smoke, GitHub issue closure through PR.
+
+---
+
+### Task 1: Verification Evidence
+
+**Files:**
+- Create: `docs/testing/excel-parity-verification-2026-05-19.md`
+
+- [x] Run `npm run test:v1:pc`.
+- [x] Record command result, emulator/package status, and date.
+- [x] Map every #60 parity question to app screen, test evidence, and status.
+- [x] Record that no EAS cloud build was run.
+
+### Task 2: Stale Housekeeping Status
+
+**Files:**
+- Modify: `docs/housekeeping/current-app-state.md`
+- Modify: `docs/housekeeping/code-review-findings.md`
+- Modify: `docs/housekeeping/issue-triage.md`
+
+- [x] Replace historical incomplete #60 status with a dated note pointing to the new evidence file.
+- [x] Mark #61 through #66 as closed/implemented in the historical triage sections.
+- [x] Preserve historical context while preventing stale instructions from misleading future agents.
+
+### Task 3: Verification And PR
+
+- [x] Run `npm run typecheck`.
+- [x] Run `npm test`.
+- [x] Run `npm run doctor`.
+- [x] Run `npm run android:doctor`.
+- [x] Run `npm run android:smoke -- --strict`.
+- [x] Run `git diff --check`.
+- [ ] Commit and create PR with `Closes #60`.

--- a/docs/superpowers/specs/2026-05-19-issue-60-excel-parity-closeout.md
+++ b/docs/superpowers/specs/2026-05-19-issue-60-excel-parity-closeout.md
@@ -1,0 +1,42 @@
+# Issue #60 Excel Parity Closeout Spec
+
+## Goal
+
+Close out the V1 Excel tracker parity parent issue with current evidence, not
+new product scope.
+
+## Scope
+
+- Verify that #61 through #66 have been implemented and closed.
+- Run the V1 PC verification gate on the current branch.
+- Record command evidence for static tests, Expo doctor, Android doctor, and
+  strict installed-app smoke.
+- Update stale housekeeping docs that still describe #60 parity as incomplete
+  because they predate the V1 issue sequence.
+- Add an evidence file under `docs/testing/` that maps #60 gate questions to
+  current app locations and automated/manual evidence.
+
+## Non-Goals
+
+- No new portfolio features.
+- No Excel import/export.
+- No V2/V3 work.
+- No EAS cloud build.
+- No Play Store release work.
+
+## Closure Rule
+
+#60 can be closed only if:
+
+- `npm run test:v1:pc` passes on this PC.
+- Android smoke finds `com.abdulshaikh.cogvest` installed on the emulator.
+- The parity evidence file documents every #60 question as pass or linked
+  defect.
+- Any stale docs are updated to avoid telling future agents the closed V1
+  slices are still missing.
+
+## Expected Output
+
+- `docs/testing/excel-parity-verification-2026-05-19.md`
+- Updated housekeeping status docs.
+- PR body includes `Closes #60`.

--- a/docs/testing/excel-parity-checklist.md
+++ b/docs/testing/excel-parity-checklist.md
@@ -5,6 +5,8 @@
 This is the V1 Excel tracker parity gate. V1 is not dev-complete until this
 checklist passes or every failed row has a linked defect.
 
+Current closeout evidence: `docs/testing/excel-parity-verification-2026-05-19.md`.
+
 CogVest should replace the useful tracking concepts from `Portfolio.xlsm`
 without recreating Excel as a spreadsheet UI. The app should stay mobile-first,
 calm, local-first, and aligned with `DESIGN.md`.

--- a/docs/testing/excel-parity-verification-2026-05-19.md
+++ b/docs/testing/excel-parity-verification-2026-05-19.md
@@ -1,0 +1,132 @@
+# Excel Parity Verification Evidence
+
+Date: 2026-05-19  
+Branch: `v1/issue-60-excel-parity-closeout`  
+Purpose: closeout evidence for #60, the V1 Excel tracker parity parent issue.
+
+## Summary
+
+V1 Excel tracker parity is represented by closed issues #61 through #66 and the
+current V1 UI alignment issues #79 through #84. The app stores raw portfolio
+records and derives portfolio views through domain functions, matching the #60
+principle without recreating Excel as a spreadsheet UI.
+
+This evidence file records the PC-only verification gate and maps every #60
+gate question to the current app surface and automated evidence.
+
+## GitHub Issue State
+
+Closed V1 parity sub-issues:
+
+- #61 Add opening positions for Excel-style holdings entry.
+- #62 Expand asset metadata for Excel tracker fields.
+- #63 Add debt and crypto tracker parity.
+- #64 Build consolidated portfolio rollups and allocation details.
+- #65 Add monthly progression snapshots.
+- #66 Document and test Excel tracker parity gate.
+
+Related closed V1 UI and verification issues:
+
+- #79 Multi-phase Add Holding flow.
+- #80 Dashboard Figma/Excel parity alignment.
+- #81 Holdings interactions and filters.
+- #82 Cash ledger alignment.
+- #83 Settings local-first trust model.
+- #84 Asset lookup and price autofill.
+- #76 Progress route naming.
+
+## PC Gate Evidence
+
+Command:
+
+```powershell
+npm run test:v1:pc
+```
+
+Result: passed on rerun with elevated network permission.
+
+Evidence:
+
+- `npm run typecheck`: passed.
+- `npm test`: passed, 32 suites and 140 tests.
+- `npm run doctor`: passed, 17/17 checks.
+- `npm run android:doctor`: passed; detected `emulator-5554`, Expo CLI via
+  `npx`, required package scripts, and Maestro.
+- `npm run android:smoke -- --strict`: passed; detected installed package
+  `com.abdulshaikh.cogvest`.
+
+First attempt note:
+
+- The first `npm run test:v1:pc` attempt failed in Expo doctor because Expo API
+  and React Native Directory checks hit sandbox network `EACCES`.
+- The same command passed when rerun with network permission.
+
+## Optional Maestro Evidence
+
+Command:
+
+```powershell
+npm run maestro:test
+```
+
+Result: not used as a blocking parity gate in this closeout.
+
+Observed result:
+
+- Maestro launched the installed app on `Pixel_8`.
+- The installed dev build showed React Native's `Unable to load script` screen
+  because Metro was not running / no release JS bundle was packaged.
+- This is an installed dev-build environment state, not evidence that the Excel
+  parity data model or screens are missing.
+
+Debug artifact:
+
+```text
+C:\Users\abdul\.maestro\tests\2026-05-19_221033
+```
+
+Follow-up rule:
+
+- For future Maestro runs against a dev build, start Metro first.
+- For release-style no-Metro E2E, install a local release/preview APK with a
+  packaged JS bundle.
+
+## Excel Parity Gate Questions
+
+| #60 question | Current V1 answer | Automated evidence | Status |
+| --- | --- | --- | --- |
+| What do I own? | Holdings and Add Holding opening positions show stored assets and quantities. | `AddOpeningPositionForm.test.tsx`, `HoldingsScreen.test.tsx`, holdings domain tests. | Pass |
+| How much did I invest? | Dashboard, Holdings, and Monthly Progress show invested values derived from raw records. | Dashboard, Holdings, Progress, and calculations tests. | Pass |
+| What is it worth now? | Quote cache/manual prices feed current values in Dashboard and Holdings. | Quote service tests, Dashboard tests, Holdings tests. | Pass |
+| What is my P&L and P&L %? | Portfolio and holding P&L/P&L % are derived and rendered. | Dashboard, Holdings, and calculations tests. | Pass |
+| How is my portfolio allocated? | Dashboard and Holdings show allocation by asset class and holding rows. | Dashboard, Holdings, and allocation calculation tests. | Pass |
+| How much is in equity, debt, crypto, and cash? | Asset metadata and allocation support equity, debt, crypto, and cash categories. | Asset metadata tests, debt/crypto quote tests, Holdings/Progress tests. | Pass |
+| What changed this month? | Monthly Progress snapshots derive monthly gain and gain %. | `ProgressScreen.test.tsx`, monthly summary calculation tests, store persistence tests. | Pass |
+| How much did I invest this month? | Monthly Progress snapshot and Cash Ledger metrics show monthly investment context. | Progress tests and Cash metrics tests. | Pass |
+| What is my savings/investment rate? | Monthly Progress derives savings rate from monthly investment and salary; Cash Ledger derives monthly invested/added context. | Progress tests and Cash tests. | Pass |
+| Can I continue daily tracking without opening Excel? | Add Holding, Holdings, Cash, Dashboard, Monthly Progress, Settings, live/manual quotes, and local persistence cover V1 daily tracking. | `npm run test:v1:pc` passed; strict installed-app smoke passed. | Pass |
+
+## Non-Goals Verified
+
+V1 closeout did not add:
+
+- editable grid/table UI
+- formula editor
+- macro support
+- Excel import/export
+- advanced tax calculations
+- Minimal Mode
+- full behaviour insight engine
+- complex historical charting beyond basic monthly progression
+- backend, auth, cloud sync, analytics, or push notifications
+- EAS cloud build or Play Store submission
+
+## Closeout Decision
+
+#60 is ready to close when this evidence PR is merged, because:
+
+- All #60 sub-issues are closed.
+- The V1 PC gate passes.
+- Every #60 parity question has a current app answer and automated evidence.
+- Optional Maestro failure is documented as a dev-build/Metro setup issue, not a
+  missing parity capability.


### PR DESCRIPTION
## Summary
- Add #60 Excel parity closeout evidence for the current V1 PC gate.
- Link the canonical parity checklist to the dated verification record.
- Update historical housekeeping docs so they no longer describe #61-#66 as open blockers.

## Verification
- npm run test:v1:pc
- git diff --check

## Notes
- First test:v1:pc attempt hit sandbox network EACCES inside Expo doctor; rerun with network permission passed.
- Optional npm run maestro:test was attempted and failed because the installed dev build could not load a JS bundle without Metro running. This is documented in the evidence file and is not used as the #60 blocking parity gate.
- No EAS cloud build was run.

Closes #60