### PR TITLE
[V1] Require explicit Add Holding lookup selection

### DIFF
--- a/docs/superpowers/plans/2026-05-25-issue-104-add-holding-explicit-selection.md
+++ b/docs/superpowers/plans/2026-05-25-issue-104-add-holding-explicit-selection.md
@@ -1,0 +1,75 @@
+# Issue 104 Add Holding Explicit Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Add Holding lookup explicit-selection-only so search never auto-picks an asset.
+
+**Architecture:** Keep lookup, manual entry, and quote resolution inside `AddOpeningPositionForm`. Remove implicit selection paths and preserve explicit row selection as the single lookup-autofill trigger. Cover the behavior in the existing component test suite.
+
+**Tech Stack:** React Native, Expo, React Native Testing Library, Jest, TypeScript.
+
+---
+
+## File Map
+
+- Modify: `src/features/openingPositions/AddOpeningPositionForm.tsx`
+  - Remove exact-match auto-selection effect.
+  - Remove preferred-result selection on search submit.
+  - Add visible `Select` copy in lookup rows so the choice is explicit.
+- Modify: `src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx`
+  - Add tests for no autofill before selection.
+  - Update fallback test to press the lookup result before expecting fields.
+
+## Task 1: Lock Current Bug With Tests
+
+- [ ] Add a test that searches an exact `bitcoin` lookup result and verifies
+  Asset name, Symbol, Ticker, Quote source ID, and Current price remain empty
+  until the result is pressed.
+- [ ] Add a test assertion that `submitEditing` on the search field does not
+  trigger quote lookup or fill fields.
+- [ ] Run:
+
+```powershell
+npm test -- src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
+```
+
+Expected before implementation: focused test fails because current code
+auto-selects exact lookup matches.
+
+## Task 2: Remove Implicit Selection
+
+- [ ] Delete the effect that finds `exactResult` and calls `selectLookupResult`.
+- [ ] Remove `getPreferredLookupResult` and `selectPreferredLookupResult`.
+- [ ] Remove `onSubmitEditing={selectPreferredLookupResult}` from the lookup
+  input.
+- [ ] Keep explicit row press behavior calling `selectLookupResult(result)`.
+- [ ] Add visible `Select` text to lookup result rows.
+
+## Task 3: Verify Focused Behavior
+
+- [ ] Run:
+
+```powershell
+npm test -- src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
+```
+
+Expected: Add Opening Position tests pass and prove explicit selection is
+required.
+
+## Task 4: Full Verification
+
+- [ ] Run:
+
+```powershell
+npm run typecheck
+npm test
+npm run doctor
+```
+
+Expected: all commands pass.
+
+## Task 5: Publish
+
+- [ ] Commit with a focused message.
+- [ ] Push branch `v1/issue-104-add-holding-explicit-selection`.
+- [ ] Open PR with `Closes #104`.

--- a/docs/superpowers/specs/2026-05-25-issue-104-add-holding-explicit-selection.md
+++ b/docs/superpowers/specs/2026-05-25-issue-104-add-holding-explicit-selection.md
@@ -1,0 +1,39 @@
+# Issue 104 Add Holding Explicit Selection Design
+
+## Goal
+
+Align Add Holding lookup with the accepted V1 baseline: lookup results are
+suggestions until the user explicitly selects one.
+
+## Root Cause
+
+`AddOpeningPositionForm` currently has two implicit selection paths:
+
+- an effect that auto-selects exact symbol/ticker/quote-source matches
+- search-submit handling that picks the preferred lookup result
+
+Both paths can mutate asset fields and trigger quote lookup before the user
+chooses a visible result. That contradicts `docs/design/v1-screen-baseline.md`.
+
+## Required Behavior
+
+- Typing a search query only fetches and displays lookup results.
+- Exact matches do not autofill fields.
+- Pressing Enter/Search in the lookup input does not pick a result.
+- The user explicitly selects a visible result row.
+- Selection autofills asset metadata and triggers live quote lookup.
+- Quote failure after explicit selection leaves current price editable and shows
+  manual fallback copy.
+- Manual entry remains available without choosing a lookup result.
+
+## Scope
+
+Modify only the Add Holding lookup behavior and tests. Do not redesign the
+entire flow, change quote providers, add advanced search, or add V2/V3 scope.
+
+## Verification
+
+- Focused tests prove exact-match lookup does not autofill before selection.
+- Focused tests prove search submit does not auto-pick a result.
+- Existing explicit-select quote success and fallback tests continue to pass.
+- Existing manual Add Holding save flow continues to pass.

--- a/src/features/openingPositions/AddOpeningPositionForm.tsx
+++ b/src/features/openingPositions/AddOpeningPositionForm.tsx
@@ -310,24 +310,6 @@ export function AddOpeningPositionForm({
     };
   }, [lookupQuery, searchAssetLookupResults]);
 
