### PR TITLE
[V1] Add Monthly Progress snapshot trend graphs

### DIFF
--- a/docs/superpowers/plans/2026-05-25-issue-105-progress-baseline-graphs.md
+++ b/docs/superpowers/plans/2026-05-25-issue-105-progress-baseline-graphs.md
@@ -1,0 +1,70 @@
+# Issue 105 Monthly Progress Baseline Graphs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Monthly Progress placeholder with stored-snapshot-driven Portfolio vs Invested and Assets vs Months graph sections.
+
+**Architecture:** Keep graph-data derivation in pure domain functions under `src/domain/calculations/`. Keep UI rendering in `ProgressScreen.tsx` with a small SVG chart component that consumes derived series data. Tests cover domain mapping separately from rendering details.
+
+**Tech Stack:** React Native, Expo SDK 54, TypeScript, Jest, React Native Testing Library, `react-native-svg`.
+
+---
+
+## Files
+
+- Create: `src/domain/calculations/__tests__/monthlyProgressCharts.test.ts`
+- Create: `src/domain/calculations/monthlyProgressCharts.ts`
+- Modify: `src/domain/calculations/index.ts`
+- Modify: `src/features/progress/ProgressScreen.tsx`
+- Modify: `src/features/progress/__tests__/ProgressScreen.test.tsx`
+
+## Task 1: Domain Graph Data
+
+- [x] Write failing tests in `src/domain/calculations/__tests__/monthlyProgressCharts.test.ts` for:
+  - fewer than two snapshots returning insufficient history.
+  - chronological month ordering.
+  - portfolio and invested values by month.
+  - asset trend values for stock, debt, and crypto only.
+  - cash excluded from asset series.
+
+- [x] Run `npm test -- src/domain/calculations/__tests__/monthlyProgressCharts.test.ts` and verify it fails because the module does not exist.
+
+- [x] Implement `src/domain/calculations/monthlyProgressCharts.ts` with:
+  - `buildMonthlyProgressChartData(snapshots: MonthlySnapshot[])`
+  - `hasEnoughHistory: boolean`
+  - `monthLabels: string[]`
+  - `portfolioSeries`
+  - `assetSeries`
+
+- [x] Export the function from `src/domain/calculations/index.ts`.
+
+- [x] Re-run the focused domain test and verify it passes.
+
+## Task 2: Screen Rendering
+
+- [x] Add failing tests in `src/features/progress/__tests__/ProgressScreen.test.tsx` for:
+  - one snapshot shows an insufficient chart-history state.
+  - two snapshots render `Portfolio vs Invested` and `Assets vs Months`.
+  - the asset graph legend includes Equity, Debt, Crypto and excludes Cash.
+
+- [x] Run `npm test -- src/features/progress/__tests__/ProgressScreen.test.tsx` and verify the new tests fail against the current placeholder.
+
+- [x] Update `src/features/progress/ProgressScreen.tsx`:
+  - import `Svg`, `Polyline`, and `Circle` from `react-native-svg`.
+  - import `buildMonthlyProgressChartData`.
+  - add a reusable lightweight line chart component.
+  - replace the `Progress trend` placeholder with the two accepted chart cards.
+  - show a premium insufficient-history state when `hasEnoughHistory` is false.
+
+- [x] Re-run the focused progress screen test and verify it passes.
+
+## Task 3: Full Verification and PR
+
+- [x] Run `npm run typecheck`.
+- [x] Run `npm test -- src/features/progress/__tests__/ProgressScreen.test.tsx`.
+- [x] Run `npm test`.
+- [x] Run `npm run doctor`.
+- [x] If emulator is available and time permits, run PC smoke/manual verification for Monthly Progress.
+- [x] Review the diff against issue #105 and `docs/design/v1-screen-baseline.md`.
+- [ ] Commit with `feat(progress): add monthly snapshot trend graphs`.
+- [ ] Push and create a PR with `Closes #105`.

