### PR TITLE
[V1] Refine design baseline assets for Issue #102

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,9 @@ into behaviour insights and Minimal Mode.
 - Current V1 Figma source is
   `docs/design/figma/issue-69-v1-screens/code.js`: main tabs are Dashboard,
   Holdings, Progress, Cash, Settings; Add Holding is a secondary screen.
-- Use docs/design/v1-ui-mockup-plan.md and the Figma file for V1 UI context.
+- Current accepted V1 screen contract is `docs/design/v1-screen-baseline.md`.
+- Use the HTML preview in `docs/design/issue-86-premium-preview/index.html`,
+  `docs/design/v1-screen-baseline.md`, and the Figma file for V1 UI context.
 
 ## Release Gates
 - V1 dev-complete requires `npm run test:v1:pc`, Android Emulator app launch,

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,6 +12,19 @@ than a standard finance dashboard.
 Every UI task must follow this document unless the issue explicitly says
 otherwise.
 
+## Current V1 Screen Baseline
+
+The accepted V1 screen contract lives in `docs/design/v1-screen-baseline.md`.
+The current repo design assets are:
+
+- HTML preview: `docs/design/issue-86-premium-preview/index.html`
+- Figma generator: `docs/design/figma/issue-69-v1-screens/code.js`
+
+Future UI work on Dashboard, Holdings, Add Holding, Progress, Cash, or Settings
+must preserve that baseline unless the issue explicitly updates the baseline.
+If the design changes, update the baseline doc, preview, and Figma generator
+together or log the drift.
+
 ## 1. Visual Theme & Atmosphere
 
 CogVest should feel like a private portfolio room, not a trading floor.

--- a/docs/design/figma/issue-69-v1-screens/README.md
+++ b/docs/design/figma/issue-69-v1-screens/README.md
@@ -3,6 +3,8 @@
 This folder contains a deterministic Figma development plugin that creates
 editable V1 screen frames for issue #86 and the refined Issue #102 baseline.
 
+Canonical screen contract: `docs/design/v1-screen-baseline.md`.
+
 ## Why This Exists
 
 Generated PNG mockups are useful for exploration, but they are unstable design
@@ -22,6 +24,10 @@ Issue #102 aligns the generated frames with the May 21, 2026 V1 mockup review:
   historical charting.
 - Cash Ledger, Settings, and V1 States carry the local-first trust and empty
   state treatment needed for later implementation work.
+- Add Holding search requires explicit user selection before autofill.
+- Monthly Progress uses two graph directions: portfolio value vs invested value,
+  and assets vs months with cash excluded. Production must not fake chart
+  history when stored snapshots are missing.
 
 ## How To Run
 
@@ -58,3 +64,5 @@ The plugin creates nine editable Android frames:
   empty cash ledger, and no monthly snapshot references.
 - Use these frames as the stable source for later Figma refinements.
 - Keep `DESIGN.md` as the product design contract.
+- Keep `docs/design/v1-screen-baseline.md` aligned with any accepted Figma
+  changes.

--- a/docs/design/figma/issue-69-v1-screens/README.md
+++ b/docs/design/figma/issue-69-v1-screens/README.md
@@ -1,7 +1,7 @@
 # CogVest Issue 86 Premium V1 Figma Screens
 
 This folder contains a deterministic Figma development plugin that creates
-editable V1 screen frames for issue #86.
+editable V1 screen frames for issue #86 and the refined Issue #102 baseline.
 
 ## Why This Exists
 
@@ -9,6 +9,19 @@ Generated PNG mockups are useful for exploration, but they are unstable design
 sources. This plugin recreates the approved premium private-ledger direction
 as editable Figma layers: frames, borderless cards, text, vector icons, simple
 shapes, and SVG chart groups.
+
+## Refined Baseline
+
+Issue #102 aligns the generated frames with the May 21, 2026 V1 mockup review:
+
+- Dashboard keeps a quieter portfolio-first hierarchy and explicit P&L context.
+- Holdings uses compact durable-position rows with quote-state notes and a
+  header Add Holding entry point.
+- Add Holding remains lookup-first and split into focused V1 phases.
+- Monthly Progress keeps a monthly snapshot scope instead of implying shipped
+  historical charting.
+- Cash Ledger, Settings, and V1 States carry the local-first trust and empty
+  state treatment needed for later implementation work.
 
 ## How To Run
 
@@ -41,5 +54,7 @@ The plugin creates nine editable Android frames:
 - It does not modify the existing roadmap pages.
 - Add Holding is split into focused states so the full lookup-first behavior is
   captured without making one crowded long-form screen.
+- V1 States covers lookup loading, provider/manual fallback, empty portfolio,
+  empty cash ledger, and no monthly snapshot references.
 - Use these frames as the stable source for later Figma refinements.
 - Keep `DESIGN.md` as the product design contract.

--- a/docs/design/figma/issue-69-v1-screens/code.js
+++ b/docs/design/figma/issue-69-v1-screens/code.js
@@ -249,6 +249,17 @@ async function main() {
     return width;
   }
 