-  useEffect(() => {
-    const normalizedQuery = lookupQuery.trim().toLowerCase();
-
-    if (!normalizedQuery || lookupResults.length === 0) {
-      return;
-    }
-
-    const exactResult = lookupResults.find((result) =>
-      [result.symbol, result.ticker, result.quoteSourceId].some(
-        (value) => value.toLowerCase() === normalizedQuery,
-      ),
-    );
-
-    if (exactResult) {
-      void selectLookupResult(exactResult);
-    }
-  }, [lookupQuery, lookupResults]);
-
   function clearSelectedAsset() {
     if (selectedAssetId) {
       setSelectedAssetId("");
@@ -408,31 +390,6 @@ export function AddOpeningPositionForm({
 
     setCurrentPrice("");
     setQuoteStatus("Live price unavailable. Enter current price manually.");
-  }
-
-  function getPreferredLookupResult() {
-    const normalizedQuery = lookupQuery.trim().toLowerCase();
-
-    return (
-      lookupResults.find((result) =>
-        [result.symbol, result.ticker, result.quoteSourceId].some(
-          (value) => value.toLowerCase() === normalizedQuery,
-        ),
-      ) ??
-      lookupResults.find((result) => result.name.toLowerCase() === normalizedQuery) ??
-      lookupResults.find((result) =>
-        result.name.toLowerCase().startsWith(normalizedQuery),
-      ) ??
-      lookupResults[0]
-    );
-  }
-
-  function selectPreferredLookupResult() {
-    const result = getPreferredLookupResult();
-
-    if (result) {
-      void selectLookupResult(result);
-    }
   }
 
   function updateAssetClass(nextAssetClass: AssetClass) {
@@ -599,7 +556,6 @@ export function AddOpeningPositionForm({
             setLookupQuery(value);
             setQuoteStatus("");
           }}
-          onSubmitEditing={selectPreferredLookupResult}
           placeholder="Search HDFC Bank, NIFTYBEES, Bitcoin..."
           returnKeyType="search"
           testID="asset-lookup-input"
@@ -631,7 +587,7 @@ export function AddOpeningPositionForm({
                   </AppText>
                 </View>
                 <AppText color="secondary" variant="caption" weight="bold">
-                  {assetClassLabel(result.assetClass)}
+                  Select
                 </AppText>
               </TouchableOpacity>
             ))}

--- a/src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
+++ b/src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
@@ -321,6 +321,79 @@ describe("AddOpeningPositionForm", () => {
     expect(getByLabelText("Current price")).toHaveProp("value", "1678.25");
   });
 
+  it("does not autofill exact lookup matches before explicit selection", async () => {
+    jest.useFakeTimers();
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const lookupResult: AssetLookupResult = {
+      assetClass: "crypto",
+      currency: "INR",
+      exchange: "CRYPTO",
+      id: "coingecko:bitcoin",
+      instrumentType: "crypto",
+      name: "Bitcoin",
+      provider: "coingecko",
+      quoteSourceId: "bitcoin",
+      sectorType: "digitalAsset",
+      sourceLabel: "CoinGecko",
+      symbol: "BTC",
+      ticker: "bitcoin",
+    };
+    const searchAssetLookupResults = jest.fn().mockResolvedValue({
+      failures: [],
+      results: [lookupResult],
+    });
+    const resolveQuote = jest.fn().mockResolvedValue({
+      ok: true,
+      quote: {
+        assetId: "asset-id",
+        asOf: "2026-05-10T10:00:00.000Z",
+        currency: "INR",
+        price: 5800000,
+        source: "coingecko",
+      },
+    });
+    const { getByLabelText, getByTestId, getByText } = render(
+      <AddOpeningPositionForm
+        resolveQuote={resolveQuote}
+        searchAssetLookupResults={searchAssetLookupResults}
+        store={store}
+      />,
+    );
+
+    fireEvent.changeText(getByLabelText("Search asset"), "bitcoin");
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+
+    await waitFor(() => {
+      expect(getByText("Bitcoin")).toBeTruthy();
+    });
+
+    expect(getByLabelText("Asset name")).toHaveProp("value", "");
+    expect(getByLabelText("Symbol")).toHaveProp("value", "");
+    expect(getByLabelText("Ticker")).toHaveProp("value", "");
+    expect(getByLabelText("Quote source ID")).toHaveProp("value", "");
+    expect(resolveQuote).not.toHaveBeenCalled();
+
+    fireEvent(getByLabelText("Search asset"), "submitEditing");
+
+    expect(getByLabelText("Asset name")).toHaveProp("value", "");
+    expect(getByLabelText("Symbol")).toHaveProp("value", "");
+    expect(getByLabelText("Ticker")).toHaveProp("value", "");
+    expect(getByLabelText("Quote source ID")).toHaveProp("value", "");
+    expect(resolveQuote).not.toHaveBeenCalled();
+
+    fireEvent.press(getByTestId("asset-lookup-result-coingecko:bitcoin"));
+
+    await waitFor(() => {
+      expect(getByLabelText("Asset name")).toHaveProp("value", "Bitcoin");
+    });
+    expect(getByLabelText("Symbol")).toHaveProp("value", "BTC");
+    expect(getByLabelText("Ticker")).toHaveProp("value", "bitcoin");
+    expect(getByLabelText("Quote source ID")).toHaveProp("value", "bitcoin");
+    expect(resolveQuote).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps manual price fallback available when selected lookup quote fails", async () => {
     jest.useFakeTimers();
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
@@ -358,6 +431,13 @@ describe("AddOpeningPositionForm", () => {
     await act(async () => {
       jest.advanceTimersByTime(400);
     });
+
+    await waitFor(() => {
+      expect(getByText("Bitcoin")).toBeTruthy();
+    });
+    expect(getByLabelText("Asset name")).toHaveProp("value", "");
+
+    fireEvent.press(getByText("Bitcoin"));
 
     await waitFor(() => {
       expect(getByLabelText("Asset name")).toHaveProp("value", "Bitcoin");


### PR DESCRIPTION
## Summary

- add #104 spec and implementation plan for the Add Holding explicit-selection baseline
- remove automatic exact-match lookup selection and search-submit preferred result selection
- keep lookup rows explicitly selectable and add regression coverage for no autofill before selection

## Verification

- npm test -- src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
- npm run typecheck
- npm test
- npm run doctor

Closes #104