--- a/docs/superpowers/specs/2026-05-25-issue-105-progress-baseline-graphs.md
+++ b/docs/superpowers/specs/2026-05-25-issue-105-progress-baseline-graphs.md
@@ -1,0 +1,49 @@
+# Issue 105 Monthly Progress Baseline Graphs Spec
+
+## Goal
+
+Implement the accepted V1 Monthly Progress graph baseline using stored monthly snapshots only.
+
+## Problem
+
+The current Monthly Progress screen preserves snapshot summary and form behavior, but the visual trend area is still a placeholder. Issue #102 accepted two graph areas for V1 parity:
+
+- Portfolio vs Invested by month.
+- Assets vs Months for equity, debt, and crypto.
+
+Cash must remain visible in snapshot metrics and cash tracking, but it must not appear in the asset trend graph.
+
+## Scope
+
+- Add pure domain graph-data derivation for monthly snapshots.
+- Render an insufficient-history chart state when fewer than two snapshots exist.
+- Render `Portfolio vs Invested` for two or more stored snapshots.
+- Render `Assets vs Months` for two or more stored snapshots.
+- Preserve snapshot form save/update behavior.
+- Preserve monthly summary, rates, and asset snapshot behavior.
+- Keep production code free of fake chart history.
+
+## Non-Goals
+
+- No historical quote fetching.
+- No V3 market history charts.
+- No Minimal Mode, LTCG, import/export, backend, auth, cloud, or analytics.
+- No change to monthly snapshot persistence semantics.
+
+## Design Contract
+
+- Follow `docs/design/v1-screen-baseline.md`.
+- Use calm premium cards and readable labels.
+- Keep charts lightweight and Android/Expo-friendly.
+- Use existing chart dependencies only if needed; do not add heavy dependencies.
+
+## Acceptance Evidence
+
+- Domain tests prove chronological ordering and cash exclusion.
+- Screen tests prove insufficient-history state and chart sections render.
+- Existing snapshot form tests continue to pass.
+- Verification commands pass before PR:
+  - `npm run typecheck`
+  - `npm test -- src/features/progress/__tests__/ProgressScreen.test.tsx`
+  - `npm test`
+  - `npm run doctor`

--- a/src/domain/calculations/__tests__/monthlyProgressCharts.test.ts
+++ b/src/domain/calculations/__tests__/monthlyProgressCharts.test.ts
@@ -1,0 +1,98 @@
+import { buildMonthlyProgressChartData } from "@/src/domain/calculations";
+import type { MonthlySnapshot } from "@/src/types";
+
+function snapshot(
+  month: string,
+  values: Partial<MonthlySnapshot> = {},
+): MonthlySnapshot {
+  return {
+    cashValue: 0,
+    cryptoValue: 0,
+    debtValue: 0,
+    equityValue: 0,
+    id: `snapshot-${month}`,
+    investedValue: 0,
+    month,
+    monthlyInvestment: 0,
+    portfolioValue: 0,
+    salary: 0,
+    ...values,
+  };
+}
+
+describe("buildMonthlyProgressChartData", () => {
+  it("marks chart history as insufficient until two snapshots exist", () => {
+    const chartData = buildMonthlyProgressChartData([
+      snapshot("2026-05", {
+        investedValue: 100000,
+        portfolioValue: 110000,
+      }),
+    ]);
+
+    expect(chartData.hasEnoughHistory).toBe(false);
+    expect(chartData.monthLabels).toEqual(["May 2026"]);
+    expect(chartData.portfolioSeries).toEqual([]);
+    expect(chartData.assetSeries).toEqual([]);
+  });
+
+  it("builds chronological portfolio and invested series", () => {
+    const chartData = buildMonthlyProgressChartData([
+      snapshot("2026-05", {
+        investedValue: 1060000,
+        portfolioValue: 1385000,
+      }),
+      snapshot("2026-04", {
+        investedValue: 1000000,
+        portfolioValue: 1260000,
+      }),
+    ]);
+
+    expect(chartData.hasEnoughHistory).toBe(true);
+    expect(chartData.monthLabels).toEqual(["Apr 2026", "May 2026"]);
+    expect(chartData.portfolioSeries).toEqual([
+      {
+        label: "Portfolio",
+        values: [1260000, 1385000],
+      },
+      {
+        label: "Invested",
+        values: [1000000, 1060000],
+      },
+    ]);
+  });
+
+  it("builds asset series for equity debt and crypto while excluding cash", () => {
+    const chartData = buildMonthlyProgressChartData([
+      snapshot("2026-04", {
+        cashValue: 120000,
+        cryptoValue: 40000,
+        debtValue: 300000,
+        equityValue: 800000,
+      }),
+      snapshot("2026-05", {
+        cashValue: 140000,
+        cryptoValue: 45000,
+        debtValue: 320000,
+        equityValue: 880000,
+      }),
+    ]);
+
+    expect(chartData.assetSeries).toEqual([
+      {
+        label: "Equity",
+        values: [800000, 880000],
+      },
+      {
+        label: "Debt",
+        values: [300000, 320000],
+      },
+      {
+        label: "Crypto",
+        values: [40000, 45000],
+      },
+    ]);
+    expect(chartData.assetSeries.some((series) => series.label === "Cash")).toBe(
+      false,
+    );
+  });
+});