+  function contextBadge(parent, label, x, y, w = 104) {
+    rect(parent, x, y, w, 24, C.surface, 999);
+    const dot = figma.createEllipse();
+    parent.appendChild(dot);
+    dot.x = x + 10;
+    dot.y = y + 9;
+    dot.resize(6, 6);
+    dot.fills = [paint(C.green)];
+    text(parent, label, x + 23, y + 6, 10.5, C.secondary, "Semi Bold", w - 30);
+  }
+
   function row(parent, x, y, w, type, title, meta, value, sub = null, valueColor = C.text, allocation = null) {
     rect(parent, x, y, w, 72, C.surface, 18);
     glyph(parent, x + 12, y + 19, type, 34);
@@ -257,6 +268,22 @@ async function main() {
     text(parent, value, x + w - 112, y + 15, 14, valueColor, "Bold", 96, "RIGHT");
     if (sub) text(parent, sub, x + w - 112, y + 35, 10.5, sub.startsWith("-") ? C.negative : C.green, "Semi Bold", 96, "RIGHT");
     if (allocation) text(parent, allocation, x + w - 112, y + 53, 9.5, C.secondary, "Regular", 96, "RIGHT");
+  }
+
+  function holdingDetailRow(parent, x, y, w, type, title, meta, value, pnl, fields, note = null) {
+    rect(parent, x, y, w, note ? 118 : 104, C.surface, 20);
+    rect(parent, x, y, 3, note ? 118 : 104, assetMeta[type].color, 999);
+    text(parent, title, x + 14, y + 15, 14, C.text, "Bold", 170);
+    text(parent, meta, x + 14, y + 37, 10.5, C.secondary, "Regular", 210);
+    text(parent, value, x + w - 112, y + 15, 14, C.text, "Bold", 96, "RIGHT");
+    text(parent, pnl, x + w - 112, y + 36, 10.5, pnl.startsWith("-") ? C.negative : C.green, "Semi Bold", 96, "RIGHT");
+    line(parent, x + 14, y + 62, w - 28, 0.3);
+    fields.forEach((field, i) => {
+      const xx = x + 14 + i * 78;
+      text(parent, field.label.toUpperCase(), xx, y + 73, 8.5, C.muted, "Bold", 66);
+      text(parent, field.value, xx, y + 87, 10.5, C.text, "Semi Bold", 68);
+    });
+    if (note) text(parent, note, x + 14, y + 103, 10.5, C.amber, "Semi Bold", w - 28);
   }
 
   function groupedRows(parent, x, y, rows) {
@@ -332,7 +359,7 @@ async function main() {
 
   function pageTitle() {
     text(page, "CogVest Issue 86 Premium V1 Screens", 24, 24, 30, C.text, "Bold", 900);
-    text(page, "Generated from docs/design/issue-86-premium-preview. Main tabs: Dashboard, Holdings, Progress, Cash, Settings. Add Holding is a secondary flow.", 24, 64, 13, C.secondary, "Regular", 980);
+    text(page, "Issue #102 refined baseline from the repo preview. Main tabs stay Dashboard, Holdings, Progress, Cash, Settings; Add Holding stays secondary and lookup-first.", 24, 64, 13, C.secondary, "Regular", 1100);
   }
 
   stage = "draw canvas";
@@ -343,13 +370,15 @@ async function main() {
   // Dashboard
   stage = "draw dashboard";
   const dashboard = screen("Dashboard", 24);
-  header(dashboard, "Dashboard", "Local portfolio · 9 May 2026", ["refresh", "eye"]);
+  contextBadge(dashboard, "Local portfolio", PAD, 42);
+  header(dashboard, "Dashboard", "9 May 2026 snapshot", ["refresh", "eye"]);
   card(dashboard, PAD, 144, CONTENT_W, 134);
   text(dashboard, "Portfolio value", 38, 166, 12, C.secondary, "Semi Bold", 120);
   text(dashboard, "₹18.42L", 38, 190, 42, C.text, "Bold", 180);
   chip(dashboard, "+₹3.10L · +20.2%", 38, 238, true, 124);
   metric(dashboard, "Invested", "₹15.32L", 188, 178, 72);
   metric(dashboard, "P&L", "+₹3.10L", 268, 178, 72, C.green);
+  text(dashboard, "since first buy", 268, 214, 9.5, C.secondary, "Regular", 72);
   metric(dashboard, "Quotes", "2m ago", 268, 232, 72);
   sectionTitle(dashboard, "Allocation", PAD, 302, "View details");
   groupedRows(dashboard, PAD, 330, [
@@ -372,6 +401,7 @@ async function main() {
   // Holdings
   stage = "draw holdings";
   const holdings = screen("Holdings", 448);
+  contextBadge(holdings, "Local portfolio", PAD, 42);
   header(holdings, "Holdings", "24 positions · local data", ["plus", "search"]);
   metricStrip(holdings, PAD, 144, [
     { label: "Current", value: "₹12.48L" },
@@ -380,17 +410,29 @@ async function main() {
     { label: "Drift", value: "3.2%", color: C.amber },
   ]);
   text(holdings, "Quotes updated 2m ago · 1 manual price", PAD, 246, 12, C.secondary, "Regular", 240);
+  text(holdings, "Refresh", 286, 246, 11, C.green, "Bold", 52, "RIGHT");
   let chipX = PAD;
-  ["All", "Equity", "Debt", "Crypto", "Cash"].forEach((c, i) => {
+  ["All 5", "Equity 2", "Debt 2", "Crypto 1", "Cash 0"].forEach((c, i) => {
     chipX += chip(holdings, c, chipX, 272, i === 0) + 8;
   });
-  [
-    ["equity", "HDFC Bank", "Equity · Financial Services", "₹1.83L", "+₹18.6K", "14.6% allocation"],
-    ["equity", "Nifty 50 ETF", "Equity · Index Fund", "₹50.7K", "+₹6.5K", "4.1% allocation"],
-    ["debt", "Sovereign Gold Bond", "Debt · Government Bond · Manual", "₹57.1K", "+₹4.1K", "4.6% allocation"],
-    ["crypto", "Bitcoin", "Crypto · Manual price", "₹13.90L", "+₹2.85L", "11.1% allocation"],
-    ["debt", "Liquid Fund", "Debt · Overnight", "₹2.50L", "+₹250", "2.0% allocation"],
-  ].forEach((r, i) => row(holdings, PAD, 326 + i * 82, CONTENT_W, r[0], r[1], r[2], r[3], r[4], C.text, r[5]));
+  holdingDetailRow(holdings, PAD, 326, CONTENT_W, "equity", "HDFC Bank", "HDFCBANK · Equity · 14.6% allocation", "₹1.83L", "+₹18.6K", [
+    { label: "Qty", value: "112" },
+    { label: "Avg", value: "₹1,450" },
+    { label: "LTP", value: "₹1,678" },
+    { label: "Quote", value: "Live" },
+  ]);
+  holdingDetailRow(holdings, PAD, 440, CONTENT_W, "equity", "Nifty IT ETF", "ITBEES · Equity · 41.3% allocation", "₹11.56L", "-₹1.87L", [
+    { label: "Qty", value: "35,612" },
+    { label: "Avg", value: "₹37.69" },
+    { label: "LTP", value: "₹32.45" },
+    { label: "Quote", value: "Stale" },
+  ], "Price may be stale · last seen 17 May");
+  holdingDetailRow(holdings, PAD, 568, CONTENT_W, "crypto", "Bitcoin", "BTC · Crypto · 11.1% allocation", "₹13.90L", "+₹2.85L", [
+    { label: "Qty", value: "0.2000" },
+    { label: "Avg", value: "₹6.0L" },
+    { label: "LTP", value: "₹74.4L" },
+    { label: "Quote", value: "Manual" },
+  ]);
   nav(holdings, "Holdings");
 
   // Add Holding - Asset Lookup
@@ -495,6 +537,7 @@ async function main() {
     { label: "Total value", color: C.text },
     { label: "Invested", color: C.investedLine },
   ]);
+  text(progress, "Monthly snapshots populate this view over time; V1 does not fake stored history.", 38, 518, 10.5, C.secondary, "Regular", 294);
   card(progress, PAD, 552, CONTENT_W, 238);
   sectionTitle(progress, "Assets vs months", 38, 572);
   assetGraph(progress, 36, 598);
@@ -536,32 +579,30 @@ async function main() {
   stage = "draw settings";
   const settings = screen("Settings", 2992);
   header(settings, "Settings", "Local-first controls", ["info"]);
-  sectionLabel(settings, "Privacy", PAD, 144);
-  groupedRows(settings, PAD, 166, [
+  card(settings, PAD, 144, CONTENT_W, 78, 18);
+  glyph(settings, 38, 162, "equity", 34);
+  text(settings, "Your data stays on this device", 84, 160, 13.5, C.text, "Bold", 220);
+  text(settings, "No account · No cloud sync · No analytics in V1.", 84, 184, 10.5, C.secondary, "Regular", 230);
+  sectionLabel(settings, "Privacy", PAD, 244);
+  groupedRows(settings, PAD, 266, [
     { type: "debt", title: "Privacy", meta: "Local storage active · No account · No cloud", value: "On", color: C.green },
     { type: "neutral", title: "Value masking", meta: "Hide sensitive values on screen", value: "Ready" },
   ]);
-  sectionLabel(settings, "Quotes", PAD, 300);
-  groupedRows(settings, PAD, 322, [
+  sectionLabel(settings, "Quotes", PAD, 400);
+  groupedRows(settings, PAD, 422, [
     { type: "cash", title: "Quotes", meta: "Every 15 min · Manual fallback on", value: "OK", color: C.green },
   ]);
-  sectionLabel(settings, "Currency", PAD, 396);
-  card(settings, PAD, 418, CONTENT_W, 106);
-  sectionTitle(settings, "Currency", 38, 438);
-  metric(settings, "Base currency", "INR", 38, 474, 90);
-  metric(settings, "Foreign summary", "On", 150, 474, 90);
-  metric(settings, "Fallback", "On", 264, 474, 74);
-  sectionLabel(settings, "Display", PAD, 546);
-  card(settings, PAD, 568, CONTENT_W, 122);
-  sectionTitle(settings, "Display and app info", 38, 588);
-  groupedRows(settings, 38, 622, [
+  sectionLabel(settings, "Currency", PAD, 496);
+  card(settings, PAD, 518, CONTENT_W, 106);
+  sectionTitle(settings, "Currency", 38, 538);
+  metric(settings, "Base currency", "INR", 38, 574, 90);
+  metric(settings, "Foreign summary", "On", 150, 574, 90);
+  metric(settings, "Fallback", "On", 264, 574, 74);
+  sectionLabel(settings, "Display", PAD, 646);
+  card(settings, PAD, 668, CONTENT_W, 72);
+  groupedRows(settings, 38, 675, [
     { type: "neutral", title: "Density", meta: "Standard V1", value: "" },
-    { type: "neutral", title: "Minimal Mode", meta: "V2 locked", value: "" },
   ]);
-  sectionLabel(settings, "Data", PAD, 710);
-  card(settings, PAD, 732, CONTENT_W, 48);
-  text(settings, "Clear local data", 38, 748, 13, C.negative, "Semi Bold", 140);
-  text(settings, "Destructive", 255, 748, 12, C.negative, "Regular", 80, "RIGHT");
   nav(settings, "Settings");
 
   // V1 States
@@ -583,9 +624,13 @@ async function main() {
   sectionTitle(states, "Provider unavailable", 38, 466);
   text(states, "Could not fetch a live quote. Continue manually and CogVest will mark the price source.", 38, 496, 12, C.secondary, "Regular", 280);
   text(states, "Enter price manually", 38, 530, 12, C.green, "Semi Bold", 160);
-  card(states, PAD, 582, CONTENT_W, 92);
-  sectionTitle(states, "No monthly snapshots", 38, 604);
-  text(states, "Monthly Progress becomes useful after the first saved snapshot. Keep the chart area calm.", 38, 634, 12, C.secondary, "Regular", 280);
+  card(states, PAD, 582, CONTENT_W, 74);
+  glyph(states, 38, 602, "cash", 34);
+  sectionTitle(states, "Empty cash ledger", 84, 598);
+  text(states, "Add broker or bank cash when it should count toward portfolio value.", 84, 626, 10.5, C.secondary, "Regular", 220);
+  card(states, PAD, 674, CONTENT_W, 92);
+  sectionTitle(states, "No monthly snapshots", 38, 696);
+  text(states, "Monthly Progress becomes useful after the first saved snapshot. Keep the chart area calm.", 38, 726, 12, C.secondary, "Regular", 280);
 
   stage = "zoom to screens";
   figma.viewport.scrollAndZoomIntoView([dashboard, holdings, addAsset, addPosition, addReview, progress, cash, settings, states]);

--- a/docs/design/issue-86-premium-preview/README.md
+++ b/docs/design/issue-86-premium-preview/README.md
@@ -2,6 +2,19 @@
 
 Static browser mockup for the CogVest V1 premium design pass.
 
+## Refined Baseline
+
+Issue #102 refines this preview after the May 21, 2026 CogVest mockup review.
+The preview keeps the approved V1 flow coverage while adopting:
+
+- quieter portfolio-first Dashboard hierarchy
+- compact Holdings cards with quantity, average cost, current price, P&L,
+  allocation context, and quote state
+- Holdings filter counts, stale-price reference, and Add Holding header action
+- focused Cash Ledger and empty cash state treatment
+- local-first trust treatment in Settings
+- explicit Progress copy that keeps historical charting out of V1 scope
+
 ## Scope
 
 - Dashboard
@@ -11,7 +24,8 @@ Static browser mockup for the CogVest V1 premium design pass.
 - Cash Ledger
 - Settings
 - V1 States
-- Empty portfolio, quote lookup, provider error, manual price fallback, and no-snapshot state frame
+- Empty portfolio, empty cash ledger, quote lookup, provider error, manual price
+  fallback, and no-snapshot state frame
 
 This is a design preview only. It does not modify the Expo app.
 

--- a/docs/design/issue-86-premium-preview/README.md
+++ b/docs/design/issue-86-premium-preview/README.md
@@ -2,6 +2,8 @@
 
 Static browser mockup for the CogVest V1 premium design pass.
 
+Canonical screen contract: `docs/design/v1-screen-baseline.md`.
+
 ## Refined Baseline
 
 Issue #102 refines this preview after the May 21, 2026 CogVest mockup review.
@@ -14,6 +16,9 @@ The preview keeps the approved V1 flow coverage while adopting:
 - focused Cash Ledger and empty cash state treatment
 - local-first trust treatment in Settings
 - explicit Progress copy that keeps historical charting out of V1 scope
+- two Progress graph treatments: portfolio value vs invested value, and assets
+  vs months with cash excluded
+- explicit Add Holding search selection; search must not auto-pick a result
 
 ## Scope
 
@@ -28,6 +33,9 @@ The preview keeps the approved V1 flow coverage while adopting:
   fallback, and no-snapshot state frame
 
 This is a design preview only. It does not modify the Expo app.
+
+Preview data is illustrative only. Production screens must use persisted local
+records and domain-derived values, or show empty states.
 
 ## Run
 

--- a/docs/design/issue-86-premium-preview/index.html
+++ b/docs/design/issue-86-premium-preview/index.html
@@ -191,6 +191,28 @@
         font-size: 13px;
       }
 
+      .context-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        min-height: 24px;
+        margin-bottom: 12px;
+        padding: 0 10px;
+        border-radius: 999px;
+        background: var(--surface);
+        color: var(--secondary);
+        font-size: 11px;
+        font-weight: 700;
+      }
+
+      .context-badge::before {
+        content: "";
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--green);
+      }
+
       .actions {
         display: flex;
         gap: 10px;
@@ -464,9 +486,20 @@
       }
 
       .quote-line {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
         margin: 10px 0 12px;
         color: var(--secondary);
         font-size: 12px;
+      }
+
+      .quote-line strong,
+      .quote-state {
+        color: var(--green);
+        font-size: 11px;
+        font-weight: 800;
       }
 
       .chips {
@@ -496,6 +529,13 @@
         color: var(--text);
       }
 
+      .chip small {
+        margin-left: 4px;
+        color: currentColor;
+        font-size: 10px;
+        opacity: 0.64;
+      }
+
       .holding {
         min-height: 74px;
       }
@@ -504,6 +544,103 @@
         display: flex;
         gap: 9px;
         white-space: nowrap;
+      }
+
+      .holding-card {
+        display: block;
+        width: 100%;
+        margin: 0 0 10px;
+        padding: 0;
+        border: 0;
+        color: inherit;
+        background: transparent;
+        font: inherit;
+        text-align: left;
+        cursor: pointer;
+      }
+
+      .holding-card:last-child {
+        margin-bottom: 0;
+      }
+
+      .holding-card .surface {
+        display: block;
+        position: relative;
+        overflow: hidden;
+        padding: 14px;
+        border-radius: 20px;
+      }
+
+      .holding-card .surface::before {
+        content: "";
+        position: absolute;
+        inset: 0 auto 0 0;
+        width: 3px;
+        background: currentColor;
+        opacity: 0.9;
+      }
+
+      .holding-head,
+      .holding-fields {
+        display: flex;
+        justify-content: space-between;
+        gap: 10px;
+      }
+
+      .holding-head {
+        align-items: flex-start;
+      }
+
+      .holding-name {
+        font-size: 14px;
+        font-weight: 850;
+        letter-spacing: -0.03em;
+      }
+
+      .holding-value {
+        text-align: right;
+        font-size: 15px;
+        font-weight: 850;
+      }
+
+      .holding-fields {
+        margin-top: 12px;
+        padding-top: 11px;
+        border-top: 1px solid var(--separator);
+      }
+
+      .holding-fields div {
+        min-width: 0;
+      }
+
+      .holding-fields span {
+        display: block;
+        color: var(--muted);
+        font-size: 10px;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .holding-fields strong {
+        display: block;
+        margin-top: 4px;
+        color: var(--text);
+        font-size: 11px;
+      }
+
+      .holding-note {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        margin-top: 9px;
+        color: var(--amber);
+        font-size: 11px;
+        font-weight: 750;
+      }
+
+      .holding-negative .surface {
+        background: linear-gradient(180deg, rgba(255, 69, 58, 0.08), var(--surface));
       }
 
       .search-card {
@@ -771,6 +908,37 @@
         stroke-linejoin: round;
       }
 
+      .trust-banner {
+        display: flex;
+        gap: 12px;
+        align-items: flex-start;
+        margin-bottom: 16px;
+        padding: 15px;
+        border-radius: var(--radius-md);
+        background: rgba(52, 199, 89, 0.08);
+      }
+
+      .trust-banner .glyph {
+        background: rgba(52, 199, 89, 0.12);
+      }
+
+      .trust-banner p,
+      .empty-panel p {
+        margin: 5px 0 0;
+        color: var(--secondary);
+        font-size: 12px;
+        line-height: 1.45;
+      }
+
+      .empty-panel {
+        padding: 18px;
+        text-align: center;
+      }
+
+      .empty-panel .empty-illustration {
+        margin: 0 auto 12px;
+      }
+
       .cta-row {
         position: sticky;
         bottom: 0;
@@ -993,10 +1161,11 @@
           <div class="phone">
             <div class="status"><span>10:42</span><span class="status-icons"><i class="status-dot"></i><i class="status-dot"></i>100%</span></div>
             <div class="content">
+              <div class="context-badge">Local portfolio</div>
               <header class="header-row">
                 <div>
                   <h2 class="title">Dashboard</h2>
-                  <p class="subtitle">Local portfolio · 9 May 2026</p>
+                  <p class="subtitle">9 May 2026 snapshot</p>
                 </div>
                 <div class="actions">
                   <button class="icon-button" type="button" aria-label="Mask portfolio values"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg></button>
@@ -1010,8 +1179,8 @@
                 <span class="gain-pill">+₹3.10L · +20.2%</span>
                 <div class="metric-grid">
                   <div class="metric"><span class="label">Invested</span><strong>₹15.32L</strong></div>
-                  <div class="metric"><span class="label">P&L</span><strong class="positive">+₹3.10L</strong></div>
-                  <div class="metric"><span class="label">Quotes</span><strong>2m ago</strong></div>
+                  <div class="metric"><span class="label">P&L</span><strong class="positive">+₹3.10L</strong><span class="row-meta">since first buy</span></div>
+                  <div class="metric"><span class="label">Quotes</span><strong>2m ago</strong><span class="row-meta">manual fallback ready</span></div>
                 </div>
               </section>
 
@@ -1053,6 +1222,7 @@
           <div class="phone">
             <div class="status"><span>10:42</span><span class="status-icons"><i class="status-dot"></i><i class="status-dot"></i>100%</span></div>
             <div class="content">
+              <div class="context-badge">Local portfolio</div>
               <header class="header-row">
                 <div><h2 class="title">Holdings</h2><p class="subtitle">24 positions · local data</p></div>
                 <div class="actions">
@@ -1069,16 +1239,28 @@
                   <div class="metric"><span class="label">Drift</span><strong style="color:var(--amber)">3.2%</strong></div>
                 </div>
               </section>
-              <div class="quote-line">Quotes updated 2m ago · 1 manual price</div>
-              <div class="chips" aria-label="Holding filters"><button class="chip active" type="button">All</button><button class="chip" type="button">Equity</button><button class="chip" type="button">Debt</button><button class="chip" type="button">Crypto</button><button class="chip" type="button">Cash</button></div>
+              <div class="quote-line"><span>Quotes updated 2m ago · 1 manual price</span><strong>Refresh</strong></div>
+              <div class="chips" aria-label="Holding filters"><button class="chip active" type="button">All <small>5</small></button><button class="chip" type="button">Equity <small>2</small></button><button class="chip" type="button">Debt <small>2</small></button><button class="chip" type="button">Crypto <small>1</small></button><button class="chip" type="button">Cash <small>0</small></button></div>
 
-              <section class="group">
-                <button class="row holding result" type="button"><span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span><div class="row-main"><div class="row-title">HDFC Bank</div><div class="row-meta">Equity · Financial Services</div><div class="row-meta"><span>Invested ₹1.64L</span><span>14.6%</span><span>Live</span></div></div><div class="row-value">₹1.83L<div class="row-sub">+₹18.6K</div></div></button>
-                <button class="row holding result" type="button"><span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span><div class="row-main"><div class="row-title">Nifty 50 ETF</div><div class="row-meta">Equity · Index Fund</div><div class="row-meta"><span>Invested ₹44.2K</span><span>4.1%</span><span>Live</span></div></div><div class="row-value">₹50.7K<div class="row-sub">+₹6.5K</div></div></button>
-                <button class="row holding result" type="button"><span class="glyph debt"><svg viewBox="0 0 24 24"><path d="M12 3 5 6v5c0 4.5 3 7.5 7 9 4-1.5 7-4.5 7-9V6z"/></svg></span><div class="row-main"><div class="row-title">Sovereign Gold Bond</div><div class="row-meta">Debt · Government Bond</div><div class="row-meta"><span>Invested ₹53.0K</span><span>4.6%</span><span>Manual</span></div></div><div class="row-value">₹57.1K<div class="row-sub">+₹4.1K</div></div></button>
-                <button class="row holding result" type="button"><span class="glyph crypto"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 7v10M9.2 9h4.1a2 2 0 0 1 0 4H9.2M9.2 13h4.8a2 2 0 0 1 0 4H9.2"/></svg></span><div class="row-main"><div class="row-title">Bitcoin</div><div class="row-meta">Crypto · Manual price</div><div class="row-meta"><span>Invested ₹11.05L</span><span>11.1%</span><span>Manual</span></div></div><div class="row-value">₹13.90L<div class="row-sub">+₹2.85L</div></div></button>
-                <button class="row holding result" type="button"><span class="glyph debt"><svg viewBox="0 0 24 24"><path d="M12 3 5 6v5c0 4.5 3 7.5 7 9 4-1.5 7-4.5 7-9V6z"/></svg></span><div class="row-main"><div class="row-title">Liquid Fund</div><div class="row-meta">Debt · Overnight</div><div class="row-meta"><span>Invested ₹2.50L</span><span>2.0%</span><span>Manual</span></div></div><div class="row-value">₹2.50L<div class="row-sub">+₹250</div></div></button>
-              </section>
+              <button class="holding-card equity" type="button">
+                <span class="surface">
+                  <span class="holding-head"><span><span class="holding-name">HDFC Bank</span><span class="row-meta">HDFCBANK · Equity · 14.6% allocation</span></span><span class="holding-value">₹1.83L<span class="row-sub">+₹18.6K</span></span></span>
+                  <span class="holding-fields"><span><span>Qty</span><strong>112</strong></span><span><span>Avg</span><strong>₹1,450</strong></span><span><span>LTP</span><strong>₹1,678</strong></span><span><span>Quote</span><strong>Live</strong></span></span>
+                </span>
+              </button>
+              <button class="holding-card equity holding-negative" type="button">
+                <span class="surface">
+                  <span class="holding-head"><span><span class="holding-name">Nifty IT ETF</span><span class="row-meta">ITBEES · Equity · 41.3% allocation</span></span><span class="holding-value">₹11.56L<span class="row-sub negative">-₹1.87L</span></span></span>
+                  <span class="holding-fields"><span><span>Qty</span><strong>35,612</strong></span><span><span>Avg</span><strong>₹37.69</strong></span><span><span>LTP</span><strong>₹32.45</strong></span><span><span>Quote</span><strong>Stale</strong></span></span>
+                  <span class="holding-note">Price may be stale · last seen 17 May</span>
+                </span>
+              </button>
+              <button class="holding-card crypto" type="button">
+                <span class="surface">
+                  <span class="holding-head"><span><span class="holding-name">Bitcoin</span><span class="row-meta">BTC · Crypto · 11.1% allocation</span></span><span class="holding-value">₹13.90L<span class="row-sub">+₹2.85L</span></span></span>
+                  <span class="holding-fields"><span><span>Qty</span><strong>0.2000</strong></span><span><span>Avg</span><strong>₹6.0L</strong></span><span><span>LTP</span><strong>₹74.4L</strong></span><span><span>Quote</span><strong>Manual</strong></span></span>
+                </span>
+              </button>
             </div>
             <div class="nav">
               <button class="nav-item" type="button"><svg viewBox="0 0 24 24"><path d="M3 10.8 12 3l9 7.8V21h-6v-6H9v6H3z"/></svg><span>Dashboard</span></button>
@@ -1094,6 +1276,7 @@
           <div class="phone">
             <div class="status"><span>10:42</span><span class="status-icons"><i class="status-dot"></i><i class="status-dot"></i>100%</span></div>
             <div class="content">
+              <div class="context-badge">Local portfolio</div>
               <header class="header-row">
                 <div><h2 class="title">Add Holding</h2><p class="subtitle">Opening position · local only</p></div>
                 <div class="actions"><button class="icon-button" type="button" aria-label="Open Add Holding help"><svg viewBox="0 0 24 24"><path d="M9.5 9a2.8 2.8 0 1 1 4.9 1.8c-.9.8-1.9 1.3-1.9 3.2"/><path d="M12 18h.01"/></svg></button></div>
@@ -1179,7 +1362,7 @@
                   <text class="trend-axis" x="282" y="152">May</text>
                 </svg>
                 <div class="trend-legend" aria-label="Portfolio trend legend"><span class="legend-portfolio"><i></i>Total value</span><span class="legend-invested"><i></i>Invested</span></div>
-                <p class="helper">X-axis shows months. Y-axis shows amount in INR.</p>
+                <p class="helper">Monthly snapshots populate this view over time. No fake stored history is implied for V1.</p>
               </section>
 
               <section class="surface data-card">
@@ -1203,7 +1386,7 @@
                   <text class="trend-axis" x="282" y="152">May</text>
                 </svg>
                 <div class="trend-legend" aria-label="Asset trend legend"><span class="trend-equity"><i></i>Equity</span><span class="trend-debt"><i></i>Debt</span><span class="trend-crypto"><i></i>Crypto</span></div>
-                <p class="helper">Cash is excluded from this asset graph and tracked separately in Cash Ledger.</p>
+                <p class="helper">Snapshot trend direction only. Cash stays separate in Cash Ledger until monthly data is saved.</p>
               </section>
 
               <section class="section">
@@ -1238,6 +1421,7 @@
           <div class="phone">
             <div class="status"><span>10:42</span><span class="status-icons"><i class="status-dot"></i><i class="status-dot"></i>100%</span></div>
             <div class="content">
+              <div class="context-badge">Local portfolio</div>
               <header class="header-row">
                 <div><h2 class="title">Cash Ledger</h2><p class="subtitle">Manual ledger · local only</p></div>
                 <div class="actions"><button class="icon-button" type="button" aria-label="Add cash entry"><svg viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg></button><button class="icon-button" type="button" aria-label="Mask cash values"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg></button></div>
@@ -1288,10 +1472,16 @@
           <div class="phone">
             <div class="status"><span>10:42</span><span class="status-icons"><i class="status-dot"></i><i class="status-dot"></i>100%</span></div>
             <div class="content">
+              <div class="context-badge">Local portfolio</div>
               <header class="header-row">
                 <div><h2 class="title">Settings</h2><p class="subtitle">Local-first controls</p></div>
                 <div class="actions"><button class="icon-button" type="button" aria-label="About CogVest"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 11v5M12 8h.01"/></svg></button></div>
               </header>
+
+              <section class="trust-banner">
+                <span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M12 3 5 6v5c0 4.5 3 7.5 7 9 4-1.5 7-4.5 7-9V6z"/><path d="M9.5 12.5 11 14l3.5-4"/></svg></span>
+                <div><div class="row-title">Your data stays on this device</div><p>No account, no cloud sync, and no analytics in the V1 tracker.</p></div>
+              </section>
 
               <div class="section-label">Privacy</div>
               <section class="group">
@@ -1362,6 +1552,12 @@
                 <div class="section-title negative">Provider unavailable</div>
                 <p class="helper">Could not fetch a live quote. Continue manually and CogVest will mark the price source.</p>
                 <button class="secondary-action" type="button">Enter price manually</button>
+              </section>
+
+              <section class="surface empty-panel">
+                <div class="empty-illustration"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg></div>
+                <div class="section-title">Empty cash ledger</div>
+                <p>Add broker or bank cash when it should count toward portfolio value.</p>
               </section>
 
               <section class="surface data-card">

--- a/docs/design/issue-86-premium-preview/index.html
+++ b/docs/design/issue-86-premium-preview/index.html
@@ -213,6 +213,13 @@
         background: var(--green);
       }
 
+      .context-badge::after {
+        content: "⌄";
+        margin-left: 1px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
       .actions {
         display: flex;
         gap: 10px;
@@ -253,8 +260,22 @@
       }
 
       .hero {
+        position: relative;
+        overflow: hidden;
         padding: 20px;
         margin-bottom: 20px;
+        border: 1px solid var(--separator);
+      }
+
+      .hero::after {
+        content: "";
+        position: absolute;
+        inset: auto -30px -54px auto;
+        width: 150px;
+        height: 150px;
+        border-radius: 50%;
+        background: radial-gradient(circle, rgba(52, 199, 89, 0.14), transparent 66%);
+        pointer-events: none;
       }
 
       .label {
@@ -265,10 +286,32 @@
 
       .hero-value {
         margin: 8px 0 8px;
-        font-size: 44px;
+        font-size: 48px;
         line-height: 0.95;
         font-weight: 850;
         letter-spacing: -0.07em;
+      }
+
+      .hero-value sup {
+        font-size: 20px;
+        font-weight: 550;
+        letter-spacing: 0;
+        color: var(--secondary);
+        vertical-align: super;
+      }
+
+      .hero-value small {
+        font-size: 22px;
+        font-weight: 550;
+        letter-spacing: -0.03em;
+        color: var(--secondary);
+      }
+
+      .hero-caption {
+        margin: 10px 0 0;
+        color: var(--secondary);
+        font-size: 11px;
+        line-height: 1.35;
       }
 
       .gain-pill {
@@ -280,6 +323,17 @@
         color: var(--green);
         font-size: 13px;
         font-weight: 800;
+      }
+
+      .today-line {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        margin-top: 2px;
+        color: var(--green);
+        font-family: "JetBrains Mono", "SF Mono", Consolas, monospace;
+        font-size: 11px;
+        font-weight: 700;
       }
 
       .metric-grid {
@@ -306,6 +360,45 @@
         margin-top: 5px;
         font-size: 15px;
         letter-spacing: -0.03em;
+      }
+
+      .quote-card {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        margin: -8px 0 18px;
+        padding: 10px 12px;
+        border-radius: 15px;
+        background: var(--surface);
+        color: var(--secondary);
+        font-size: 11px;
+      }
+
+      .quote-card strong {
+        color: var(--green);
+        font-size: 11px;
+      }
+
+      .allocation-bar {
+        display: flex;
+        gap: 1px;
+        height: 5px;
+        margin: 2px 0 12px;
+        overflow: hidden;
+        border-radius: 999px;
+        background: var(--elevated);
+      }
+
+      .allocation-segment {
+        height: 100%;
+      }
+
+      .allocation-dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 999px;
+        flex: 0 0 auto;
       }
 
       .section {
@@ -448,6 +541,10 @@
         grid-template-columns: repeat(3, 1fr);
         gap: 0;
         margin-top: 14px;
+      }
+
+      .month-card .mini-metrics {
+        grid-template-columns: repeat(2, 1fr);
       }
 
       .mini-metrics div + div {
@@ -687,6 +784,43 @@
         outline: 1px solid rgba(52, 199, 89, 0.22);
       }
 
+      .result.pending {
+        background: rgba(255, 255, 255, 0.03);
+        outline: 1px solid var(--separator);
+      }
+
+      .select-pill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 58px;
+        height: 28px;
+        border-radius: 999px;
+        background: rgba(52, 199, 89, 0.12);
+        color: var(--green);
+        font-size: 11px;
+        font-weight: 850;
+      }
+
+      .selection-note {
+        display: flex;
+        gap: 10px;
+        align-items: flex-start;
+        padding: 12px;
+        border: 1px dashed var(--separator);
+        border-radius: 16px;
+        color: var(--secondary);
+        font-size: 12px;
+        line-height: 1.45;
+      }
+
+      .selection-note strong {
+        display: block;
+        margin-bottom: 2px;
+        color: var(--text);
+        font-size: 13px;
+      }
+
       .group .result {
         margin-top: 0;
         border-radius: 0;
@@ -790,28 +924,121 @@
         letter-spacing: -0.03em;
       }
 
+      .form-field.prefill strong {
+        color: var(--secondary);
+      }
+
+      .form-field .auto {
+        color: var(--green);
+        font-size: 10px;
+        font-weight: 650;
+      }
+
       .trend-graph {
         width: 100%;
-        height: 160px;
-        margin-top: 16px;
+        height: 118px;
+        margin-top: 12px;
         color: var(--secondary);
+        overflow: visible;
+      }
+
+      .chart-card {
+        padding: 13px;
+        border: 1px solid var(--separator);
+        border-radius: 16px;
+      }
+
+      .chart-header {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: flex-start;
+        margin-bottom: 10px;
+      }
+
+      .chart-kicker {
+        margin-bottom: 4px;
+        color: var(--muted);
+        font-size: 9px;
+        font-weight: 850;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+      }
+
+      .chart-value {
+        font-family: "JetBrains Mono", "SF Mono", Consolas, monospace;
+        font-size: 18px;
+        font-weight: 700;
+        letter-spacing: -0.04em;
+      }
+
+      .chart-delta {
+        margin-top: 2px;
+        color: var(--green);
+        font-family: "JetBrains Mono", "SF Mono", Consolas, monospace;
+        font-size: 10px;
+      }
+
+      .chart-range {
+        display: flex;
+        gap: 4px;
+      }
+
+      .range-chip {
+        border-radius: 8px;
+        padding: 4px 7px;
+        background: var(--elevated);
+        color: var(--muted);
+        font-size: 9px;
+        font-weight: 800;
+      }
+
+      .range-chip.active {
+        background: var(--green-soft);
+        color: var(--green);
+        outline: 1px solid rgba(52, 199, 89, 0.22);
+      }
+
+      .chart-axis {
+        display: flex;
+        justify-content: space-between;
+        margin-top: 6px;
+        padding: 0 2px;
+        color: var(--muted);
+        font-family: "JetBrains Mono", "SF Mono", Consolas, monospace;
+        font-size: 8px;
+      }
+
+      .chart-hint {
+        margin: 10px 0 0;
+        padding-top: 10px;
+        border-top: 1px solid var(--separator);
+        color: var(--muted);
+        text-align: center;
+        font-size: 10px;
+        line-height: 1.5;
+      }
+
+      .chart-hint em {
+        color: var(--green);
+        font-style: normal;
       }
 
       .trend-grid {
         stroke: var(--separator);
-        stroke-width: 1;
+        stroke-width: 0.8;
       }
 
       .trend-line {
         fill: none;
-        stroke-width: 2.4;
+        stroke-width: 2.2;
         stroke-linecap: round;
         stroke-linejoin: round;
       }
 
       .trend-portfolio {
-        stroke: var(--text);
-        stroke-width: 4;
+        stroke: var(--green);
+        stroke-width: 3.2;
       }
 
       .trend-invested {
@@ -821,13 +1048,13 @@
       }
 
       .trend-equity {
-        stroke: #7c83ff;
-        color: #7c83ff;
+        stroke: var(--green);
+        color: var(--green);
       }
 
       .trend-debt {
-        stroke: #62c99a;
-        color: #62c99a;
+        stroke: var(--blue);
+        color: var(--blue);
       }
 
       .trend-crypto {
@@ -852,7 +1079,7 @@
 
       .trend-area {
         fill: url("#portfolioFade");
-        opacity: 0.26;
+        opacity: 0.32;
       }
 
       .trend-axis {
@@ -869,6 +1096,7 @@
       .trend-legend {
         display: flex;
         gap: 12px;
+        justify-content: center;
         margin-top: 10px;
         color: var(--secondary);
         font-size: 11px;
@@ -965,6 +1193,12 @@
 
       .primary.full-width {
         width: 100%;
+      }
+
+      .primary.disabled {
+        pointer-events: none;
+        background: var(--elevated);
+        color: var(--muted);
       }
 
       .secondary-action {
@@ -1165,7 +1399,7 @@
               <header class="header-row">
                 <div>
                   <h2 class="title">Dashboard</h2>
-                  <p class="subtitle">9 May 2026 snapshot</p>
+                  <p class="subtitle">19 May 2026</p>
                 </div>
                 <div class="actions">
                   <button class="icon-button" type="button" aria-label="Mask portfolio values"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg></button>
@@ -1174,32 +1408,36 @@
               </header>
 
               <section class="surface hero">
-                <div class="label">Portfolio value</div>
-                <div class="hero-value">₹18.42L</div>
-                <span class="gain-pill">+₹3.10L · +20.2%</span>
+                <div class="label">Portfolio Value</div>
+                <div class="hero-value"><sup>₹</sup>27.92<small>L</small></div>
+                <div class="today-line">▲ +₹37.4K · +1.36% today</div>
+                <p class="hero-caption">Premium UI outside. Excel-grade tracking logic inside.</p>
                 <div class="metric-grid">
-                  <div class="metric"><span class="label">Invested</span><strong>₹15.32L</strong></div>
-                  <div class="metric"><span class="label">P&L</span><strong class="positive">+₹3.10L</strong><span class="row-meta">since first buy</span></div>
-                  <div class="metric"><span class="label">Quotes</span><strong>2m ago</strong><span class="row-meta">manual fallback ready</span></div>
+                  <div class="metric"><span class="label">Invested</span><strong>₹15.95L</strong></div>
+                  <div class="metric"><span class="label">P&L</span><strong class="positive">+₹11.97L</strong><span class="row-meta">since first buy</span></div>
+                  <div class="metric"><span class="label">Return</span><strong class="positive">+75.1%</strong><span class="row-meta">all time</span></div>
                 </div>
               </section>
 
+              <div class="quote-card"><span>Quotes refreshed 2m ago · 1 manual fallback</span><strong>Refresh</strong></div>
+
               <section class="section">
-                <div class="section-head"><span class="section-title">Allocation</span><button class="section-action" type="button">View details</button></div>
+                <div class="section-head"><span class="section-title">Allocation</span><button class="section-action" type="button">Holdings →</button></div>
                 <div class="group">
-                  <div class="row"><span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span><div class="row-main"><div class="row-title">Equity</div><div class="progress-line equity"><span style="width:68%"></span></div></div><div class="row-value">68%<div class="row-meta">₹12.71L</div></div></div>
-                  <div class="row"><span class="glyph debt"><svg viewBox="0 0 24 24"><path d="M12 3 5 6v5c0 4.5 3 7.5 7 9 4-1.5 7-4.5 7-9V6z"/></svg></span><div class="row-main"><div class="row-title">Debt</div><div class="progress-line debt"><span style="width:15%"></span></div></div><div class="row-value">15%<div class="row-meta">₹2.76L</div></div></div>
-                  <div class="row"><span class="glyph crypto"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 7v10M9.2 9h4.1a2 2 0 0 1 0 4H9.2M9.2 13h4.8a2 2 0 0 1 0 4H9.2"/></svg></span><div class="row-main"><div class="row-title">Crypto</div><div class="progress-line crypto"><span style="width:7%"></span></div></div><div class="row-value">7%<div class="row-meta">₹1.29L</div></div></div>
-                  <div class="row"><span class="glyph cash"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg></span><div class="row-main"><div class="row-title">Cash</div><div class="progress-line cash"><span style="width:10%"></span></div></div><div class="row-value">10%<div class="row-meta">₹1.65L</div></div></div>
+                  <div class="allocation-bar" aria-hidden="true">
+                    <span class="allocation-segment" style="width:53.31%;background:var(--amber)"></span>
+                    <span class="allocation-segment" style="width:46.69%;background:var(--green)"></span>
+                  </div>
+                  <div class="row"><span class="allocation-dot" style="background:var(--amber)"></span><div class="row-main"><div class="row-title">Crypto</div><div class="row-meta">Digital assets</div></div><div class="row-value">53.31%<div class="row-meta">₹14.89L</div></div></div>
+                  <div class="row"><span class="allocation-dot" style="background:var(--green)"></span><div class="row-main"><div class="row-title">Equity</div><div class="row-meta">Stocks and ETFs</div></div><div class="row-value">46.69%<div class="row-meta">₹13.04L</div></div></div>
                 </div>
               </section>
 
               <section class="surface month-card">
                 <div class="section-head"><span class="section-title">This month</span><button class="section-action" type="button">May 2026</button></div>
                 <div class="mini-metrics">
-                  <div><span class="label">Invested</span><strong>₹1.20L</strong></div>
-                  <div><span class="label">Savings</span><strong>42%</strong></div>
-                  <div><span class="label">Cash</span><strong class="positive">+₹70K</strong></div>
+                  <div><span class="label">Invested</span><strong>₹14.62L</strong></div>
+                  <div><span class="label">Cash change</span><strong>₹0</strong></div>
                 </div>
               </section>
 
@@ -1224,41 +1462,42 @@
             <div class="content">
               <div class="context-badge">Local portfolio</div>
               <header class="header-row">
-                <div><h2 class="title">Holdings</h2><p class="subtitle">24 positions · local data</p></div>
+                <div><h2 class="title">Holdings</h2><p class="subtitle">3 positions · local data</p></div>
                 <div class="actions">
                   <button class="icon-button" type="button" aria-label="Add holding"><svg viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg></button>
                   <button class="icon-button" type="button" aria-label="Search holdings"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="m16 16 5 5"/></svg></button>
+                  <button class="icon-button" type="button" aria-label="Mask holding values"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg></button>
                 </div>
               </header>
 
               <section class="surface summary">
                 <div class="metric-grid">
-                  <div class="metric"><span class="label">Current</span><strong>₹12.48L</strong></div>
-                  <div class="metric"><span class="label">Invested</span><strong>₹11.05L</strong></div>
-                  <div class="metric"><span class="label">P&L</span><strong class="positive">+₹1.42L</strong></div>
-                  <div class="metric"><span class="label">Drift</span><strong style="color:var(--amber)">3.2%</strong></div>
+                  <div class="metric"><span class="label">Current</span><strong>₹27.92L</strong></div>
+                  <div class="metric"><span class="label">Invested</span><strong>₹15.95L</strong></div>
+                  <div class="metric"><span class="label">P&L</span><strong class="positive">+₹11.97L</strong></div>
+                  <div class="metric"><span class="label">Return</span><strong class="positive">+75.1%</strong></div>
                 </div>
               </section>
               <div class="quote-line"><span>Quotes updated 2m ago · 1 manual price</span><strong>Refresh</strong></div>
-              <div class="chips" aria-label="Holding filters"><button class="chip active" type="button">All <small>5</small></button><button class="chip" type="button">Equity <small>2</small></button><button class="chip" type="button">Debt <small>2</small></button><button class="chip" type="button">Crypto <small>1</small></button><button class="chip" type="button">Cash <small>0</small></button></div>
+              <div class="chips" aria-label="Holding filters"><button class="chip active" type="button">All <small>3</small></button><button class="chip" type="button">Equity <small>2</small></button><button class="chip" type="button">Crypto <small>1</small></button><button class="chip" type="button">Debt <small>0</small></button><button class="chip" type="button">Cash <small>0</small></button></div>
 
               <button class="holding-card equity" type="button">
                 <span class="surface">
-                  <span class="holding-head"><span><span class="holding-name">HDFC Bank</span><span class="row-meta">HDFCBANK · Equity · 14.6% allocation</span></span><span class="holding-value">₹1.83L<span class="row-sub">+₹18.6K</span></span></span>
-                  <span class="holding-fields"><span><span>Qty</span><strong>112</strong></span><span><span>Avg</span><strong>₹1,450</strong></span><span><span>LTP</span><strong>₹1,678</strong></span><span><span>Quote</span><strong>Live</strong></span></span>
+                  <span class="holding-head"><span><span class="holding-name">Reliance Industries</span><span class="row-meta">RELIANCE · Equity · 5.31% allocation</span></span><span class="holding-value">₹1.48L<span class="row-sub">+11.71%</span></span></span>
+                  <span class="holding-fields"><span><span>Qty</span><strong>112</strong></span><span><span>Avg</span><strong>₹1,184</strong></span><span><span>LTP</span><strong>₹1,322</strong></span><span><span>P&L</span><strong>+₹15.5K</strong></span></span>
                 </span>
               </button>
               <button class="holding-card equity holding-negative" type="button">
                 <span class="surface">
-                  <span class="holding-head"><span><span class="holding-name">Nifty IT ETF</span><span class="row-meta">ITBEES · Equity · 41.3% allocation</span></span><span class="holding-value">₹11.56L<span class="row-sub negative">-₹1.87L</span></span></span>
-                  <span class="holding-fields"><span><span>Qty</span><strong>35,612</strong></span><span><span>Avg</span><strong>₹37.69</strong></span><span><span>LTP</span><strong>₹32.45</strong></span><span><span>Quote</span><strong>Stale</strong></span></span>
+                  <span class="holding-head"><span><span class="holding-name">Nippon Nifty IT ETF</span><span class="row-meta">ITBEES · Equity · 41.38% allocation</span></span><span class="holding-value">₹11.56L<span class="row-sub negative">-13.90%</span></span></span>
+                  <span class="holding-fields"><span><span>Qty</span><strong>35,612</strong></span><span><span>Avg</span><strong>₹37.69</strong></span><span><span>LTP</span><strong>₹32.45</strong></span><span><span>P&L</span><strong>-₹1.87L</strong></span></span>
                   <span class="holding-note">Price may be stale · last seen 17 May</span>
                 </span>
               </button>
               <button class="holding-card crypto" type="button">
                 <span class="surface">
-                  <span class="holding-head"><span><span class="holding-name">Bitcoin</span><span class="row-meta">BTC · Crypto · 11.1% allocation</span></span><span class="holding-value">₹13.90L<span class="row-sub">+₹2.85L</span></span></span>
-                  <span class="holding-fields"><span><span>Qty</span><strong>0.2000</strong></span><span><span>Avg</span><strong>₹6.0L</strong></span><span><span>LTP</span><strong>₹74.4L</strong></span><span><span>Quote</span><strong>Manual</strong></span></span>
+                  <span class="holding-head"><span><span class="holding-name">Bitcoin</span><span class="row-meta">BTC · Crypto · 53.31% allocation</span></span><span class="holding-value">₹14.89L<span class="row-sub">+1,140%</span></span></span>
+                  <span class="holding-fields"><span><span>Qty</span><strong>0.2000</strong></span><span><span>Avg</span><strong>₹6.0L</strong></span><span><span>LTP</span><strong>₹74.4L</strong></span><span><span>P&L</span><strong>+₹13.7L</strong></span></span>
                 </span>
               </button>
             </div>
@@ -1288,22 +1527,24 @@
 
               <section class="surface search-card">
                 <div class="section-title">Find asset</div>
-                <div class="search-input" style="margin-top:12px"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="m16 16 5 5"/></svg>Search name or symbol</div>
-                <p class="helper">Only search text is sent to quote providers.</p>
-                <button class="row result selected" type="button"><span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span><div class="row-main"><div class="row-title">HDFC Bank</div><div class="row-meta">HDFCBANK.NS · NSE · INR · Equity</div></div><div class="row-value">₹1,678.25<div class="tag">Live</div></div></button>
-                <button class="row result" type="button"><span class="glyph crypto"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 7v10M9.2 9h4.1a2 2 0 0 1 0 4H9.2M9.2 13h4.8a2 2 0 0 1 0 4H9.2"/></svg></span><div class="row-main"><div class="row-title">Bitcoin</div><div class="row-meta">bitcoin · CoinGecko · INR</div></div><div class="row-value">₹92.10L<div class="tag">Live</div></div></button>
+                <div class="search-input" style="margin-top:12px"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="m16 16 5 5"/></svg>hdfc bank</div>
+                <p class="helper">Search returns possible matches. CogVest should not auto-pick an asset.</p>
+                <button class="row result pending" type="button"><span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span><div class="row-main"><div class="row-title">HDFC Bank</div><div class="row-meta">HDFCBANK.NS · NSE · INR · Equity</div><div class="row-meta">LTP ₹1,678.25 · Live</div></div><div class="select-pill">Select</div></button>
+                <button class="row result pending" type="button"><span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span><div class="row-main"><div class="row-title">HDFC Life</div><div class="row-meta">HDFCLIFE.NS · NSE · INR · Equity</div><div class="row-meta">LTP ₹642.10 · Live</div></div><div class="select-pill">Select</div></button>
+                <button class="row result pending" type="button"><span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span><div class="row-main"><div class="row-title">HDFC Nifty 50 ETF</div><div class="row-meta">HDFCNIFETF.NS · NSE · INR · ETF</div><div class="row-meta">LTP ₹235.45 · Live</div></div><div class="select-pill">Select</div></button>
               </section>
 
               <section class="surface data-card">
-                <div class="section-title">Selected result</div>
-                <div class="data-row"><span>Asset</span><strong>HDFC Bank</strong></div>
-                <div class="data-row"><span>Ticker</span><strong>HDFCBANK.NS</strong></div>
-                <div class="data-row"><span>Next</span><strong>Position details</strong></div>
-                <p class="helper">Classification, quantity, price source, derived preview, and review are separate Figma states.</p>
+                <div class="section-title">Selection required</div>
+                <div class="selection-note">
+                  <span class="glyph"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="m16 16 5 5"/></svg></span>
+                  <div><strong>No asset selected yet</strong>Tap Select on the exact instrument before CogVest opens classification and position details.</div>
+                </div>
+                <p class="helper">Manual entry remains available when the provider cannot find the asset.</p>
               </section>
 
               <div class="cta-row">
-                <button class="primary" type="button">Continue to position</button>
+                <button class="primary" type="button">Select asset first</button>
                 <button class="secondary-action" type="button">Enter manually</button>
               </div>
             </div>
@@ -1321,8 +1562,9 @@
           <div class="phone">
             <div class="status"><span>10:42</span><span class="status-icons"><i class="status-dot"></i><i class="status-dot"></i>100%</span></div>
             <div class="content">
+              <div class="context-badge">Local portfolio</div>
               <header class="header-row">
-                <div><h2 class="title">Monthly Progress</h2><p class="subtitle">May 2026 snapshot</p></div>
+                <div><h2 class="title">Progress</h2><p class="subtitle">May 2026</p></div>
                 <div class="actions"><button class="icon-button" type="button" aria-label="Mask progress values"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg></button></div>
               </header>
 
@@ -1330,81 +1572,93 @@
 
               <section class="surface summary">
                 <div class="metric-grid">
-                  <div class="metric"><span class="label">Portfolio</span><strong>₹19.87L</strong></div>
-                  <div class="metric"><span class="label">Invested</span><strong>₹1.40L</strong></div>
-                  <div class="metric"><span class="label">Cash</span><strong>₹3.25L</strong></div>
-                  <div class="metric"><span class="label">Savings</span><strong>34%</strong></div>
+                  <div class="metric"><span class="label">Portfolio</span><strong>₹27.92L</strong></div>
+                  <div class="metric"><span class="label">Invested</span><strong>₹14.62L</strong></div>
+                  <div class="metric"><span class="label">Cash</span><strong>₹0</strong></div>
+                  <div class="metric"><span class="label">Savings</span><strong>66%</strong></div>
                 </div>
               </section>
 
-              <section class="surface data-card">
-                <div class="section-title">Portfolio vs invested</div>
-                <svg class="trend-graph" viewBox="0 0 320 160" role="img" aria-label="Portfolio value versus invested value by month">
+              <section class="surface chart-card">
+                <div class="chart-header">
+                  <div>
+                    <div class="chart-kicker">Portfolio Growth</div>
+                    <div class="chart-value">₹27.92L</div>
+                    <div class="chart-delta">▲ +₹19.92L since Oct 2025</div>
+                  </div>
+                  <div class="chart-range"><span class="range-chip">3M</span><span class="range-chip active">8M</span><span class="range-chip">1Y</span></div>
+                </div>
+                <svg class="trend-graph" viewBox="0 0 290 100" role="img" aria-label="Portfolio value versus invested value by month">
                   <defs>
                     <linearGradient id="portfolioFade" x1="0" x2="0" y1="0" y2="1">
-                      <stop offset="0%" stop-color="#f5f5f7"/>
-                      <stop offset="100%" stop-color="#f5f5f7" stop-opacity="0"/>
+                      <stop offset="0%" stop-color="#34c759" stop-opacity="0.3"/>
+                      <stop offset="100%" stop-color="#34c759" stop-opacity="0.02"/>
                     </linearGradient>
                   </defs>
-                  <path class="trend-grid" d="M32 24H306M32 58H306M32 92H306M32 126H306"/>
-                  <path class="trend-area" d="M34 104 C60 96 78 108 100 82 C122 58 144 72 166 64 C190 56 208 88 230 38 C252 10 274 64 306 26 L306 132 L34 132Z"/>
-                  <path class="trend-line trend-portfolio" d="M34 104 C60 96 78 108 100 82 C122 58 144 72 166 64 C190 56 208 88 230 38 C252 10 274 64 306 26"/>
-                  <path class="trend-line trend-invested" d="M34 118 C72 116 92 112 120 108 C152 104 180 100 210 94 C246 88 276 82 306 76"/>
-                  <circle class="trend-point trend-portfolio" cx="100" cy="82" r="3.5"/>
-                  <circle class="trend-point trend-portfolio" cx="230" cy="38" r="3.5"/>
-                  <circle class="trend-point trend-portfolio" cx="306" cy="26" r="3.5"/>
-                  <circle class="trend-point trend-invested" cx="306" cy="76" r="3"/>
-                  <text class="trend-axis" x="4" y="28">20L</text>
-                  <text class="trend-axis" x="5" y="95">10L</text>
-                  <text class="trend-axis" x="13" y="130">0</text>
-                  <text class="trend-axis" x="34" y="152">Dec</text>
-                  <text class="trend-axis" x="138" y="152">Mar</text>
-                  <text class="trend-axis" x="282" y="152">May</text>
+                  <path class="trend-grid" d="M0 25H290M0 50H290M0 75H290"/>
+                  <path class="trend-area" d="M0 90 C14 87 27 83 41 81 C55 79 68 77 82 75 C97 72 110 67 124 64 C138 61 151 55 165 52 C179 49 193 41 207 39 C221 37 234 27 248 24 C262 21 276 8 290 5 L290 95 L0 95Z"/>
+                  <path class="trend-line trend-portfolio" d="M0 90 C14 87 27 83 41 81 C55 79 68 77 82 75 C97 72 110 67 124 64 C138 61 151 55 165 52 C179 49 193 41 207 39 C221 37 234 27 248 24 C262 21 276 8 290 5"/>
+                  <path class="trend-line trend-invested" d="M0 91 C41 88 82 84 124 78 C165 72 207 66 248 58 C268 54 282 51 290 50"/>
+                  <circle class="trend-point trend-portfolio" cx="290" cy="5" r="4"/>
+                  <circle class="trend-point trend-portfolio" cx="290" cy="5" r="8" opacity="0.18"/>
+                  <circle class="trend-point trend-portfolio" cx="290" cy="5" r="12" opacity="0.08"/>
+                  <circle class="trend-point trend-invested" cx="290" cy="50" r="3"/>
+                  <rect x="236" y="2" width="48" height="17" rx="5" fill="#1c1c1e" stroke="#34c759" stroke-opacity="0.38"/>
+                  <text x="260" y="14" text-anchor="middle" font-family="JetBrains Mono, SF Mono, Consolas, monospace" font-size="8" fill="#34c759">₹27.92L</text>
                 </svg>
+                <div class="chart-axis"><span>Oct</span><span>Nov</span><span>Dec</span><span>Jan</span><span>Feb</span><span>Mar</span><span>Apr</span><span style="color:var(--green)">May</span></div>
                 <div class="trend-legend" aria-label="Portfolio trend legend"><span class="legend-portfolio"><i></i>Total value</span><span class="legend-invested"><i></i>Invested</span></div>
-                <p class="helper">Monthly snapshots populate this view over time. No fake stored history is implied for V1.</p>
+                <p class="chart-hint">Save your first snapshot to <em>populate live data</em>. V1 must not fake stored history.</p>
               </section>
 
-              <section class="surface data-card">
-                <div class="section-title">Assets vs months</div>
-                <svg class="trend-graph" viewBox="0 0 320 160" role="img" aria-label="Asset value trends by month excluding cash">
-                  <path class="trend-grid" d="M32 24H306M32 58H306M32 92H306M32 126H306"/>
-                  <path class="trend-line trend-equity" d="M34 98 C58 90 78 106 100 78 C124 52 144 68 166 60 C190 52 210 84 230 38 C252 18 276 58 306 36"/>
-                  <path class="trend-line trend-debt" d="M34 126 C60 122 78 124 100 116 C128 108 150 112 176 102 C206 92 236 98 262 86 C282 78 294 84 306 76"/>
-                  <path class="trend-line trend-crypto" d="M34 138 C58 132 78 144 102 122 C124 102 140 134 164 112 C188 86 206 126 230 108 C258 78 282 118 306 96"/>
-                  <circle class="trend-point trend-equity" cx="306" cy="36" r="3.5"/>
-                  <circle class="trend-point trend-debt" cx="306" cy="76" r="3.5"/>
-                  <circle class="trend-point trend-crypto" cx="306" cy="96" r="3.5"/>
-                  <text class="axis-label trend-equity" x="250" y="32">₹12.45L</text>
-                  <text class="axis-label trend-debt" x="254" y="72">₹3.22L</text>
-                  <text class="axis-label trend-crypto" x="254" y="92">₹1.20L</text>
-                  <text class="trend-axis" x="4" y="28">15L</text>
-                  <text class="trend-axis" x="5" y="95">7.5L</text>
-                  <text class="trend-axis" x="13" y="130">0</text>
-                  <text class="trend-axis" x="34" y="152">Dec</text>
-                  <text class="trend-axis" x="138" y="152">Mar</text>
-                  <text class="trend-axis" x="282" y="152">May</text>
+              <section class="surface chart-card">
+                <div class="chart-header">
+                  <div>
+                    <div class="chart-kicker">Assets vs months</div>
+                    <div class="chart-value">Crypto leads</div>
+                    <div class="chart-delta">Cash excluded · tracked separately</div>
+                  </div>
+                  <div class="chart-range"><span class="range-chip">3M</span><span class="range-chip active">8M</span><span class="range-chip">1Y</span></div>
+                </div>
+                <svg class="trend-graph" viewBox="0 0 290 100" role="img" aria-label="Asset value trends by month excluding cash">
+                  <path class="trend-grid" d="M0 25H290M0 50H290M0 75H290"/>
+                  <path class="trend-line trend-crypto" d="M0 92 C14 88 27 84 41 78 C55 70 68 62 82 58 C97 54 110 44 124 40 C138 36 151 30 165 28 C179 26 193 20 207 18 C221 16 234 13 248 11 C262 9 276 7 290 5"/>
+                  <path class="trend-line trend-equity" d="M0 88 C14 85 27 82 41 79 C55 76 68 73 82 70 C97 67 110 63 124 60 C138 56 151 52 165 48 C179 44 193 40 207 36 C221 32 234 28 248 24 C262 21 276 18 290 15"/>
+                  <path class="trend-line trend-debt" d="M0 94 C41 93 82 92 124 91 C165 90 207 89 248 88 C268 87 282 86 290 86"/>
+                  <circle class="trend-point trend-crypto" cx="0" cy="92" r="2" opacity="0.42"/><circle class="trend-point trend-crypto" cx="41" cy="78" r="2" opacity="0.42"/><circle class="trend-point trend-crypto" cx="82" cy="58" r="2" opacity="0.42"/><circle class="trend-point trend-crypto" cx="124" cy="40" r="2" opacity="0.42"/><circle class="trend-point trend-crypto" cx="165" cy="28" r="2" opacity="0.42"/><circle class="trend-point trend-crypto" cx="207" cy="18" r="2" opacity="0.42"/><circle class="trend-point trend-crypto" cx="248" cy="11" r="2" opacity="0.42"/>
+                  <circle class="trend-point trend-equity" cx="0" cy="88" r="2" opacity="0.42"/><circle class="trend-point trend-equity" cx="41" cy="79" r="2" opacity="0.42"/><circle class="trend-point trend-equity" cx="82" cy="70" r="2" opacity="0.42"/><circle class="trend-point trend-equity" cx="124" cy="60" r="2" opacity="0.42"/><circle class="trend-point trend-equity" cx="165" cy="48" r="2" opacity="0.42"/><circle class="trend-point trend-equity" cx="207" cy="36" r="2" opacity="0.42"/><circle class="trend-point trend-equity" cx="248" cy="24" r="2" opacity="0.42"/>
+                  <circle class="trend-point trend-debt" cx="0" cy="94" r="2" opacity="0.35"/><circle class="trend-point trend-debt" cx="41" cy="93" r="2" opacity="0.35"/><circle class="trend-point trend-debt" cx="82" cy="92" r="2" opacity="0.35"/><circle class="trend-point trend-debt" cx="124" cy="91" r="2" opacity="0.35"/><circle class="trend-point trend-debt" cx="165" cy="90" r="2" opacity="0.35"/><circle class="trend-point trend-debt" cx="207" cy="89" r="2" opacity="0.35"/><circle class="trend-point trend-debt" cx="248" cy="88" r="2" opacity="0.35"/>
+                  <circle class="trend-point trend-crypto" cx="290" cy="5" r="4"/><circle class="trend-point trend-crypto" cx="290" cy="5" r="8" opacity="0.16"/><circle class="trend-point trend-crypto" cx="290" cy="5" r="12" opacity="0.07"/>
+                  <circle class="trend-point trend-equity" cx="290" cy="15" r="3.5"/><circle class="trend-point trend-equity" cx="290" cy="15" r="8" opacity="0.12"/>
+                  <circle class="trend-point trend-debt" cx="290" cy="86" r="3"/>
+                  <rect x="232" y="2" width="52" height="17" rx="5" fill="#1c1c1e" stroke="#ff9f0a" stroke-opacity="0.38"/>
+                  <text x="258" y="14" text-anchor="middle" font-family="JetBrains Mono, SF Mono, Consolas, monospace" font-size="8" fill="#ff9f0a">₹14.89L</text>
+                  <rect x="232" y="22" width="52" height="17" rx="5" fill="#1c1c1e" stroke="#34c759" stroke-opacity="0.34"/>
+                  <text x="258" y="34" text-anchor="middle" font-family="JetBrains Mono, SF Mono, Consolas, monospace" font-size="8" fill="#34c759">₹13.04L</text>
                 </svg>
+                <div class="chart-axis"><span>Oct</span><span>Nov</span><span>Dec</span><span>Jan</span><span>Feb</span><span>Mar</span><span>Apr</span><span style="color:var(--green)">May</span></div>
                 <div class="trend-legend" aria-label="Asset trend legend"><span class="trend-equity"><i></i>Equity</span><span class="trend-debt"><i></i>Debt</span><span class="trend-crypto"><i></i>Crypto</span></div>
-                <p class="helper">Snapshot trend direction only. Cash stays separate in Cash Ledger until monthly data is saved.</p>
+                <p class="chart-hint">Use saved monthly snapshots only. The graph is a design target, not fake production data.</p>
               </section>
 
               <section class="section">
-                <div class="section-head"><span class="section-title">What changed?</span><button class="section-action" type="button">Details</button></div>
+                <div class="section-head"><span class="section-title">What changed this month?</span><button class="section-action" type="button">Details</button></div>
                 <div class="group">
-                  <div class="row"><span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span><div class="row-main"><div class="row-title">Equity</div><div class="row-meta">Market value and contributions</div></div><div class="row-value">+₹58K</div></div>
-                  <div class="row"><span class="glyph debt"><svg viewBox="0 0 24 24"><path d="M12 3 5 6v5c0 4.5 3 7.5 7 9 4-1.5 7-4.5 7-9V6z"/></svg></span><div class="row-main"><div class="row-title">Debt</div><div class="row-meta">Stable allocation</div></div><div class="row-value">+₹12K</div></div>
-                  <div class="row"><span class="glyph crypto"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 7v10M9.2 9h4.1a2 2 0 0 1 0 4H9.2M9.2 13h4.8a2 2 0 0 1 0 4H9.2"/></svg></span><div class="row-main"><div class="row-title">Crypto</div><div class="row-meta">Manual price movement</div></div><div class="row-value negative">-₹8.5K</div></div>
-                  <div class="row"><span class="glyph cash"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg></span><div class="row-main"><div class="row-title">Cash</div><div class="row-meta">Net cash change</div></div><div class="row-value">+₹70K</div></div>
+                  <div class="row"><div class="row-main"><div class="row-title">Monthly investment</div><div class="row-meta">User-entered snapshot field</div></div><div class="row-value">₹14.62L</div></div>
+                  <div class="row"><div class="row-main"><div class="row-title">Cash added</div><div class="row-meta">Cash ledger contribution</div></div><div class="row-value">₹0</div></div>
+                  <div class="row"><div class="row-main"><div class="row-title">Expense rate</div><div class="row-meta">Not tracked in V1 yet</div></div><div class="row-value">—</div></div>
                 </div>
               </section>
 
               <section class="surface data-card">
-                <div class="section-title">Closing snapshot</div>
-                <div class="data-row"><span>Equity</span><strong>₹12.45L · 62.6%</strong></div>
-                <div class="data-row"><span>Debt</span><strong>₹3.22L · 16.2%</strong></div>
-                <div class="data-row"><span>Crypto</span><strong>₹1.20L · 6.0%</strong></div>
-                <div class="data-row"><span>Cash</span><strong>₹3.25L · 16.3%</strong></div>
+                <div class="section-title">Record Snapshot · May 2026</div>
+                <div class="form-grid">
+                  <div class="form-field prefill"><label>Portfolio Value <span class="auto">· auto-filled</span></label><strong>₹27.92L</strong></div>
+                  <div class="form-field prefill"><label>Invested <span class="auto">· auto-filled</span></label><strong>₹15.95L</strong></div>
+                  <div class="form-field"><label>Monthly Investment</label><strong>e.g. ₹60,000</strong></div>
+                  <div class="form-field"><label>Salary</label><strong>e.g. ₹1,60,000</strong></div>
+                </div>
+                <button class="primary full-width" type="button">Save Monthly Snapshot</button>
               </section>
             </div>
             <div class="nav">
@@ -1429,12 +1683,11 @@
 
               <section class="surface hero">
                 <div class="label">Cash balance</div>
-                <div class="hero-value">₹1,65,600</div>
-                <span class="gain-pill">Available · ₹1.20L</span>
+                <div class="hero-value"><sup>₹</sup>0.00</div>
                 <div class="metric-grid">
-                  <div class="metric"><span class="label">Added</span><strong>₹70K</strong></div>
-                  <div class="metric"><span class="label">Invested</span><strong>₹45K</strong></div>
-                  <div class="metric"><span class="label">Savings</span><strong>32.8%</strong></div>
+                  <div class="metric"><span class="label">Invested</span><strong>₹14.62L</strong></div>
+                  <div class="metric"><span class="label">Available</span><strong>₹0.00</strong></div>
+                  <div class="metric"><span class="label">Savings</span><strong>—</strong></div>
                 </div>
               </section>
 
@@ -1442,20 +1695,18 @@
                 <div class="section-title">Add cash entry</div>
                 <div class="chips" aria-label="Cash entry type"><button class="chip active" type="button">Deposit</button><button class="chip" type="button">Withdraw</button><button class="chip" type="button">Transfer</button></div>
                 <div class="form-grid">
-                  <div class="form-field"><label>Amount (INR)</label><strong>₹0</strong></div>
-                  <div class="form-field"><label>Date</label><strong>09 May 2026</strong></div>
-                  <div class="form-field full"><label>Note</label><strong>Salary, SIP transfer, emergency fund</strong></div>
+                  <div class="form-field"><label>Amount (INR)</label><strong>Enter amount</strong></div>
+                  <div class="form-field"><label>Date</label><strong>19 May 2026</strong></div>
+                  <div class="form-field"><label>Label</label><strong>e.g. Salary</strong></div>
+                  <div class="form-field full"><label>Note</label><strong>Optional note</strong></div>
                 </div>
                 <button class="primary full-width" type="button">Save entry</button>
               </section>
 
-              <section class="section">
-                <div class="section-head"><span class="section-title">Recent cash ledger</span><button class="section-action" type="button">View all</button></div>
-                <div class="group">
-                  <div class="row"><span class="glyph cash"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg></span><div class="row-main"><div class="row-title">Salary added</div><div class="row-meta">Cash deposit</div></div><div class="row-value positive">+₹70K</div></div>
-                  <div class="row"><span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M4 15l5-5 4 4 7-8"/><path d="M14 6h6v6"/></svg></span><div class="row-main"><div class="row-title">SIP transfer</div><div class="row-meta">Index Fund</div></div><div class="row-value">-₹15K</div></div>
-                  <div class="row"><span class="glyph cash"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg></span><div class="row-main"><div class="row-title">Emergency fund top-up</div><div class="row-meta">Cash reserve</div></div><div class="row-value positive">+₹10K</div></div>
-                </div>
+              <section class="surface empty-panel">
+                <div class="empty-illustration"><svg viewBox="0 0 24 24"><path d="M4 7h16v12H4z"/><path d="M4 7l11-3 2 3"/><path d="M15 13h5"/></svg></div>
+                <div class="section-title">No cash entries yet</div>
+                <p>Add broker or bank cash to include it in your total portfolio value.</p>
               </section>
             </div>
             <div class="nav">
@@ -1474,46 +1725,37 @@
             <div class="content">
               <div class="context-badge">Local portfolio</div>
               <header class="header-row">
-                <div><h2 class="title">Settings</h2><p class="subtitle">Local-first controls</p></div>
+                <div><h2 class="title">Settings</h2><p class="subtitle">v1.0.0 Preview</p></div>
                 <div class="actions"><button class="icon-button" type="button" aria-label="About CogVest"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 11v5M12 8h.01"/></svg></button></div>
               </header>
 
               <section class="trust-banner">
                 <span class="glyph equity"><svg viewBox="0 0 24 24"><path d="M12 3 5 6v5c0 4.5 3 7.5 7 9 4-1.5 7-4.5 7-9V6z"/><path d="M9.5 12.5 11 14l3.5-4"/></svg></span>
-                <div><div class="row-title">Your data stays on this device</div><p>No account, no cloud sync, and no analytics in the V1 tracker.</p></div>
+                <div><div class="row-title">Your data never leaves this device</div><p>No account. No cloud sync. No analytics. Everything is stored locally on your Android device only.</p></div>
               </section>
 
-              <div class="section-label">Privacy</div>
+              <div class="section-label">Display</div>
               <section class="group">
-                <div class="row"><span class="glyph debt"><svg viewBox="0 0 24 24"><path d="M12 3 5 6v5c0 4.5 3 7.5 7 9 4-1.5 7-4.5 7-9V6z"/><path d="M9.5 12.5 11 14l3.5-4"/></svg></span><div class="row-main"><div class="row-title">Privacy</div><div class="row-meta">Local storage active · No account · No cloud</div></div><div class="row-value positive">On</div></div>
-                <div class="row"><span class="glyph"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg></span><div class="row-main"><div class="row-title">Value masking</div><div class="row-meta">Hide sensitive values on screen</div></div><div class="row-value">Ready</div></div>
+                <div class="row"><span class="glyph"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/></svg></span><div class="row-main"><div class="row-title">Value masking</div><div class="row-meta">Hide INR amounts in shared spaces</div></div><div class="row-value">Off</div></div>
               </section>
 
               <div class="section-label">Quotes</div>
               <section class="group">
-                <div class="row"><span class="glyph cash"><svg viewBox="0 0 24 24"><path d="M20 7v5h-5M4 17v-5h5"/><path d="M18 12a6 6 0 0 0-10.2-4.2L4 11m16 2-3.8 3.2A6 6 0 0 1 6 12"/></svg></span><div class="row-main"><div class="row-title">Quotes</div><div class="row-meta">Every 15 min · Manual fallback on</div></div><div class="row-value positive">OK</div></div>
+                <div class="row"><div class="row-main"><div class="row-title">Last refreshed</div><div class="row-meta">3 cached positions</div></div><div class="row-value positive">19 May 2026</div></div>
+                <div class="row"><div class="row-main"><div class="row-title">Provider status</div></div><div class="row-value positive">Live</div></div>
+                <div class="row"><div class="row-main"><div class="row-title">Manual fallback</div><div class="row-meta">Prices used when APIs fail</div></div><div class="row-value">0 saved</div></div>
               </section>
 
               <div class="section-label">Currency</div>
-              <section class="surface data-card">
-                <div class="section-title">Currency</div>
-                <div class="data-row"><span>Base currency</span><strong>INR</strong></div>
-                <div class="data-row"><span>Foreign summary</span><strong>On</strong></div>
-                <div class="data-row"><span>USD and crypto fallback</span><strong>On</strong></div>
-              </section>
-
-              <div class="section-label">Display</div>
-              <section class="surface data-card">
-                <div class="section-title">Display and app info</div>
-                <div class="data-row"><span>Density</span><strong>Standard V1</strong></div>
-                <div class="data-row"><span>Minimal Mode</span><strong>V2 locked</strong></div>
-                <div class="data-row"><span>App version</span><strong>1.0.0 preview</strong></div>
+              <section class="group">
+                <div class="row"><div class="row-main"><div class="row-title">Base currency</div></div><div class="row-value">INR ₹</div></div>
+                <div class="row"><div class="row-main"><div class="row-title">Foreign asset summary</div><div class="row-meta">Show USD holdings in INR</div></div><div class="row-value positive">On</div></div>
+                <div class="row"><div class="row-main"><div class="row-title">USD and crypto fallback</div><div class="row-meta">Use fallback if live rate fails</div></div><div class="row-value positive">On</div></div>
               </section>
 
               <div class="section-label">Data</div>
-              <section class="surface data-card">
-                <div class="section-title negative">Data</div>
-                <div class="data-row"><span>Clear local data</span><strong class="negative">Destructive</strong></div>
+              <section class="group">
+                <div class="row" style="opacity:.35;pointer-events:none"><div class="row-main"><div class="row-title negative">Clear local data</div><div class="row-meta">Coming in a future update</div></div><div class="row-value">—</div></div>
               </section>
             </div>
             <div class="nav">

--- a/docs/design/v1-screen-baseline.md
+++ b/docs/design/v1-screen-baseline.md
@@ -1,0 +1,199 @@
+# V1 Screen Baseline
+
+This is the accepted V1 screen contract for CogVest UI implementation work.
+Use it with `DESIGN.md` and the current design assets:
+
+- HTML preview: `docs/design/issue-86-premium-preview/index.html`
+- Figma generator: `docs/design/figma/issue-69-v1-screens/code.js`
+- Figma file: `https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d`
+
+The external mockup used during review is not a future dependency. The repo
+assets above carry the accepted baseline forward.
+
+## Product Direction
+
+CogVest V1 should feel like a premium private investment ledger:
+
+- calm true-dark Android UI
+- portfolio-first, not trading-first
+- Excel-grade tracking concepts without spreadsheet density
+- readable INR values with value masking support
+- local-first trust visible in the UI
+- green used only for active state, primary action, and positive financial state
+
+Do not add Minimal Mode, LTCG UI, historical-chart scope, import/export,
+multi-portfolio behavior, auth, cloud sync, analytics, or trading-app visuals in
+V1 design or implementation unless a later issue explicitly changes scope.
+
+## Screen Set
+
+V1 primary tabs:
+
+- Dashboard
+- Holdings
+- Progress
+- Cash
+- Settings
+
+Add Holding is a secondary flow launched from Dashboard/Holdings, not a main
+bottom tab in the accepted V1 baseline.
+
+## Dashboard
+
+Dashboard answers the first five-second questions:
+
+- What is my portfolio worth?
+- How much did I invest?
+- What is my P&L?
+- How is the portfolio allocated?
+- Is quote data fresh?
+
+Baseline structure:
+
+- local portfolio header with mask and refresh actions
+- large `Portfolio Value` hero
+- total gain/loss context, invested value, P&L, and return
+- compact allocation card
+- monthly contribution/cash context
+- calm conviction/insight placeholder only when useful
+
+The dashboard must not become a trading terminal. Avoid ticker feeds, noisy
+daily movers, dense mini-widgets, and fake market history.
+
+## Holdings
+
+Holdings replaces Excel rows with durable mobile position cards.
+
+Each holding card should expose:
+
+- asset name and symbol
+- asset class and useful metadata
+- current value
+- invested value
+- quantity
+- average cost
+- current price or last traded price
+- P&L and P&L %
+- allocation percentage
+- live/manual/stale quote state where relevant
+
+Rules:
+
+- use filter chips with counts where useful
+- keep the Add Holding entry point in the Holdings header
+- keep Search and value masking available
+- do not use spreadsheet-style columns or editable grids
+- keep allocation visible for each holding and consistent with Dashboard totals
+
+## Add Holding
+
+Add Holding is lookup-first and explicit-selection-first.
+
+Required flow:
+
+1. Search for an asset by familiar name or symbol.
+2. Show result choices.
+3. Require the user to tap `Select` before fields are autofilled.
+4. Allow manual entry as fallback.
+5. Capture classification.
+6. Capture position details.
+7. Show derived preview.
+8. Review and save.
+
+The UI must not auto-pick the first search result. Manual ticker/current-price
+entry is a fallback, not the primary perceived path.
+
+Required concepts:
+
+- asset name
+- ticker/symbol
+- currency
+- asset class
+- instrument type
+- sector/type metadata
+- quantity
+- average cost
+- current price
+- live/manual price source
+- acquisition date
+- optional conviction
+- optional note
+
+## Progress
+
+The V1 screen title is `Monthly Progress`; the tab label can be `Progress`.
+
+Accepted chart direction:
+
+- first graph: total portfolio value vs invested value by month
+- second graph: asset values vs months
+- cash is excluded from the asset-trend graph and tracked separately in Cash
+- charts must use stored monthly snapshots or a clear empty/no-snapshot state
+
+Do not fake production chart history. If snapshots are missing, show a premium
+empty state and a clear path to record a snapshot.
+
+Monthly Progress must preserve Excel parity concepts:
+
+- portfolio value
+- monthly gain/change
+- equity value
+- debt value
+- crypto value
+- invested value
+- monthly investment
+- salary if tracked
+- cash context
+- savings rate
+- expense rate if tracked
+- asset class snapshot
+
+## Cash Ledger
+
+Cash is part of portfolio tracking but should stay visually separate from
+asset-trend history.
+
+Baseline structure:
+
+- title `Cash Ledger`
+- subtitle `Manual ledger - local only`
+- cash balance hero
+- invested, available, and savings context
+- entry form for deposit, withdrawal, and investment transfer
+- recent ledger rows or a useful empty state
+
+Investment transfers should reduce available cash where applicable. Empty cash
+state should be acceptable and should not imply missing setup.
+
+## Settings
+
+Settings should build trust.
+
+Baseline groups:
+
+- Privacy: local storage, no account, no cloud, no analytics
+- Display: value masking status and mask preview
+- Quotes: refresh status, provider status, manual fallback status
+- Currency: INR base and foreign/crypto fallback settings
+- Data: destructive or future data actions separated from normal settings
+
+Do not show unsupported settings as if they work. V2/V3 features may be marked
+as locked or future only if they appear at all.
+
+## Data Consistency Rules
+
+- Dashboard totals, Holdings totals, allocation, and Progress snapshot values
+  must be derived from the same domain functions.
+- Mockup numbers are visual examples only; production screens must use stored
+  local data or empty states.
+- Persist raw user records. Derive portfolio values, P&L, allocation, and
+  progression summaries.
+- P&L must not be communicated only by color; include signs, labels, or text.
+- All INR wealth values must participate in value masking.
+
+## Future Work Rule
+
+Any UI PR that changes Dashboard, Holdings, Add Holding, Progress, Cash, or
+Settings must compare against this baseline before merge. If the accepted
+design changes, update this document, the HTML preview, and the Figma generator
+in the same issue or explicitly log the drift.

--- a/docs/design/v1-ui-mockup-plan.md
+++ b/docs/design/v1-ui-mockup-plan.md
@@ -1,8 +1,9 @@
 # V1 UI Mockup Plan
 
 > Status: historical V1 visual planning reference. For current V1 UI work, use
-> `DESIGN.md` and `docs/design/figma/issue-69-v1-screens/code.js` as the
-> source of truth. This document remains only for early context.
+> `DESIGN.md`, `docs/design/figma/issue-69-v1-screens/code.js`, and the active
+> design-baseline revision spec under `docs/superpowers/specs/` as the source of
+> truth. This document remains only for early context.
 
 Figma: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d
 

--- a/docs/design/v1-ui-mockup-plan.md
+++ b/docs/design/v1-ui-mockup-plan.md
@@ -1,9 +1,10 @@
 # V1 UI Mockup Plan
 
 > Status: historical V1 visual planning reference. For current V1 UI work, use
-> `DESIGN.md`, `docs/design/figma/issue-69-v1-screens/code.js`, and the active
-> design-baseline revision spec under `docs/superpowers/specs/` as the source of
-> truth. This document remains only for early context.
+> `DESIGN.md`, `docs/design/v1-screen-baseline.md`,
+> `docs/design/issue-86-premium-preview/index.html`, and
+> `docs/design/figma/issue-69-v1-screens/code.js` as the source of truth. This
+> document remains only for early context.
 
 Figma: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d
 
@@ -22,11 +23,17 @@ Show total `₹0.00`, no allocation, and a strong `Add Holding` CTA. Empty copy 
 
 ### Filled Dashboard
 
-Show portfolio value, allocation summary, quote freshness, monthly context, basic conviction nudge, and Add Holding CTA. Do not show Minimal Mode or LTCG.
+Show portfolio value, invested value, P&L, return, allocation summary, quote
+freshness, monthly context, and calm conviction/insight context. Do not show
+Minimal Mode or LTCG.
 
 ### Add Holding
 
-Use the multi-phase Figma direction: Asset, Classification, Position, Review. Include asset lookup/autofill where available, manual fallback, quantity, average/current price, date, optional conviction, optional note, and review before save.
+Use the multi-phase baseline: search, explicit asset selection, classification,
+position, derived preview, review. The search result must not auto-select; the
+user chooses the asset before autofill. Include manual fallback, quantity,
+average/current price, date, optional conviction, optional note, and review
+before save.
 
 ### Holdings Empty
 
@@ -34,7 +41,16 @@ Show empty card with “No holdings yet” and CTA to Add Holding.
 
 ### Holdings Filled
 
-Holding card rows: asset name/symbol, quantity, average cost, current value, unrealised P&L, quote freshness. No LTCG badge in V1.
+Holding card rows: asset name/symbol, asset class metadata, current value,
+invested value, allocation, quantity, average cost, current price, unrealised
+P&L, quote freshness, and stale/manual state where relevant. No LTCG badge in
+V1.
+
+### Monthly Progress
+
+Use two stored-snapshot-driven graph areas when data exists: total portfolio
+value vs invested value, and assets vs months excluding cash. If no snapshots
+exist, show a clear no-snapshot state. Do not fake production chart history.
 
 ### Cash Empty/Filled
 

--- a/docs/housekeeping/stale-doc-audit.md
+++ b/docs/housekeeping/stale-doc-audit.md
@@ -22,7 +22,7 @@ from this audit.
 | --- | --- | --- |
 | `docs/cogvest-codex-prompts.md` | Historical / stale | Contains old all-in prompts with V1 Minimal Mode and LTCG instructions. Conflicts with current V1 boundaries. |
 | `docs/cogvest-master-spec.md` | Broad product spec | Valuable product context, but contains Minimal Mode, LTCG, and older screen language that should not be interpreted as V1 implementation scope. |
-| `docs/design/v1-ui-mockup-plan.md` | Historical visual reference | Updated during #74 cleanup to point current V1 work to `DESIGN.md` and Figma issue #69 files. |
+| `docs/design/v1-ui-mockup-plan.md` | Historical visual reference | Current V1 work now points to `DESIGN.md`, `docs/design/v1-screen-baseline.md`, the HTML preview, and Figma issue #69 files. |
 | `docs/design/v2-ui-mockup-plan.md` | Future reference | Fine for V2, but should not drive current V1 work. |
 | `docs/design/v3-ui-mockup-plan.md` | Future reference | Fine for V3, but should not drive current V1 work. |
 | `docs/cogvest_standard_mode.png` | Historical mockup | Older visual direction. Current Figma/code.js and `DESIGN.md` should override it. |
@@ -37,7 +37,7 @@ from this audit.
 | History vs Progress | `AGENTS.md` says V1 language should prefer Progress | Rename stale references from History/Progression to Progress/Monthly Progress where applicable. |
 | Minimal Mode in V1 docs | `AGENTS.md` excludes Minimal Mode from V1 | Mark older Minimal Mode docs as V2-only or historical. |
 | LTCG in V1 docs | `AGENTS.md` excludes LTCG UI/tax badges from V1 | Mark LTCG docs/prompts as V2/V3-only and keep V1 tests asserting no LTCG UI. |
-| Old visual mockups vs Figma | `DESIGN.md` and `docs/design/figma/issue-69-v1-screens/code.js` | Add a short note in older mockup docs saying they are superseded by current Figma V1 screens. |
+| Old visual mockups vs current baseline | `DESIGN.md`, `docs/design/v1-screen-baseline.md`, the HTML preview, and `docs/design/figma/issue-69-v1-screens/code.js` | Older mockups are superseded by the accepted V1 screen baseline. |
 | Android APK testing | `AGENTS.md` and `docs/testing/android-pc-test-harness.md` | Add local release APK build notes discovered during #72 reproduction if not already documented. |
 
 ## Recommended Doc Tasks

--- a/docs/issues/v1-issue-drafts.md
+++ b/docs/issues/v1-issue-drafts.md
@@ -4,6 +4,10 @@
 > source of truth. User-facing V1 language should now prefer Add Holding,
 > Dashboard, Holdings, Progress, Cash, and Settings; internal code may still use
 > trade terminology until refactored.
+>
+> Current V1 UI work should use `docs/design/v1-screen-baseline.md`,
+> `docs/design/issue-86-premium-preview/index.html`, and
+> `docs/design/figma/issue-69-v1-screens/code.js`, not the early drafts below.
 
 Milestone: CogVest V1 MVP
 
@@ -28,7 +32,9 @@ Create the Android-first Expo foundation for CogVest.
 - Files: `app/_layout.tsx`, `app/(tabs)/_layout.tsx`, tab placeholders, `package.json`, `tsconfig.json`, `jest.config.js`.
 
 ### Design Reference
-- `docs/design/v1-ui-mockup-plan.md`
+- `docs/design/v1-screen-baseline.md`
+- `docs/design/issue-86-premium-preview/index.html`
+- `docs/design/figma/issue-69-v1-screens/code.js`
 - Figma: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d
 
 ### Acceptance Criteria
@@ -66,7 +72,7 @@ Provide reusable UI primitives before screens are built.
 - Files: `src/theme/*`, `src/components/common/*`.
 
 ### Design Reference
-- `docs/design/v1-ui-mockup-plan.md`
+- `docs/design/v1-screen-baseline.md`
 
 ### Acceptance Criteria
 - Tokens match CogVest design rules.
@@ -216,7 +222,7 @@ Trade validation must be correct before the UI writes local data.
 - Files: `src/domain/validators/trade.ts`, `src/features/trades/tradeForm.ts`.
 
 ### Design Reference
-- `docs/design/v1-ui-mockup-plan.md`
+- `docs/design/v1-screen-baseline.md`
 
 ### Acceptance Criteria
 - Invalid inputs return actionable errors.
@@ -253,7 +259,7 @@ Fast Add Holding entry is the core V1 workflow.
 - Files: `app/(tabs)/add-trade.tsx`, `src/components/forms/*`.
 
 ### Design Reference
-- `docs/design/v1-ui-mockup-plan.md`
+- `docs/design/v1-screen-baseline.md`
 - Figma: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d
 
 ### Acceptance Criteria
@@ -292,7 +298,7 @@ Holdings are the primary proof that trades are being derived correctly.
 - Files: `src/features/holdings/useHoldings.ts`, `src/components/cards/HoldingCard.tsx`, `app/(tabs)/holdings.tsx`.
 
 ### Design Reference
-- `docs/design/v1-ui-mockup-plan.md`
+- `docs/design/v1-screen-baseline.md`
 
 ### Acceptance Criteria
 - Holdings derive from trades and quotes.
@@ -332,7 +338,7 @@ Dashboard gives the at-a-glance portfolio view.
 - Files: `src/features/dashboard/useDashboard.ts`, dashboard cards, `app/(tabs)/dashboard.tsx`.
 
 ### Design Reference
-- `docs/design/v1-ui-mockup-plan.md`
+- `docs/design/v1-screen-baseline.md`
 
 ### Acceptance Criteria
 - Total equals holdings plus cash.
@@ -369,7 +375,7 @@ Cash is part of total portfolio value.
 - Files: `app/(tabs)/cash.tsx`, `src/features/cash/useCash.ts`, `src/components/cards/CashEntryRow.tsx`.
 
 ### Design Reference
-- `docs/design/v1-ui-mockup-plan.md`
+- `docs/design/v1-screen-baseline.md`
 
 ### Acceptance Criteria
 - Cash total is additions minus withdrawals.
@@ -405,7 +411,7 @@ Users need privacy controls for portfolio values.
 - Files: `app/settings.tsx`, preference hooks, value renderers.
 
 ### Design Reference
-- `docs/design/v1-ui-mockup-plan.md`
+- `docs/design/v1-screen-baseline.md`
 
 ### Acceptance Criteria
 - Wealth values mask globally.

--- a/docs/roadmap/cogvest-version-roadmap.md
+++ b/docs/roadmap/cogvest-version-roadmap.md
@@ -5,8 +5,11 @@
 - Master spec: `docs/cogvest-master-spec.md`
 - Historical full prompt set: `docs/cogvest-codex-prompts.md` (reference only; current V1 scope is this roadmap plus `AGENTS.md`)
 - Planning prompt: `docs/prompts/versioned-roadmap-planning-prompt.md`
+- V1 screen baseline: `docs/design/v1-screen-baseline.md`
+- V1 HTML preview: `docs/design/issue-86-premium-preview/index.html`
+- V1 Figma generator: `docs/design/figma/issue-69-v1-screens/code.js`
 - Figma mockups: https://www.figma.com/design/elYeXztRAlYZBSRvlgL23d
-- Historical visual references: `docs/cogvest_standard_mode.png`, `docs/cogvest_minimal_mode.png` (superseded for V1 by `DESIGN.md` and the issue #69 Figma screens)
+- Historical visual references: `docs/cogvest_standard_mode.png`, `docs/cogvest_minimal_mode.png` (superseded for V1 by `DESIGN.md`, `docs/design/v1-screen-baseline.md`, and the issue #69 Figma screens)
 
 ## Version Strategy
 
@@ -23,10 +26,12 @@ Included:
 - Local MMKV persistence through Zustand.
 - Add Holding with opening position entry, asset metadata, current/manual price, notes, and optional conviction.
 - Lightweight asset lookup/autofill for common supported assets, with manual fallback.
+- Add Holding search requires explicit user selection before autofill; it must not auto-pick the first result.
 - Live quote fetching for current prices on app open and pull-to-refresh.
 - Manual price fallback when quotes fail.
 - Holdings derived from trades.
-- Basic dashboard with total value, allocation, and quote freshness.
+- Basic dashboard with total value, invested value, P&L, allocation, and quote freshness.
+- Monthly Progress with stored-snapshot views for portfolio value vs invested value and assets vs months, excluding cash from the asset trend.
 - Cash add/withdraw tracking.
 - Simple settings for value masking and app metadata.
 - Value masking across INR wealth values.

--- a/docs/roadmap/v1-mvp-spec.md
+++ b/docs/roadmap/v1-mvp-spec.md
@@ -12,6 +12,8 @@ The user can add holdings quickly, see current holdings and portfolio value in I
 
 - App scaffold with Expo Router tabs.
 - Theme, typography, spacing, and reusable common components.
+- V1 screen baseline from `docs/design/v1-screen-baseline.md`, the HTML
+  preview, and the Figma generator.
 - Domain types for assets, trades, cash, quotes, holdings, preferences.
 - Pure domain calculations for holdings, allocation, portfolio total, day change, formatters, and basic conviction readiness.
 - Zustand store with MMKV persistence for raw local data.
@@ -33,6 +35,7 @@ The user can add holdings quickly, see current holdings and portfolio value in I
 - LTCG UI or tax badges.
 - Historical charts.
 - Advanced asset search.
+- Auto-selecting the first Add Holding search result.
 - Patience analysis.
 - Trade frequency analysis.
 - Full behaviour engine.
@@ -48,6 +51,21 @@ The user can add holdings quickly, see current holdings and portfolio value in I
 - Cash.
 - Monthly Progress.
 - Settings.
+
+## V1 Design Baseline
+
+Use `docs/design/v1-screen-baseline.md` as the accepted screen contract.
+
+Key implementation rules:
+
+- Dashboard, Holdings, Progress, Cash, and Settings are the primary tabs.
+- Add Holding is a secondary flow launched from Dashboard/Holdings.
+- Add Holding search must require explicit user selection before autofill.
+- Holdings must show allocation context per holding without table-like density.
+- Monthly Progress uses stored snapshots for portfolio value vs invested value
+  and assets vs months; cash is excluded from the asset-trend graph.
+- Production screens must not fake portfolio or chart history when data is
+  missing.
 
 ## Data Model Changes
 

--- a/docs/superpowers/plans/2026-05-22-issue-102-design-baseline-revision.md
+++ b/docs/superpowers/plans/2026-05-22-issue-102-design-baseline-revision.md
@@ -1,0 +1,253 @@
+# Issue #102 Design Baseline Revision Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Revise CogVest's V1 design assets so the repo baseline reflects the refined May 21 HTML mockup direction while preserving the approved V1 Add Holding and state coverage.
+
+**Architecture:** Keep the browser preview and Figma development plugin as the two stable design outputs. Use the preview to express richer mobile layouts and state examples, then align the Figma generator and its README with the same screen set and scope guardrails so later UI implementation has one design contract.
+
+**Tech Stack:** Static HTML/CSS preview, Figma Plugin API JavaScript, Markdown design docs.
+
+---
+
+## File Map
+
+- Modify `docs/design/issue-86-premium-preview/index.html` to adopt the refined
+  dashboard, holdings, cash, settings, and state treatment while preserving the
+  current Add Holding and V1 Progress scope.
+- Modify `docs/design/issue-86-premium-preview/README.md` to describe the
+  refined revision coverage and local preview verification.
+- Modify `docs/design/figma/issue-69-v1-screens/code.js` to generate screens
+  matching the refined repo preview instead of the older Issue #86 baseline.
+- Modify `docs/design/figma/issue-69-v1-screens/README.md` to explain the new
+  design baseline and exact Figma output coverage.
+- Optionally modify `docs/design/v1-ui-mockup-plan.md` only if the active source
+  guidance needs to point more precisely at the revised assets.
+
+### Task 1: Reconcile Browser Preview Direction
+
+**Files:**
+- Modify: `docs/design/issue-86-premium-preview/index.html`
+- Modify: `docs/design/issue-86-premium-preview/README.md`
+
+- [ ] **Step 1: Read the approved Issue #102 spec and the current preview**
+
+Run:
+
+```powershell
+Get-Content -Raw docs\superpowers\specs\2026-05-21-issue-102-design-baseline-revision.md
+Get-Content -Raw docs\design\issue-86-premium-preview\README.md
+rg -n "Dashboard|Holdings|Add Holding|Monthly Progress|Cash Ledger|Settings|state" docs\design\issue-86-premium-preview\index.html
+```
+
+Expected: the spec requires refined Holdings/Cash/Settings treatment while the
+preview still exposes the older Issue #86 layouts.
+
+- [ ] **Step 2: Update preview tokens and shared mobile shell treatment**
+
+Edit the preview CSS so the design remains true-dark and CogVest-specific while
+borrowing the refined mockup's hierarchy:
+
+```css
+:root {
+  --bg: #000000;
+  --surface: #141416;
+  --surface-strong: #1c1c1e;
+  --surface-soft: #202024;
+  --separator: rgba(255, 255, 255, 0.1);
+  --text: #f5f5f7;
+  --secondary: #98989d;
+  --muted: #636366;
+  --positive: #34c759;
+}
+```
+
+Keep comments and names aligned with the existing file patterns rather than
+introducing a second token system.
+
+- [ ] **Step 3: Update the refined screen layouts**
+
+Use the approved spec to make these preview changes:
+
+- Dashboard: portfolio-first hero, explicit P&L context, calm allocation and
+  monthly summary, no over-promoted daily trading cue.
+- Holdings: compact durable-position cards, filter counts, visible quantity,
+  average cost, current price, P&L, allocation, quote freshness, stale/manual
+  state, and header Add Holding action.
+- Cash Ledger: focused entry controls and an empty-state treatment.
+- Settings: local-first trust treatment plus grouped value masking, quotes,
+  currency, and data controls.
+
+Do not remove:
+
+- Add Holding lookup, position, and review screens.
+- quote lookup/manual fallback design states.
+- no-snapshot state.
+
+- [ ] **Step 4: Keep Progress inside V1 scope**
+
+If the preview uses a graph-like treatment, pair it with copy that makes the
+V1 constraint explicit:
+
+```html
+<p class="helper">
+  Monthly snapshots populate this view over time. No saved history yet.
+</p>
+```
+
+Expected: the preview may show long-term structure, but it must not present fake
+historical charting as a shipped V1 feature.
+
+- [ ] **Step 5: Update the preview README**
+
+Document the refined revision and verification command:
+
+```markdown
+## Refined Baseline
+
+This preview carries the Issue #102 visual revision:
+
+- refined Dashboard, Holdings, Cash Ledger, and Settings hierarchy
+- Add Holding remains lookup-first and multi-phase
+- V1 states cover loading, stale/manual quote fallback, and no snapshots
+```
+
+- [ ] **Step 6: Verify the static preview files**
+
+Run:
+
+```powershell
+git diff --check
+rg -n "Add Holding|stale|manual|Monthly Progress|Cash Ledger|Local-first" docs\design\issue-86-premium-preview
+```
+
+Expected: no whitespace errors and required V1 coverage remains present.
+
+### Task 2: Align The Figma Generator
+
+**Files:**
+- Modify: `docs/design/figma/issue-69-v1-screens/code.js`
+- Modify: `docs/design/figma/issue-69-v1-screens/README.md`
+
+- [ ] **Step 1: Map preview coverage to Figma output**
+
+Run:
+
+```powershell
+rg -n "Dashboard|Holdings|Add Holding|Monthly Progress|Cash Ledger|Settings|V1 States" docs\design\figma\issue-69-v1-screens\code.js
+rg -n "Dashboard|Holdings|Add Holding|Monthly Progress|Cash Ledger|Settings|state" docs\design\issue-86-premium-preview\index.html
+```
+
+Expected: both assets cover the same V1 screen family, but the Figma generator
+still needs the refined layouts and state notes.
+
+- [ ] **Step 2: Update shared Figma generator primitives and tokens**
+
+Keep the deterministic page-generation model and update token/layout helpers to
+match the refined repo preview. Preserve:
+
+```js
+const PAGE_NAME = "Issue 86 - Premium V1 Screens";
+```
+
+and keep generation append-only so reruns do not remove prior Figma revisions.
+
+- [ ] **Step 3: Refine generated screens**
+
+Update generated frames to reflect the approved revision:
+
+- Dashboard uses stronger hero hierarchy and calmer support cards.
+- Holdings rows expose durable-position context and quote-state notes.
+- Holdings includes an Add Holding header action.
+- Cash Ledger and Settings match the refined grouping language.
+- Add Holding lookup, position, and review frames remain represented.
+- V1 States includes loading, provider/manual fallback, empty portfolio or
+  holdings, and no-snapshot coverage.
+
+- [ ] **Step 4: Keep Progress guarded**
+
+Update Figma copy/helpers so Monthly Progress remains a monthly snapshot view,
+not a fake historical-chart implementation requirement.
+
+- [ ] **Step 5: Update Figma README**
+
+Describe the Issue #102 revision and exact screen coverage:
+
+```markdown
+- Dashboard
+- Holdings
+- Add Holding - Asset Lookup
+- Add Holding - Position
+- Add Holding - Review
+- Monthly Progress
+- Cash Ledger
+- Settings
+- V1 States
+```
+
+- [ ] **Step 6: Verify generator integrity**
+
+Run:
+
+```powershell
+node --check docs\design\figma\issue-69-v1-screens\code.js
+git diff --check
+```
+
+Expected: Figma generator JavaScript parses and docs diff has no whitespace
+errors.
+
+### Task 3: Spec Review And Publish
+
+**Files:**
+- Review: `docs/superpowers/specs/2026-05-21-issue-102-design-baseline-revision.md`
+- Review: `docs/design/issue-86-premium-preview/index.html`
+- Review: `docs/design/figma/issue-69-v1-screens/code.js`
+
+- [ ] **Step 1: Review the diff against the spec**
+
+Run:
+
+```powershell
+git diff --stat
+git diff -- docs\design\issue-86-premium-preview docs\design\figma\issue-69-v1-screens
+```
+
+Check explicitly:
+
+- Add Holding remains lookup-first and multi-phase.
+- Progress stays within monthly-snapshot scope.
+- Holdings has loading and stale/manual quote references.
+- Dashboard, Cash, and Settings reflect the refined hierarchy.
+
+- [ ] **Step 2: Run final verification**
+
+Run:
+
+```powershell
+node --check docs\design\figma\issue-69-v1-screens\code.js
+git diff --check
+```
+
+Expected: both commands exit `0`.
+
+- [ ] **Step 3: Commit the design asset revision**
+
+Run:
+
+```powershell
+git add docs\design\issue-86-premium-preview docs\design\figma\issue-69-v1-screens docs\design\v1-ui-mockup-plan.md docs\superpowers\plans\2026-05-22-issue-102-design-baseline-revision.md
+git commit -m "docs(design): refine v1 baseline assets" -m "Closes #102"
+```
+
+- [ ] **Step 4: Push and update the PR**
+
+Run:
+
+```powershell
+git push
+```
+
+Expected: PR for the Issue #102 branch includes the spec, plan, and revised
+design assets with a closing reference for #102.
+

--- a/docs/superpowers/plans/2026-05-22-issue-102-design-baseline-revision.md
+++ b/docs/superpowers/plans/2026-05-22-issue-102-design-baseline-revision.md
@@ -21,8 +21,10 @@
   matching the refined repo preview instead of the older Issue #86 baseline.
 - Modify `docs/design/figma/issue-69-v1-screens/README.md` to explain the new
   design baseline and exact Figma output coverage.
-- Optionally modify `docs/design/v1-ui-mockup-plan.md` only if the active source
-  guidance needs to point more precisely at the revised assets.
+- Add/modify `docs/design/v1-screen-baseline.md` as the canonical accepted
+  screen contract.
+- Modify `DESIGN.md`, `AGENTS.md`, and `docs/design/v1-ui-mockup-plan.md` so
+  future agents and UI issues point to the same baseline.
 
 ### Task 1: Reconcile Browser Preview Direction
 
@@ -197,12 +199,52 @@ git diff --check
 Expected: Figma generator JavaScript parses and docs diff has no whitespace
 errors.
 
-### Task 3: Spec Review And Publish
+### Task 3: Document The Accepted Baseline
+
+**Files:**
+- Add: `docs/design/v1-screen-baseline.md`
+- Modify: `DESIGN.md`
+- Modify: `AGENTS.md`
+- Modify: `docs/design/v1-ui-mockup-plan.md`
+- Modify: `docs/superpowers/specs/2026-05-21-issue-102-design-baseline-revision.md`
+
+- [ ] **Step 1: Record the accepted screen contract**
+
+Capture:
+
+- Dashboard portfolio-first hierarchy.
+- Holdings durable-position cards and per-holding allocation.
+- Add Holding explicit search selection before autofill.
+- Monthly Progress two-graph direction: portfolio vs invested, and assets vs
+  months excluding cash.
+- Cash Ledger and Settings local-first treatment.
+- Production data rule: stored local records or empty states, never fake chart
+  history.
+
+- [ ] **Step 2: Point future work at the baseline**
+
+Update docs so future UI work reads:
+
+- `docs/design/v1-screen-baseline.md`
+- `docs/design/issue-86-premium-preview/index.html`
+- `docs/design/figma/issue-69-v1-screens/code.js`
+- `DESIGN.md`
+
+Expected: older `v1-ui-mockup-plan.md` remains historical and no longer reads as
+the active design contract.
+
+- [ ] **Step 3: Update GitHub issue #102**
+
+Use the accepted spec body as the issue body so GitHub points to the same
+baseline as the repo.
+
+### Task 4: Spec Review And Publish
 
 **Files:**
 - Review: `docs/superpowers/specs/2026-05-21-issue-102-design-baseline-revision.md`
 - Review: `docs/design/issue-86-premium-preview/index.html`
 - Review: `docs/design/figma/issue-69-v1-screens/code.js`
+- Review: `docs/design/v1-screen-baseline.md`
 
 - [ ] **Step 1: Review the diff against the spec**
 
@@ -250,4 +292,3 @@ git push
 
 Expected: PR for the Issue #102 branch includes the spec, plan, and revised
 design assets with a closing reference for #102.
-

--- a/docs/superpowers/specs/2026-05-21-issue-102-design-baseline-revision.md
+++ b/docs/superpowers/specs/2026-05-21-issue-102-design-baseline-revision.md
@@ -1,0 +1,129 @@
+# Issue #102 Design Baseline Revision Spec
+
+## Goal
+
+Align CogVest's current V1 design baseline with the refined May 21, 2026 HTML
+mockup direction while preserving the existing V1 product scope, Excel parity
+requirements, and Issue #86 Add Holding/state coverage.
+
+## Decision
+
+The refined mockup becomes the visual reference for the next design pass because
+it improves:
+
+- screen rhythm and hierarchy
+- Holdings density without reverting to spreadsheet UI
+- quote freshness, loading, and stale-price communication
+- Cash Ledger entry and empty-state treatment
+- Settings trust and grouped-control treatment
+- P&L context labels such as `since first buy` and `all time`
+
+The repo remains the stable design source. The external HTML mockup is an input
+reference; revised repo docs, preview assets, and Figma/plugin output must carry
+the final V1 baseline forward.
+
+## Design Direction
+
+Adopt from the refined mockup:
+
+- portfolio-first dashboard hierarchy with quieter supporting metrics
+- durable-position Holdings cards with quantity, average cost, current price,
+  P&L, allocation context, and quote state visible in a controlled density
+- Holdings header Add Holding entry point rather than forcing Add into the main
+  bottom navigation
+- local-first trust copy and grouped controls in Settings
+- focused Cash Ledger entry and empty-state treatment
+- first-class loading and stale/manual quote states
+
+Keep the CogVest direction from `DESIGN.md`:
+
+- calm, premium, Android-first, local-first portfolio tracking
+- long-term investing emphasis over trading energy
+- readable, maskable, INR-first financial values
+- restrained green accent use
+- no spreadsheet clone UI
+
+## V1 Scope Guardrails
+
+### Add Holding
+
+Keep the lookup-first multi-phase flow from the current design baseline:
+
+1. Asset lookup and selection
+2. Classification
+3. Position details
+4. Review and save
+
+Manual ticker/current-price entry remains fallback behavior, not the primary
+perceived path.
+
+### Progress
+
+The refined line-chart treatment is useful visual research, but historical
+charting must not become an implicit V1 requirement.
+
+V1 Monthly Progress stays focused on:
+
+- monthly snapshot context
+- monthly change and contribution data
+- snapshot entry where required
+- calm no-snapshot or insufficient-data states
+
+If later V1 work uses a chart-like placeholder, it must not fake stored history
+or reopen V3 historical chart scope.
+
+### Portfolio Context
+
+A `Local portfolio` marker is useful. Do not use a dropdown affordance or imply
+multi-portfolio interaction unless that capability exists in the scoped work.
+
+### Palette
+
+Use current `DESIGN.md` tokens as the implementation contract for now. The design
+pass may explore the refined mockup's softer graphite layering, but any token
+change must update `DESIGN.md` before downstream UI implementation depends on it.
+
+## Design Assets To Reconcile
+
+- `docs/design/issue-86-premium-preview/`
+- `docs/design/figma/issue-69-v1-screens/`
+- current Figma Issue #86 V1 screens
+- related V1 design guidance that points future UI work at a source of truth
+
+## Required Coverage
+
+The revised V1 baseline must represent:
+
+- Dashboard
+- Holdings
+- Add Holding lookup, position, and review states
+- Monthly Progress
+- Cash Ledger
+- Settings
+- empty portfolio or empty holdings state
+- quote lookup loading state
+- stale/manual/provider-failure quote state
+- no monthly snapshots state
+
+## Non-Goals
+
+- No app feature implementation in this design-baseline pass.
+- No Minimal Mode.
+- No LTCG UI.
+- No V3 historical charts or advanced market screens.
+- No multi-portfolio feature design unless separately scoped.
+- No loss of Excel parity concepts just to simplify visual layout.
+
+## Acceptance Criteria
+
+- Issue #102 points future work at one stable V1 design-baseline pass.
+- Repo design assets make the refined visual direction explicit.
+- Dashboard, Holdings, Cash, and Settings incorporate the improved hierarchy and
+  density decisions where appropriate.
+- Add Holding remains covered as a lookup-first multi-phase flow.
+- Holdings includes loading and stale/manual quote design references.
+- Monthly Progress scope stays explicit and does not promote historical charting
+  into V1 by accident.
+- Any palette-token change is recorded in `DESIGN.md` before implementation uses
+  it.
+

--- a/docs/superpowers/specs/2026-05-21-issue-102-design-baseline-revision.md
+++ b/docs/superpowers/specs/2026-05-21-issue-102-design-baseline-revision.md
@@ -22,6 +22,8 @@ The repo remains the stable design source. The external HTML mockup is an input
 reference; revised repo docs, preview assets, and Figma/plugin output must carry
 the final V1 baseline forward.
 
+Accepted screen contract: `docs/design/v1-screen-baseline.md`.
+
 ## Design Direction
 
 Adopt from the refined mockup:
@@ -34,6 +36,8 @@ Adopt from the refined mockup:
 - local-first trust copy and grouped controls in Settings
 - focused Cash Ledger entry and empty-state treatment
 - first-class loading and stale/manual quote states
+- two Monthly Progress graph treatments: total portfolio value vs invested
+  value, and asset values vs months with cash excluded
 
 Keep the CogVest direction from `DESIGN.md`:
 
@@ -57,6 +61,9 @@ Keep the lookup-first multi-phase flow from the current design baseline:
 Manual ticker/current-price entry remains fallback behavior, not the primary
 perceived path.
 
+Search results must not auto-select. The user must choose a result before
+autofill changes asset fields.
+
 ### Progress
 
 The refined line-chart treatment is useful visual research, but historical
@@ -71,6 +78,14 @@ V1 Monthly Progress stays focused on:
 
 If later V1 work uses a chart-like placeholder, it must not fake stored history
 or reopen V3 historical chart scope.
+
+The accepted visual direction uses two chart areas:
+
+- total portfolio value vs invested value across months
+- asset values vs months, excluding cash
+
+Charts must use stored monthly snapshots or clearly show an empty/no-snapshot
+state. Do not fake stored history or reopen V3 historical chart scope.
 
 ### Portfolio Context
 
@@ -87,6 +102,7 @@ change must update `DESIGN.md` before downstream UI implementation depends on it
 
 - `docs/design/issue-86-premium-preview/`
 - `docs/design/figma/issue-69-v1-screens/`
+- `docs/design/v1-screen-baseline.md`
 - current Figma Issue #86 V1 screens
 - related V1 design guidance that points future UI work at a source of truth
 
@@ -126,4 +142,5 @@ The revised V1 baseline must represent:
   into V1 by accident.
 - Any palette-token change is recorded in `DESIGN.md` before implementation uses
   it.
-
+- `docs/design/v1-screen-baseline.md`, the HTML preview, and Figma generator
+  agree on the accepted screen semantics.


### PR DESCRIPTION
## Summary

- record the approved Issue #102 design-baseline revision spec and execution plan
- refine the static V1 preview with portfolio context, denser Holdings cards, guarded Progress copy, Cash empty-state treatment, and Settings trust hierarchy
- align the deterministic Figma generator and README with the same refined V1 baseline and state coverage

## Validation

- node --check docs\design\figma\issue-69-v1-screens\code.js
- git diff --check
- reviewed the design diff against the Issue #102 spec guardrails for Add Holding, Monthly Progress, and quote-state coverage

Closes #102