--- a/src/domain/calculations/index.ts
+++ b/src/domain/calculations/index.ts
@@ -1,4 +1,11 @@
 export {
+  buildMonthlyProgressChartData,
+} from "./monthlyProgressCharts";
+export type {
+  MonthlyProgressChartData,
+  MonthlyProgressChartSeries,
+} from "./monthlyProgressCharts";
+export {
   calculateAllocation,
   calculateCashBalance,
   calculateCashMonthlyMetrics,

--- a/src/domain/calculations/monthlyProgressCharts.ts
+++ b/src/domain/calculations/monthlyProgressCharts.ts
@@ -1,0 +1,72 @@
+import type { MonthlySnapshot } from "@/src/types";
+
+export type MonthlyProgressChartSeries = {
+  label: string;
+  values: number[];
+};
+
+export type MonthlyProgressChartData = {
+  assetSeries: MonthlyProgressChartSeries[];
+  hasEnoughHistory: boolean;
+  monthLabels: string[];
+  portfolioSeries: MonthlyProgressChartSeries[];
+};
+
+function formatShortMonth(month: string) {
+  const [year, monthPart] = month.split("-");
+
+  return new Intl.DateTimeFormat("en-IN", {
+    month: "short",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(new Date(Date.UTC(Number(year), Number(monthPart) - 1, 1)));
+}
+
+export function buildMonthlyProgressChartData(
+  snapshots: MonthlySnapshot[],
+): MonthlyProgressChartData {
+  const chronological = [...snapshots].sort((left, right) =>
+    left.month.localeCompare(right.month),
+  );
+  const monthLabels = chronological.map((snapshot) =>
+    formatShortMonth(snapshot.month),
+  );
+
+  if (chronological.length < 2) {
+    return {
+      assetSeries: [],
+      hasEnoughHistory: false,
+      monthLabels,
+      portfolioSeries: [],
+    };
+  }
+
+  return {
+    assetSeries: [
+      {
+        label: "Equity",
+        values: chronological.map((snapshot) => snapshot.equityValue),
+      },
+      {
+        label: "Debt",
+        values: chronological.map((snapshot) => snapshot.debtValue),
+      },
+      {
+        label: "Crypto",
+        values: chronological.map((snapshot) => snapshot.cryptoValue),
+      },
+    ],
+    hasEnoughHistory: true,
+    monthLabels,
+    portfolioSeries: [
+      {
+        label: "Portfolio",
+        values: chronological.map((snapshot) => snapshot.portfolioValue),
+      },
+      {
+        label: "Invested",
+        values: chronological.map((snapshot) => snapshot.investedValue),
+      },
+    ],
+  };
+}

--- a/src/features/progress/ProgressScreen.tsx
+++ b/src/features/progress/ProgressScreen.tsx
@@ -1,5 +1,6 @@
 import { useState, useSyncExternalStore } from "react";
 import { StyleSheet, View } from "react-native";
+import Svg, { Circle, Polyline } from "react-native-svg";
 import type { StoreApi } from "zustand/vanilla";
 
 import {
@@ -16,11 +17,13 @@ import {
   assetClassLabel,
 } from "@/src/components/common";
 import {
+  buildMonthlyProgressChartData,
   calculateAllocation,
   calculateCashBalance,
   calculateHoldings,
   calculateMonthlyProgressSummaries,
   calculatePortfolioTotal,
+  type MonthlyProgressChartSeries,
 } from "@/src/domain/calculations";
 import { formatINR, formatPercentage } from "@/src/domain/formatters";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
@@ -101,6 +104,183 @@ const requiredNumberFields: Array<keyof SnapshotFormValues> = [
   "monthlyInvestment",
   "salary",
 ];
+
+const chartWidth = 280;
+const chartHeight = 132;
+const chartPadding = 12;
+
+function getSeriesColor(label: string) {
+  switch (label) {
+    case "Portfolio":
+      return colors.text.primary;
+    case "Invested":
+      return colors.profit;
+    case "Equity":
+      return colors.primary;
+    case "Debt":
+      return colors.blue;
+    case "Crypto":
+      return colors.cryptoAmber;
+    default:
+      return colors.text.secondary;
+  }
+}
+
+function getSeriesPoints(series: MonthlyProgressChartSeries[], index: number) {
+  const values = series.flatMap((item) => item.values);
+  const minValue = Math.min(...values);
+  const maxValue = Math.max(...values);
+  const range = maxValue - minValue || 1;
+  const pointCount = series[index]?.values.length ?? 0;
+  const usableWidth = chartWidth - chartPadding * 2;
+  const usableHeight = chartHeight - chartPadding * 2;
+
+  return (series[index]?.values ?? [])
+    .map((value, valueIndex) => {
+      const x =
+        pointCount === 1
+          ? chartWidth / 2
+          : chartPadding + (usableWidth * valueIndex) / (pointCount - 1);
+      const y =
+        chartPadding + usableHeight - ((value - minValue) / range) * usableHeight;
+
+      return `${x},${y}`;
+    })
+    .join(" ");
+}
+
+function TrendLegend({
+  series,
+  testIDPrefix,
+}: {
+  series: MonthlyProgressChartSeries[];
+  testIDPrefix: string;
+}) {
+  return (
+    <View style={styles.chartLegend}>
+      {series.map((item) => (
+        <View
+          key={item.label}
+          style={styles.legendItem}
+          testID={`${testIDPrefix}-${item.label}`}
+        >
+          <View
+            style={[
+              styles.legendDot,
+              { backgroundColor: getSeriesColor(item.label) },
+            ]}
+          />
+          <AppText color="secondary" variant="caption" weight="medium">
+            {item.label}
+          </AppText>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function TrendChart({
+  monthLabels,
+  series,
+  testIDPrefix,
+}: {
+  monthLabels: string[];
+  series: MonthlyProgressChartSeries[];
+  testIDPrefix: string;
+}) {
+  return (
+    <View style={styles.chartBlock}>
+      <View style={styles.svgWrap}>
+        <Svg height={chartHeight} width="100%" viewBox={`0 0 ${chartWidth} ${chartHeight}`}>
+          {series.map((item, index) => (
+            <Polyline
+              key={item.label}
+              fill="none"
+              points={getSeriesPoints(series, index)}
+              stroke={getSeriesColor(item.label)}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={3}
+            />
+          ))}
+          {series.map((item, seriesIndex) =>
+            item.values.map((_, pointIndex) => {
+              const [x, y] = getSeriesPoints(series, seriesIndex)
+                .split(" ")
+                [pointIndex].split(",");
+
+              return (
+                <Circle
+                  key={`${item.label}-${pointIndex}`}
+                  cx={Number(x)}
+                  cy={Number(y)}
+                  fill={colors.surface.card}
+                  r={3}
+                  stroke={getSeriesColor(item.label)}
+                  strokeWidth={2}
+                />
+              );
+            }),
+          )}
+        </Svg>
+      </View>
+      <View style={styles.monthAxis}>
+        {monthLabels.map((month) => (
+          <AppText key={month} color="secondary" variant="caption">
+            {month}
+          </AppText>
+        ))}
+      </View>
+      <TrendLegend series={series} testIDPrefix={testIDPrefix} />
+    </View>
+  );
+}
+
+function ProgressTrendCards({
+  assetSeries,
+  hasEnoughHistory,
+  monthLabels,
+  portfolioSeries,
+}: {
+  assetSeries: MonthlyProgressChartSeries[];
+  hasEnoughHistory: boolean;
+  monthLabels: string[];
+  portfolioSeries: MonthlyProgressChartSeries[];
+}) {
+  if (!hasEnoughHistory) {
+    return (
+      <PremiumCard>
+        <SectionHeader title="Trend history is still building" />
+        <View style={styles.chartPlaceholder}>
+          <AppText color="secondary" align="center">
+            Record at least 2 monthly snapshots to compare portfolio and asset trends.
+          </AppText>
+        </View>
+      </PremiumCard>
+    );
+  }
+
+  return (
+    <>
+      <PremiumCard>
+        <SectionHeader title="Portfolio vs Invested" />
+        <TrendChart
+          monthLabels={monthLabels}
+          series={portfolioSeries}
+          testIDPrefix="portfolio-trend"
+        />
+      </PremiumCard>
+      <PremiumCard>
+        <SectionHeader title="Assets vs Months" />
+        <TrendChart
+          monthLabels={monthLabels}
+          series={assetSeries}
+          testIDPrefix="asset-trend"
+        />
+      </PremiumCard>
+    </>
+  );
+}
 
 function parseNumberField(
   values: SnapshotFormValues,
@@ -204,6 +384,7 @@ export function ProgressScreen({
     snapshot.monthlySnapshots,
   );
   const latestSummary = monthlySummaries[0];
+  const chartData = buildMonthlyProgressChartData(snapshot.monthlySnapshots);
 
   function setField(field: keyof SnapshotFormValues, value: string) {
     setFormValues((currentValues) => ({
@@ -289,6 +470,13 @@ export function ProgressScreen({
               ]}
             />
 
+            <ProgressTrendCards
+              assetSeries={chartData.assetSeries}
+              hasEnoughHistory={chartData.hasEnoughHistory}
+              monthLabels={chartData.monthLabels}
+              portfolioSeries={chartData.portfolioSeries}
+            />
+
             <PremiumCard>
               <SectionHeader title="Asset class snapshot" />
               {latestSummary.assetSnapshot.map((item) => (
@@ -368,14 +556,12 @@ export function ProgressScreen({
               </AppText>
             </PremiumCard>
 
-            <PremiumCard>
-              <SectionHeader title="Progress trend" />
-              <View style={styles.chartPlaceholder}>
-                <AppText color="secondary" align="center">
-                  Trend appears after monthly records are available.
-                </AppText>
-              </View>
-            </PremiumCard>
+            <ProgressTrendCards
+              assetSeries={chartData.assetSeries}
+              hasEnoughHistory={chartData.hasEnoughHistory}
+              monthLabels={chartData.monthLabels}
+              portfolioSeries={chartData.portfolioSeries}
+            />
 
             <PremiumCard>
               <SectionHeader title="Asset class snapshot" />
@@ -541,6 +727,14 @@ const styles = StyleSheet.create({
     minHeight: 120,
     padding: spacing.md,
   },
+  chartBlock: {
+    gap: spacing.sm,
+  },
+  chartLegend: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.sm,
+  },
   content: {
     gap: spacing.cardGap,
     paddingBottom: spacing.lg,
@@ -548,6 +742,20 @@ const styles = StyleSheet.create({
   },
   fieldGrid: {
     gap: spacing.cardInner,
+  },
+  legendDot: {
+    borderRadius: 4,
+    height: 8,
+    width: 8,
+  },
+  legendItem: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: spacing.xs,
+  },
+  monthAxis: {
+    flexDirection: "row",
+    justifyContent: "space-between",
   },
   snapshotCopy: {
     flex: 1,
@@ -558,5 +766,12 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     gap: spacing.cardInner,
     justifyContent: "space-between",
+  },
+  svgWrap: {
+    backgroundColor: colors.surface.elevated,
+    borderRadius: 18,
+    overflow: "hidden",
+    paddingHorizontal: spacing.xs,
+    paddingVertical: spacing.sm,
   },
 });

--- a/src/features/progress/__tests__/ProgressScreen.test.tsx
+++ b/src/features/progress/__tests__/ProgressScreen.test.tsx
@@ -95,6 +95,39 @@ describe("ProgressScreen", () => {
     expect(getByText("May close")).toBeTruthy();
   });
 
+  it("shows an insufficient chart-history state until two snapshots exist", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addMonthlySnapshot(maySnapshot);
+
+    const { getByText } = render(<ProgressScreen store={store} />);
+
+    expect(getByText("Trend history is still building")).toBeTruthy();
+    expect(
+      getByText("Record at least 2 monthly snapshots to compare portfolio and asset trends."),
+    ).toBeTruthy();
+  });
+
+  it("renders stored-snapshot portfolio and asset graphs without cash in asset trends", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addMonthlySnapshot(maySnapshot);
+    store.getState().addMonthlySnapshot(aprilSnapshot);
+
+    const { getAllByText, getByTestId, getByText, queryByTestId } = render(
+      <ProgressScreen store={store} />,
+    );
+
+    expect(getByText("Portfolio vs Invested")).toBeTruthy();
+    expect(getByText("Assets vs Months")).toBeTruthy();
+    expect(getAllByText("Apr 2026").length).toBeGreaterThanOrEqual(2);
+    expect(getAllByText("May 2026").length).toBeGreaterThanOrEqual(2);
+    expect(getByTestId("portfolio-trend-Portfolio")).toBeTruthy();
+    expect(getByTestId("portfolio-trend-Invested")).toBeTruthy();
+    expect(getByTestId("asset-trend-Equity")).toBeTruthy();
+    expect(getByTestId("asset-trend-Debt")).toBeTruthy();
+    expect(getByTestId("asset-trend-Crypto")).toBeTruthy();
+    expect(queryByTestId("asset-trend-Cash")).toBeNull();
+  });
+
   it("updates an existing month instead of creating duplicate snapshots", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     store.getState().addMonthlySnapshot(maySnapshot);


### PR DESCRIPTION
## Summary
- add pure monthly snapshot chart-data derivation for portfolio/invested and asset trends
- render Monthly Progress graph cards from stored snapshots only
- show insufficient-history state until at least two snapshots exist

## Verification
- npm run typecheck
- npm test -- src/domain/calculations/__tests__/monthlyProgressCharts.test.ts
- npm test -- src/features/progress/__tests__/ProgressScreen.test.tsx
- npm test
- npm run doctor
- npm run android:smoke

Closes #105