### PR TITLE
[V1] Refactor feature screens into controllers

### DIFF
--- a/docs/superpowers/plans/2026-05-25-issue-108-feature-boundary-refactor.md
+++ b/docs/superpowers/plans/2026-05-25-issue-108-feature-boundary-refactor.md
@@ -1,0 +1,34 @@
+# Issue 108 Feature Boundary Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move feature orchestration from large screen components into feature hooks/controllers without changing V1 behavior.
+
+**Architecture:** Each affected feature gets a local hook that owns store subscription, form state, derived values, validation, and persistence actions. Screens keep rendering JSX and wire UI events to hook actions. Domain, services, and store boundaries remain unchanged.
+
+**Tech Stack:** Expo Router, React Native, TypeScript, Zustand vanilla store, Jest, React Native Testing Library.
+
+---
+
+## Files
+
+- Create: `src/features/openingPositions/useAddOpeningPosition.ts`
+- Create: `src/features/openingPositions/__tests__/useAddOpeningPosition.test.tsx`
+- Modify: `src/features/openingPositions/AddOpeningPositionForm.tsx`
+- Create: `src/features/trades/useAddTrade.ts`
+- Create: `src/features/trades/__tests__/useAddTrade.test.tsx`
+- Modify: `src/features/trades/add-trade-form.tsx`
+- Create: `src/features/progress/useProgress.ts`
+- Create: `src/features/progress/__tests__/useProgress.test.tsx`
+- Modify: `src/features/progress/ProgressScreen.tsx`
+
+## Tasks
+
+- [x] Extract Monthly Progress orchestration into `useProgress` with tests for save/update snapshot and derived chart state.
+- [x] Update `ProgressScreen.tsx` to consume `useProgress` and keep existing screen tests green.
+- [x] Extract Add Trade orchestration into `useAddTrade` with tests for manual asset validation, review, confirm, and persistence.
+- [x] Update `add-trade-form.tsx` to consume `useAddTrade` and keep existing screen tests green.
+- [x] Extract Add Holding orchestration into `useAddOpeningPosition` with tests for lookup selection, review, confirm, and persistence.
+- [x] Update `AddOpeningPositionForm.tsx` to consume `useAddOpeningPosition` and keep existing screen tests green.
+- [x] Run required verification commands and architecture checks.
+- [ ] Commit, push, and open PR with `Closes #108`.

--- a/docs/superpowers/specs/2026-05-25-issue-108-feature-boundary-refactor.md
+++ b/docs/superpowers/specs/2026-05-25-issue-108-feature-boundary-refactor.md
@@ -1,0 +1,47 @@
+# Issue 108 Feature Boundary Refactor Spec
+
+## Goal
+
+Refactor Add Holding, Add Trade, and Monthly Progress so feature orchestration lives in feature hooks/controllers while screens remain mostly presentational.
+
+## Current State
+
+- CogVest has no backend and no server routes.
+- Third-party quote/search calls live under `src/services`.
+- Raw state and persistence live under `src/store`.
+- Pure calculations and validators live under `src/domain`.
+- The main boundary problem is feature screens mixing UI rendering with orchestration.
+
+## Target Architecture
+
+- `AddOpeningPositionForm.tsx` renders the Add Holding flow and delegates state/actions to `useAddOpeningPosition`.
+- `add-trade-form.tsx` renders the Add Trade/Add Holding legacy flow and delegates state/actions to `useAddTrade`.
+- `ProgressScreen.tsx` renders the Monthly Progress screen and delegates snapshot form, derived metrics, and persistence actions to `useProgress`.
+- Existing domain/service/store boundaries stay unchanged.
+
+## Scope
+
+- Create feature-local hooks/controllers.
+- Move orchestration logic out of the three screen components.
+- Preserve existing UI behavior and test IDs.
+- Add hook/controller tests where logic is extracted.
+- Keep this as a refactor: no new product behavior.
+
+## Non-Goals
+
+- No backend, auth, cloud sync, analytics, or push notifications.
+- No V2/V3 features.
+- No Minimal Mode or LTCG UI.
+- No import/export or historical quote fetching.
+- No visual redesign.
+- No app-wide architecture rewrite.
+
+## Acceptance Criteria
+
+- Add Holding screen no longer owns lookup, quote resolution, validation, derived preview, and persistence orchestration in the component body.
+- Add Trade screen no longer owns validation and persistence orchestration in the component body.
+- Monthly Progress screen no longer owns snapshot calculation/persistence orchestration in the component body.
+- Existing Add Holding, Add Trade, and Monthly Progress screen tests pass.
+- Hook/controller tests cover moved orchestration.
+- `src/domain` and `src/components` import-direction checks still pass.
+- Backend dependency/route scan still shows no backend/auth/cloud addition.

--- a/src/features/openingPositions/AddOpeningPositionForm.tsx
+++ b/src/features/openingPositions/AddOpeningPositionForm.tsx
@@ -1,7 +1,4 @@
-import * as Haptics from "expo-haptics";
-import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { Pressable, StyleSheet, TouchableOpacity, View } from "react-native";
-import type { StoreApi } from "zustand/vanilla";
 
 import {
   AppButton,
@@ -14,65 +11,25 @@ import {
   SectionHeader,
 } from "@/src/components/common";
 import { FormTextField } from "@/src/components/forms";
-import { getDefaultAssetMetadata } from "@/src/domain/assets";
-import { calculateHolding } from "@/src/domain/calculations";
 import { formatINR, formatPercentage } from "@/src/domain/formatters";
-import {
-  searchAssetLookupResults as defaultSearchAssetLookupResults,
-  type AssetLookupResult,
-  type AssetLookupSearchResult,
-} from "@/src/services/assetLookup";
-import {
-  resolveQuote as defaultResolveQuote,
-  type QuoteResult,
-  type ResolveQuoteInput,
-} from "@/src/services/quotes";
-import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
 import { colors, interaction, radii, spacing } from "@/src/theme";
 import type {
-  Asset,
   AssetClass,
   ConvictionScore,
   InstrumentType,
-  OpeningPosition,
   SectorType,
 } from "@/src/types";
-import { createId } from "@/src/utils";
 
-import { validateOpeningPositionForm } from "./openingPositionForm";
+import {
+  assetClasses,
+  convictionScores,
+  phases,
+  type AddOpeningPositionControllerInput,
+  type AddHoldingPhase,
+  useAddOpeningPosition,
+} from "./useAddOpeningPosition";
 
-type AddOpeningPositionFormProps = {
-  resolveQuote?: (input: ResolveQuoteInput) => Promise<QuoteResult>;
-  searchAssetLookupResults?: (input: {
-    query: string;
-  }) => Promise<AssetLookupSearchResult>;
-  store?: StoreApi<PortfolioStoreState>;
-};
-
-type FieldErrors = Partial<Record<string, string>>;
-type AddHoldingPhase = "asset" | "class" | "position" | "review";
-
-type PhaseConfig = {
-  key: AddHoldingPhase;
-  label: string;
-};
-
-const assetClasses: AssetClass[] = ["stock", "etf", "debt", "crypto"];
-const convictionScores: ConvictionScore[] = [1, 2, 3, 4, 5];
-const phases: PhaseConfig[] = [
-  { key: "asset", label: "Asset" },
-  { key: "class", label: "Class" },
-  { key: "position", label: "Position" },
-  { key: "review", label: "Review" },
-];
-
-function todayInputValue() {
-  return new Date().toISOString().slice(0, 10);
-}
-
-function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
-  return useSyncExternalStore(store.subscribe, store.getState, store.getState);
-}
+type AddOpeningPositionFormProps = AddOpeningPositionControllerInput;
 
 function formatSignedINR(value: number) {
   const amount = formatINR(value);
@@ -81,389 +38,68 @@ function formatSignedINR(value: number) {
 }
 
 export function AddOpeningPositionForm({
-  resolveQuote = defaultResolveQuote,
-  searchAssetLookupResults = defaultSearchAssetLookupResults,
-  store = getPortfolioStore(),
+  resolveQuote,
+  searchAssetLookupResults,
+  store,
 }: AddOpeningPositionFormProps) {
-  const snapshot = usePortfolioSnapshot(store);
-  const [currentPhase, setCurrentPhase] = useState<AddHoldingPhase>("asset");
-  const [lookupQuery, setLookupQuery] = useState("");
-  const [lookupResults, setLookupResults] = useState<AssetLookupResult[]>([]);
-  const [isLookupSearching, setIsLookupSearching] = useState(false);
-  const [lookupStatus, setLookupStatus] = useState("");
-  const [quoteStatus, setQuoteStatus] = useState("");
-  const [selectedAssetId, setSelectedAssetId] = useState("");
-  const [assetClass, setAssetClass] = useState<AssetClass>("stock");
-  const [assetName, setAssetName] = useState("");
-  const [symbol, setSymbol] = useState("");
-  const [ticker, setTicker] = useState("");
-  const [instrumentType, setInstrumentType] = useState<InstrumentType>("stock");
-  const [sectorType, setSectorType] = useState<SectorType>("financialServices");
-  const [quoteSourceId, setQuoteSourceId] = useState("");
-  const [quantity, setQuantity] = useState("");
-  const [averageCostPrice, setAverageCostPrice] = useState("");
-  const [currentPrice, setCurrentPrice] = useState("");
-  const [date, setDate] = useState(todayInputValue());
-  const [conviction, setConviction] = useState("");
-  const [notes, setNotes] = useState("");
-  const [errors, setErrors] = useState<FieldErrors>({});
-  const [reviewAsset, setReviewAsset] = useState<Asset | undefined>();
-  const [reviewOpeningPosition, setReviewOpeningPosition] =
-    useState<OpeningPosition | undefined>();
-  const [successMessage, setSuccessMessage] = useState("");
-
-  const selectedAsset = useMemo(
-    () => snapshot.assets.find((asset) => asset.id === selectedAssetId),
-    [selectedAssetId, snapshot.assets],
-  );
-
-  const previewHolding =
-    reviewAsset && reviewOpeningPosition
-      ? calculateHolding({
-          asset: reviewAsset,
-          currentPrice: reviewOpeningPosition.currentPrice ?? 0,
-          openingPositions: [reviewOpeningPosition],
-          trades: [],
-        })
-      : undefined;
-
-  function resetReview() {
-    setReviewAsset(undefined);
-    setReviewOpeningPosition(undefined);
-    setSuccessMessage("");
-  }
-
-  function getPhaseIndex(phase: AddHoldingPhase) {
-    return phases.findIndex((item) => item.key === phase);
-  }
-
-  function moveToPhase(phase: AddHoldingPhase) {
-    setCurrentPhase(phase);
-    setSuccessMessage("");
-  }
-
-  function validateAssetPhase() {
-    const phaseErrors: FieldErrors = {};
-
-    if (assetName.trim().length === 0) {
-      phaseErrors.assetName = "Asset name is required.";
-    }
-
-    if (symbol.trim().length === 0) {
-      phaseErrors.symbol = "Symbol is required.";
-    }
-
-    if (ticker.trim().length === 0) {
-      phaseErrors.ticker = "Ticker is required.";
-    }
-
-    setErrors(phaseErrors);
-    return Object.keys(phaseErrors).length === 0;
-  }
-
-  function validateClassPhase() {
-    const result = validateOpeningPositionForm({
-      assetClass,
-      assetName: assetName || "Phase validation asset",
-      averageCostPrice: averageCostPrice || "1",
-      conviction,
-      currentPrice: currentPrice || "1",
-      date,
-      instrumentType,
-      notes,
-      quoteSourceId,
-      quantity: quantity || "1",
-      sectorType,
-      symbol: symbol || "PHASE",
-      ticker: ticker || "PHASE.NS",
-    });
-
-    const phaseErrors: FieldErrors = {};
-
-    if (!result.isValid) {
-      if (result.errors.instrumentType) {
-        phaseErrors.instrumentType = result.errors.instrumentType;
-      }
-      if (result.errors.sectorType) {
-        phaseErrors.sectorType = result.errors.sectorType;
-      }
-    }
-
-    setErrors(phaseErrors);
-    return Object.keys(phaseErrors).length === 0;
-  }
-
-  function validatePositionPhase() {
-    const result = validateOpeningPositionForm({
-      assetClass,
-      assetName: assetName || "Phase validation asset",
-      averageCostPrice,
-      conviction,
-      currentPrice,
-      date,
-      instrumentType: instrumentType || "stock",
-      notes,
-      quoteSourceId,
-      quantity,
-      sectorType: sectorType || "financialServices",
-      symbol: symbol || "PHASE",
-      ticker: ticker || "PHASE.NS",
-    });
-
-    const phaseErrors: FieldErrors = {};
-
-    if (!result.isValid) {
-      if (result.errors.quantity) {
-        phaseErrors.quantity = result.errors.quantity;
-      }
-      if (result.errors.averageCostPrice) {
-        phaseErrors.averageCostPrice = result.errors.averageCostPrice;
-      }
-      if (result.errors.currentPrice) {
-        phaseErrors.currentPrice = result.errors.currentPrice;
-      }
-      if (result.errors.date) {
-        phaseErrors.date = result.errors.date;
-      }
-      if (result.errors.conviction) {
-        phaseErrors.conviction = result.errors.conviction;
-      }
-    }
-
-    setErrors(phaseErrors);
-    return Object.keys(phaseErrors).length === 0;
-  }
-
-  function continueFromAsset() {
-    if (validateAssetPhase()) {
-      moveToPhase("class");
-    }
-  }
-
-  function continueFromClass() {
-    if (validateClassPhase()) {
-      moveToPhase("position");
-    }
-  }
-
-  function continueFromPosition() {
-    if (validatePositionPhase()) {
-      handleReview();
-    }
-  }
-
-  useEffect(() => {
-    const trimmedQuery = lookupQuery.trim();
-
-    if (trimmedQuery.length === 0) {
-      setLookupResults([]);
-      setLookupStatus("");
-      setIsLookupSearching(false);
-      return undefined;
-    }
-
-    if (trimmedQuery.length < 2) {
-      setLookupResults([]);
-      setLookupStatus("Type at least 2 characters to search.");
-      setIsLookupSearching(false);
-      return undefined;
-    }
-
-    let isCancelled = false;
-
-    setIsLookupSearching(true);
-    setLookupStatus("Searching public asset directories...");
-
-    const timeout = setTimeout(async () => {
-      try {
-        const result = await searchAssetLookupResults({ query: trimmedQuery });
-
-        if (isCancelled) {
-          return;
-        }
-
-        setLookupResults(result.results);
-        setLookupStatus(
-          result.results.length > 0
-            ? "Select a result to autofill asset details."
-            : "No public result found. You can enter details manually.",
-        );
-
-        if (result.failures.length > 0 && result.results.length === 0) {
-          setLookupStatus("Lookup unavailable. You can enter details manually.");
-        }
-      } catch {
-        if (!isCancelled) {
-          setLookupResults([]);
-          setLookupStatus("Lookup unavailable. You can enter details manually.");
-        }
-      } finally {
-        if (!isCancelled) {
-          setIsLookupSearching(false);
-        }
-      }
-    }, 350);
-
-    return () => {
-      isCancelled = true;
-      clearTimeout(timeout);
-    };
-  }, [lookupQuery, searchAssetLookupResults]);
-
-  function clearSelectedAsset() {
-    if (selectedAssetId) {
-      setSelectedAssetId("");
-    }
-  }
-
-  function selectAsset(asset: Asset) {
-    const quote = snapshot.quoteCache[asset.id];
-
-    setSelectedAssetId(asset.id);
-    setAssetClass(asset.assetClass);
-    setAssetName(asset.name);
-    setInstrumentType(asset.instrumentType ?? getDefaultAssetMetadata(asset.assetClass).instrumentType);
-    setQuoteSourceId(asset.quoteSourceId ?? asset.ticker);
-    setSectorType(asset.sectorType ?? getDefaultAssetMetadata(asset.assetClass).sectorType);
-    setSymbol(asset.symbol);
-    setTicker(asset.ticker);
-    if (quote) {
-      setCurrentPrice(quote.price.toString());
-    }
-    resetReview();
-  }
-
-  function buildManualAsset(id: string): Asset {
-    const trimmedTicker = ticker.trim();
-
-    return {
-      assetClass,
-      currency: "INR",
-      exchange: assetClass === "crypto" ? "CRYPTO" : "NSE",
-      id,
-      instrumentType,
-      name: assetName.trim(),
-      quoteSourceId: quoteSourceId.trim() || trimmedTicker,
-      sectorType,
-      symbol: symbol.trim().toUpperCase(),
-      ticker: assetClass === "crypto" ? trimmedTicker : trimmedTicker.toUpperCase(),
-    };
-  }
-
-  function buildLookupAsset(result: AssetLookupResult): Asset {
-    return {
-      assetClass: result.assetClass,
-      currency: result.currency,
-      exchange: result.exchange,
-      id: createId("asset"),
-      instrumentType: result.instrumentType,
-      name: result.name,
-      quoteSourceId: result.quoteSourceId,
-      sectorType: result.sectorType,
-      symbol: result.symbol,
-      ticker: result.ticker,
-    };
-  }
-
-  async function selectLookupResult(result: AssetLookupResult) {
-    setSelectedAssetId("");
-    setAssetClass(result.assetClass);
-    setAssetName(result.name);
-    setInstrumentType(result.instrumentType);
-    setQuoteSourceId(result.quoteSourceId);
-    setSectorType(result.sectorType);
-    setSymbol(result.symbol);
-    setTicker(result.ticker);
-    setLookupQuery("");
-    setLookupResults([]);
-    setLookupStatus("");
-    setQuoteStatus("Fetching live current price...");
-    resetReview();
-
-    const quoteResult = await resolveQuote({ asset: buildLookupAsset(result) });
-
-    if (quoteResult.ok) {
-      setCurrentPrice(quoteResult.quote.price.toString());
-      setQuoteStatus(`Live price autofilled from ${result.sourceLabel}.`);
-      return;
-    }
-
-    setCurrentPrice("");
-    setQuoteStatus("Live price unavailable. Enter current price manually.");
-  }
-
-  function updateAssetClass(nextAssetClass: AssetClass) {
-    const defaults = getDefaultAssetMetadata(nextAssetClass);
-
-    setAssetClass(nextAssetClass);
-    setInstrumentType(defaults.instrumentType);
-    setSectorType(defaults.sectorType);
-    clearSelectedAsset();
-    resetReview();
-  }
-
-  function handleReview() {
-    resetReview();
-    const result = validateOpeningPositionForm({
-      assetClass,
-      assetName,
-      averageCostPrice,
-      conviction,
-      currentPrice,
-      date,
-      instrumentType,
-      notes,
-      quoteSourceId,
-      quantity,
-      sectorType,
-      symbol,
-      ticker,
-    });
-
-    if (!result.isValid) {
-      setErrors(result.errors);
-      return;
-    }
-
-    const assetId = selectedAsset?.id ?? createId("asset");
-    const asset = selectedAsset ?? buildManualAsset(assetId);
-
-    setErrors({});
-    setReviewAsset(asset);
-    setReviewOpeningPosition({
-      assetId: asset.id,
-      averageCostPrice: result.value.averageCostPrice,
-      conviction: result.value.conviction,
-      currentPrice: result.value.currentPrice,
-      date: `${result.value.date}T00:00:00.000Z`,
-      id: createId("opening"),
-      notes: result.value.notes,
-      quantity: result.value.quantity,
-    });
-    setCurrentPhase("review");
-  }
-
-  async function handleConfirm() {
-    if (!reviewAsset || !reviewOpeningPosition) {
-      return;
-    }
-
-    if (!selectedAsset) {
-      store.getState().addAsset(reviewAsset);
-    }
-
-    store.getState().addOpeningPosition(reviewOpeningPosition);
-    store.getState().upsertQuote({
-      asOf: new Date().toISOString(),
-      assetId: reviewAsset.id,
-      currency: "INR",
-      price: reviewOpeningPosition.currentPrice ?? 0,
-      source: "manual",
-    });
-    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-    setSuccessMessage("Opening position saved.");
-    setReviewOpeningPosition(undefined);
-  }
+  const holding = useAddOpeningPosition({
+    resolveQuote,
+    searchAssetLookupResults,
+    store,
+  });
+  const {
+    assetClass,
+    assetName,
+    averageCostPrice,
+    clearSelectedAsset,
+    continueFromAsset,
+    continueFromClass,
+    continueFromPosition,
+    conviction,
+    currentPhase,
+    currentPrice,
+    date,
+    errors,
+    getPhaseIndex,
+    handleConfirm,
+    instrumentType,
+    isLookupSearching,
+    lookupQuery,
+    lookupResults,
+    lookupStatus,
+    moveToPhase,
+    notes,
+    previewHolding,
+    quantity,
+    quoteSourceId,
+    quoteStatus,
+    resetReview,
+    reviewAsset,
+    reviewOpeningPosition,
+    sectorType,
+    selectAsset,
+    selectLookupResult,
+    selectedAssetId,
+    setAssetName,
+    setAverageCostPrice,
+    setConviction,
+    setCurrentPrice,
+    setDate,
+    setInstrumentType,
+    setLookupQuery,
+    setNotes,
+    setQuantity,
+    setQuoteSourceId,
+    setQuoteStatus,
+    setSectorType,
+    setSymbol,
+    setTicker,
+    snapshot,
+    successMessage,
+    symbol,
+    ticker,
+    updateAssetClass,
+  } = holding;
 
   function renderStepper() {
     const currentIndex = getPhaseIndex(currentPhase);

--- a/src/features/openingPositions/__tests__/useAddOpeningPosition.test.tsx
+++ b/src/features/openingPositions/__tests__/useAddOpeningPosition.test.tsx
@@ -1,0 +1,44 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import { createPortfolioStore } from "@/src/store";
+
+import { useAddOpeningPosition } from "../useAddOpeningPosition";
+
+describe("useAddOpeningPosition", () => {
+  it("reviews and confirms a manual opening position through the feature controller", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const { result } = renderHook(() => useAddOpeningPosition({ store }));
+
+    act(() => {
+      result.current.setAssetName("Reliance Industries");
+      result.current.setSymbol("RELIANCE");
+      result.current.setTicker("RELIANCE.NS");
+      result.current.setQuantity("2");
+      result.current.setAverageCostPrice("100");
+      result.current.setCurrentPrice("120");
+    });
+
+    act(() => {
+      result.current.handleReview();
+    });
+
+    expect(result.current.reviewOpeningPosition).toMatchObject({
+      averageCostPrice: 100,
+      currentPrice: 120,
+      quantity: 2,
+    });
+
+    await act(async () => {
+      await result.current.handleConfirm();
+    });
+
+    expect(store.getState().assets).toHaveLength(1);
+    expect(store.getState().openingPositions).toHaveLength(1);
+    expect(store.getState().trades).toEqual([]);
+    expect(store.getState().quoteCache[store.getState().assets[0].id]).toMatchObject({
+      price: 120,
+      source: "manual",
+    });
+  });
+});

--- a/src/features/openingPositions/useAddOpeningPosition.ts
+++ b/src/features/openingPositions/useAddOpeningPosition.ts
@@ -1,0 +1,495 @@
+import * as Haptics from "expo-haptics";
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import type { StoreApi } from "zustand/vanilla";
+
+import { getDefaultAssetMetadata } from "@/src/domain/assets";
+import { calculateHolding } from "@/src/domain/calculations";
+import {
+  searchAssetLookupResults as defaultSearchAssetLookupResults,
+  type AssetLookupResult,
+  type AssetLookupSearchResult,
+} from "@/src/services/assetLookup";
+import {
+  resolveQuote as defaultResolveQuote,
+  type QuoteResult,
+  type ResolveQuoteInput,
+} from "@/src/services/quotes";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import type {
+  Asset,
+  AssetClass,
+  ConvictionScore,
+  InstrumentType,
+  OpeningPosition,
+  SectorType,
+} from "@/src/types";
+import { createId } from "@/src/utils";
+
+import { validateOpeningPositionForm } from "./openingPositionForm";
+
+export type AddHoldingPhase = "asset" | "class" | "position" | "review";
+export type FieldErrors = Partial<Record<string, string>>;
+
+export type AddOpeningPositionControllerInput = {
+  resolveQuote?: (input: ResolveQuoteInput) => Promise<QuoteResult>;
+  searchAssetLookupResults?: (input: {
+    query: string;
+  }) => Promise<AssetLookupSearchResult>;
+  store?: StoreApi<PortfolioStoreState>;
+};
+
+export const assetClasses: AssetClass[] = ["stock", "etf", "debt", "crypto"];
+export const convictionScores: ConvictionScore[] = [1, 2, 3, 4, 5];
+export const phases: Array<{ key: AddHoldingPhase; label: string }> = [
+  { key: "asset", label: "Asset" },
+  { key: "class", label: "Class" },
+  { key: "position", label: "Position" },
+  { key: "review", label: "Review" },
+];
+
+function todayInputValue() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
+  return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+}
+
+export function useAddOpeningPosition({
+  resolveQuote = defaultResolveQuote,
+  searchAssetLookupResults = defaultSearchAssetLookupResults,
+  store = getPortfolioStore(),
+}: AddOpeningPositionControllerInput = {}) {
+  const snapshot = usePortfolioSnapshot(store);
+  const [currentPhase, setCurrentPhase] = useState<AddHoldingPhase>("asset");
+  const [lookupQuery, setLookupQuery] = useState("");
+  const [lookupResults, setLookupResults] = useState<AssetLookupResult[]>([]);
+  const [isLookupSearching, setIsLookupSearching] = useState(false);
+  const [lookupStatus, setLookupStatus] = useState("");
+  const [quoteStatus, setQuoteStatus] = useState("");
+  const [selectedAssetId, setSelectedAssetId] = useState("");
+  const [assetClass, setAssetClass] = useState<AssetClass>("stock");
+  const [assetName, setAssetName] = useState("");
+  const [symbol, setSymbol] = useState("");
+  const [ticker, setTicker] = useState("");
+  const [instrumentType, setInstrumentType] = useState<InstrumentType>("stock");
+  const [sectorType, setSectorType] = useState<SectorType>("financialServices");
+  const [quoteSourceId, setQuoteSourceId] = useState("");
+  const [quantity, setQuantity] = useState("");
+  const [averageCostPrice, setAverageCostPrice] = useState("");
+  const [currentPrice, setCurrentPrice] = useState("");
+  const [date, setDate] = useState(todayInputValue());
+  const [conviction, setConviction] = useState("");
+  const [notes, setNotes] = useState("");
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [reviewAsset, setReviewAsset] = useState<Asset | undefined>();
+  const [reviewOpeningPosition, setReviewOpeningPosition] =
+    useState<OpeningPosition | undefined>();
+  const [successMessage, setSuccessMessage] = useState("");
+
+  const selectedAsset = useMemo(
+    () => snapshot.assets.find((asset) => asset.id === selectedAssetId),
+    [selectedAssetId, snapshot.assets],
+  );
+
+  const previewHolding =
+    reviewAsset && reviewOpeningPosition
+      ? calculateHolding({
+          asset: reviewAsset,
+          currentPrice: reviewOpeningPosition.currentPrice ?? 0,
+          openingPositions: [reviewOpeningPosition],
+          trades: [],
+        })
+      : undefined;
+
+  function resetReview() {
+    setReviewAsset(undefined);
+    setReviewOpeningPosition(undefined);
+    setSuccessMessage("");
+  }
+
+  function getPhaseIndex(phase: AddHoldingPhase) {
+    return phases.findIndex((item) => item.key === phase);
+  }
+
+  function moveToPhase(phase: AddHoldingPhase) {
+    setCurrentPhase(phase);
+    setSuccessMessage("");
+  }
+
+  function validateAssetPhase() {
+    const phaseErrors: FieldErrors = {};
+
+    if (assetName.trim().length === 0) {
+      phaseErrors.assetName = "Asset name is required.";
+    }
+
+    if (symbol.trim().length === 0) {
+      phaseErrors.symbol = "Symbol is required.";
+    }
+
+    if (ticker.trim().length === 0) {
+      phaseErrors.ticker = "Ticker is required.";
+    }
+
+    setErrors(phaseErrors);
+    return Object.keys(phaseErrors).length === 0;
+  }
+
+  function validateClassPhase() {
+    const result = validateOpeningPositionForm({
+      assetClass,
+      assetName: assetName || "Phase validation asset",
+      averageCostPrice: averageCostPrice || "1",
+      conviction,
+      currentPrice: currentPrice || "1",
+      date,
+      instrumentType,
+      notes,
+      quoteSourceId,
+      quantity: quantity || "1",
+      sectorType,
+      symbol: symbol || "PHASE",
+      ticker: ticker || "PHASE.NS",
+    });
+    const phaseErrors: FieldErrors = {};
+
+    if (!result.isValid) {
+      if (result.errors.instrumentType) {
+        phaseErrors.instrumentType = result.errors.instrumentType;
+      }
+      if (result.errors.sectorType) {
+        phaseErrors.sectorType = result.errors.sectorType;
+      }
+    }
+
+    setErrors(phaseErrors);
+    return Object.keys(phaseErrors).length === 0;
+  }
+
+  function validatePositionPhase() {
+    const result = validateOpeningPositionForm({
+      assetClass,
+      assetName: assetName || "Phase validation asset",
+      averageCostPrice,
+      conviction,
+      currentPrice,
+      date,
+      instrumentType: instrumentType || "stock",
+      notes,
+      quoteSourceId,
+      quantity,
+      sectorType: sectorType || "financialServices",
+      symbol: symbol || "PHASE",
+      ticker: ticker || "PHASE.NS",
+    });
+    const phaseErrors: FieldErrors = {};
+
+    if (!result.isValid) {
+      if (result.errors.quantity) {
+        phaseErrors.quantity = result.errors.quantity;
+      }
+      if (result.errors.averageCostPrice) {
+        phaseErrors.averageCostPrice = result.errors.averageCostPrice;
+      }
+      if (result.errors.currentPrice) {
+        phaseErrors.currentPrice = result.errors.currentPrice;
+      }
+      if (result.errors.date) {
+        phaseErrors.date = result.errors.date;
+      }
+      if (result.errors.conviction) {
+        phaseErrors.conviction = result.errors.conviction;
+      }
+    }
+
+    setErrors(phaseErrors);
+    return Object.keys(phaseErrors).length === 0;
+  }
+
+  function continueFromAsset() {
+    if (validateAssetPhase()) {
+      moveToPhase("class");
+    }
+  }
+
+  function continueFromClass() {
+    if (validateClassPhase()) {
+      moveToPhase("position");
+    }
+  }
+
+  function continueFromPosition() {
+    if (validatePositionPhase()) {
+      handleReview();
+    }
+  }
+
+  useEffect(() => {
+    const trimmedQuery = lookupQuery.trim();
+
+    if (trimmedQuery.length === 0) {
+      setLookupResults([]);
+      setLookupStatus("");
+      setIsLookupSearching(false);
+      return undefined;
+    }
+
+    if (trimmedQuery.length < 2) {
+      setLookupResults([]);
+      setLookupStatus("Type at least 2 characters to search.");
+      setIsLookupSearching(false);
+      return undefined;
+    }
+
+    let isCancelled = false;
+
+    setIsLookupSearching(true);
+    setLookupStatus("Searching public asset directories...");
+
+    const timeout = setTimeout(async () => {
+      try {
+        const result = await searchAssetLookupResults({ query: trimmedQuery });
+
+        if (isCancelled) {
+          return;
+        }
+
+        setLookupResults(result.results);
+        setLookupStatus(
+          result.results.length > 0
+            ? "Select a result to autofill asset details."
+            : "No public result found. You can enter details manually.",
+        );
+
+        if (result.failures.length > 0 && result.results.length === 0) {
+          setLookupStatus("Lookup unavailable. You can enter details manually.");
+        }
+      } catch {
+        if (!isCancelled) {
+          setLookupResults([]);
+          setLookupStatus("Lookup unavailable. You can enter details manually.");
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsLookupSearching(false);
+        }
+      }
+    }, 350);
+
+    return () => {
+      isCancelled = true;
+      clearTimeout(timeout);
+    };
+  }, [lookupQuery, searchAssetLookupResults]);
+
+  function clearSelectedAsset() {
+    if (selectedAssetId) {
+      setSelectedAssetId("");
+    }
+  }
+
+  function selectAsset(asset: Asset) {
+    const quote = snapshot.quoteCache[asset.id];
+
+    setSelectedAssetId(asset.id);
+    setAssetClass(asset.assetClass);
+    setAssetName(asset.name);
+    setInstrumentType(asset.instrumentType ?? getDefaultAssetMetadata(asset.assetClass).instrumentType);
+    setQuoteSourceId(asset.quoteSourceId ?? asset.ticker);
+    setSectorType(asset.sectorType ?? getDefaultAssetMetadata(asset.assetClass).sectorType);
+    setSymbol(asset.symbol);
+    setTicker(asset.ticker);
+    if (quote) {
+      setCurrentPrice(quote.price.toString());
+    }
+    resetReview();
+  }
+
+  function buildManualAsset(id: string): Asset {
+    const trimmedTicker = ticker.trim();
+
+    return {
+      assetClass,
+      currency: "INR",
+      exchange: assetClass === "crypto" ? "CRYPTO" : "NSE",
+      id,
+      instrumentType,
+      name: assetName.trim(),
+      quoteSourceId: quoteSourceId.trim() || trimmedTicker,
+      sectorType,
+      symbol: symbol.trim().toUpperCase(),
+      ticker: assetClass === "crypto" ? trimmedTicker : trimmedTicker.toUpperCase(),
+    };
+  }
+
+  function buildLookupAsset(result: AssetLookupResult): Asset {
+    return {
+      assetClass: result.assetClass,
+      currency: result.currency,
+      exchange: result.exchange,
+      id: createId("asset"),
+      instrumentType: result.instrumentType,
+      name: result.name,
+      quoteSourceId: result.quoteSourceId,
+      sectorType: result.sectorType,
+      symbol: result.symbol,
+      ticker: result.ticker,
+    };
+  }
+
+  async function selectLookupResult(result: AssetLookupResult) {
+    setSelectedAssetId("");
+    setAssetClass(result.assetClass);
+    setAssetName(result.name);
+    setInstrumentType(result.instrumentType);
+    setQuoteSourceId(result.quoteSourceId);
+    setSectorType(result.sectorType);
+    setSymbol(result.symbol);
+    setTicker(result.ticker);
+    setLookupQuery("");
+    setLookupResults([]);
+    setLookupStatus("");
+    setQuoteStatus("Fetching live current price...");
+    resetReview();
+
+    const quoteResult = await resolveQuote({ asset: buildLookupAsset(result) });
+
+    if (quoteResult.ok) {
+      setCurrentPrice(quoteResult.quote.price.toString());
+      setQuoteStatus(`Live price autofilled from ${result.sourceLabel}.`);
+      return;
+    }
+
+    setCurrentPrice("");
+    setQuoteStatus("Live price unavailable. Enter current price manually.");
+  }
+
+  function updateAssetClass(nextAssetClass: AssetClass) {
+    const defaults = getDefaultAssetMetadata(nextAssetClass);
+
+    setAssetClass(nextAssetClass);
+    setInstrumentType(defaults.instrumentType);
+    setSectorType(defaults.sectorType);
+    clearSelectedAsset();
+    resetReview();
+  }
+
+  function handleReview() {
+    resetReview();
+    const result = validateOpeningPositionForm({
+      assetClass,
+      assetName,
+      averageCostPrice,
+      conviction,
+      currentPrice,
+      date,
+      instrumentType,
+      notes,
+      quoteSourceId,
+      quantity,
+      sectorType,
+      symbol,
+      ticker,
+    });
+
+    if (!result.isValid) {
+      setErrors(result.errors);
+      return;
+    }
+
+    const assetId = selectedAsset?.id ?? createId("asset");
+    const asset = selectedAsset ?? buildManualAsset(assetId);
+
+    setErrors({});
+    setReviewAsset(asset);
+    setReviewOpeningPosition({
+      assetId: asset.id,
+      averageCostPrice: result.value.averageCostPrice,
+      conviction: result.value.conviction,
+      currentPrice: result.value.currentPrice,
+      date: `${result.value.date}T00:00:00.000Z`,
+      id: createId("opening"),
+      notes: result.value.notes,
+      quantity: result.value.quantity,
+    });
+    setCurrentPhase("review");
+  }
+
+  async function handleConfirm() {
+    if (!reviewAsset || !reviewOpeningPosition) {
+      return;
+    }
+
+    if (!selectedAsset) {
+      store.getState().addAsset(reviewAsset);
+    }
+
+    store.getState().addOpeningPosition(reviewOpeningPosition);
+    store.getState().upsertQuote({
+      asOf: new Date().toISOString(),
+      assetId: reviewAsset.id,
+      currency: "INR",
+      price: reviewOpeningPosition.currentPrice ?? 0,
+      source: "manual",
+    });
+    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    setSuccessMessage("Opening position saved.");
+    setReviewOpeningPosition(undefined);
+  }
+
+  return {
+    assetClass,
+    assetName,
+    averageCostPrice,
+    clearSelectedAsset,
+    continueFromAsset,
+    continueFromClass,
+    continueFromPosition,
+    conviction,
+    currentPhase,
+    currentPrice,
+    date,
+    errors,
+    getPhaseIndex,
+    handleConfirm,
+    handleReview,
+    instrumentType,
+    isLookupSearching,
+    lookupQuery,
+    lookupResults,
+    lookupStatus,
+    moveToPhase,
+    notes,
+    previewHolding,
+    quantity,
+    quoteSourceId,
+    quoteStatus,
+    resetReview,
+    reviewAsset,
+    reviewOpeningPosition,
+    sectorType,
+    selectAsset,
+    selectLookupResult,
+    selectedAssetId,
+    setAssetName,
+    setAverageCostPrice,
+    setConviction,
+    setCurrentPrice,
+    setDate,
+    setInstrumentType,
+    setLookupQuery,
+    setNotes,
+    setQuantity,
+    setQuoteSourceId,
+    setQuoteStatus,
+    setSectorType,
+    setSymbol,
+    setTicker,
+    snapshot,
+    successMessage,
+    symbol,
+    ticker,
+    updateAssetClass,
+  };
+}

--- a/src/features/progress/ProgressScreen.tsx
+++ b/src/features/progress/ProgressScreen.tsx
@@ -1,4 +1,3 @@
-import { useState, useSyncExternalStore } from "react";
 import { StyleSheet, View } from "react-native";
 import Svg, { Circle, Polyline } from "react-native-svg";
 import type { StoreApi } from "zustand/vanilla";
@@ -16,29 +15,16 @@ import {
   SectionHeader,
   assetClassLabel,
 } from "@/src/components/common";
-import {
-  buildMonthlyProgressChartData,
-  calculateAllocation,
-  calculateCashBalance,
-  calculateHoldings,
-  calculateMonthlyProgressSummaries,
-  calculatePortfolioTotal,
-  type MonthlyProgressChartSeries,
-} from "@/src/domain/calculations";
+import type { MonthlyProgressChartSeries } from "@/src/domain/calculations";
 import { formatINR, formatPercentage } from "@/src/domain/formatters";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
 import { colors, spacing } from "@/src/theme";
-import type { MonthlySnapshot } from "@/src/types";
-import { createId } from "@/src/utils";
 import { FormTextField } from "@/src/components/forms";
+import { useProgress } from "./useProgress";
 
 type ProgressScreenProps = {
   store?: StoreApi<PortfolioStoreState>;
 };
-
-function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
-  return useSyncExternalStore(store.subscribe, store.getState, store.getState);
-}
 
 function getMonthLabel(date = new Date()) {
   return new Intl.DateTimeFormat("en-IN", {
@@ -58,52 +44,11 @@ function formatMonth(month: string) {
   }).format(new Date(Date.UTC(Number(year), monthIndex, 1)));
 }
 
-function isCurrentMonth(isoDate: string, now = new Date()) {
-  const date = new Date(isoDate);
-
-  return (
-    date.getFullYear() === now.getFullYear() &&
-    date.getMonth() === now.getMonth()
-  );
-}
-
 function formatSignedINR(value: number) {
   const amount = formatINR(value);
 
   return value > 0 ? `+${amount}` : amount;
 }
-
-function emptyFormValues() {
-  const now = new Date();
-
-  return {
-    cashValue: "",
-    cryptoValue: "",
-    debtValue: "",
-    equityValue: "",
-    investedValue: "",
-    month: `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`,
-    monthlyExpense: "",
-    monthlyInvestment: "",
-    notes: "",
-    portfolioValue: "",
-    salary: "",
-  };
-}
-
-type SnapshotFormValues = ReturnType<typeof emptyFormValues>;
-type SnapshotFormErrors = Partial<Record<keyof SnapshotFormValues, string>>;
-
-const requiredNumberFields: Array<keyof SnapshotFormValues> = [
-  "portfolioValue",
-  "investedValue",
-  "equityValue",
-  "debtValue",
-  "cryptoValue",
-  "cashValue",
-  "monthlyInvestment",
-  "salary",
-];
 
 const chartWidth = 280;
 const chartHeight = 132;
@@ -282,145 +227,10 @@ function ProgressTrendCards({
   );
 }
 
-function parseNumberField(
-  values: SnapshotFormValues,
-  field: keyof SnapshotFormValues,
-  errors: SnapshotFormErrors,
-) {
-  const value = values[field].trim();
-  const parsedValue = value.length > 0 ? Number(value) : Number.NaN;
-
-  if (!Number.isFinite(parsedValue) || parsedValue < 0) {
-    errors[field] = "Enter a valid amount.";
-  }
-
-  return parsedValue;
-}
-
-function validateSnapshotForm(values: SnapshotFormValues) {
-  const errors: SnapshotFormErrors = {};
-
-  if (!/^\d{4}-\d{2}$/.test(values.month.trim())) {
-    errors.month = "Use YYYY-MM.";
-  }
-
-  const parsedValues = Object.fromEntries(
-    requiredNumberFields.map((field) => [
-      field,
-      parseNumberField(values, field, errors),
-    ]),
-  ) as Record<(typeof requiredNumberFields)[number], number>;
-  const trimmedExpense = values.monthlyExpense.trim();
-  const monthlyExpense =
-    trimmedExpense.length === 0 ? undefined : Number(trimmedExpense);
-
-  if (
-    monthlyExpense !== undefined &&
-    (!Number.isFinite(monthlyExpense) || monthlyExpense < 0)
-  ) {
-    errors.monthlyExpense = "Enter a valid amount.";
-  }
-
-  if (Object.keys(errors).length > 0) {
-    return { errors, snapshot: null };
-  }
-
-  return {
-    errors,
-    snapshot: {
-      cashValue: parsedValues.cashValue,
-      cryptoValue: parsedValues.cryptoValue,
-      debtValue: parsedValues.debtValue,
-      equityValue: parsedValues.equityValue,
-      id: createId("snapshot"),
-      investedValue: parsedValues.investedValue,
-      month: values.month.trim(),
-      monthlyExpense,
-      monthlyInvestment: parsedValues.monthlyInvestment,
-      notes: values.notes.trim() || undefined,
-      portfolioValue: parsedValues.portfolioValue,
-      salary: parsedValues.salary,
-    } satisfies MonthlySnapshot,
-  };
-}
-
 export function ProgressScreen({
   store = getPortfolioStore(),
 }: ProgressScreenProps) {
-  const snapshot = usePortfolioSnapshot(store);
-  const [formValues, setFormValues] = useState(emptyFormValues);
-  const [errors, setErrors] = useState<SnapshotFormErrors>({});
-  const holdings = calculateHoldings({
-    assets: snapshot.assets,
-    openingPositions: snapshot.openingPositions,
-    quoteCache: snapshot.quoteCache,
-    trades: snapshot.trades,
-  });
-  const cashBalance = calculateCashBalance(snapshot.cashEntries);
-  const portfolioValue = calculatePortfolioTotal(holdings, snapshot.cashEntries);
-  const totalInvested = holdings.reduce(
-    (total, holding) => total + holding.totalInvested,
-    0,
-  );
-  const monthlyTradeInvestment = snapshot.trades
-    .filter((trade) => trade.type === "buy" && isCurrentMonth(trade.date))
-    .reduce((total, trade) => total + trade.totalValue, 0);
-  const monthlyOpeningInvestment = snapshot.openingPositions
-    .filter((position) => isCurrentMonth(position.date))
-    .reduce(
-      (total, position) =>
-        total + position.quantity * position.averageCostPrice,
-      0,
-    );
-  const monthlyInvestment = monthlyTradeInvestment + monthlyOpeningInvestment;
-  const monthlyCashAdded = snapshot.cashEntries
-    .filter((entry) => entry.type === "addition" && isCurrentMonth(entry.date))
-    .reduce((total, entry) => total + entry.amount, 0);
-  const savingsRate =
-    monthlyCashAdded === 0 ? 0 : (monthlyInvestment / monthlyCashAdded) * 100;
-  const allocation = calculateAllocation({ cashBalance, holdings });
-  const hasData = holdings.length > 0 || snapshot.cashEntries.length > 0;
-  const monthlySummaries = calculateMonthlyProgressSummaries(
-    snapshot.monthlySnapshots,
-  );
-  const latestSummary = monthlySummaries[0];
-  const chartData = buildMonthlyProgressChartData(snapshot.monthlySnapshots);
-
-  function setField(field: keyof SnapshotFormValues, value: string) {
-    setFormValues((currentValues) => ({
-      ...currentValues,
-      [field]: value,
-    }));
-    setErrors((currentErrors) => ({
-      ...currentErrors,
-      [field]: undefined,
-    }));
-  }
-
-  function saveSnapshot() {
-    const result = validateSnapshotForm(formValues);
-
-    if (!result.snapshot) {
-      setErrors(result.errors);
-      return;
-    }
-
-    const existingSnapshot = snapshot.monthlySnapshots.find(
-      (monthlySnapshot) => monthlySnapshot.month === result.snapshot.month,
-    );
-
-    if (existingSnapshot) {
-      store.getState().updateMonthlySnapshot({
-        ...result.snapshot,
-        id: existingSnapshot.id,
-      });
-    } else {
-      store.getState().addMonthlySnapshot(result.snapshot);
-    }
-
-    setFormValues(emptyFormValues());
-    setErrors({});
-  }
+  const progress = useProgress({ store });
 
   return (
     <ScreenContainer scroll testID="progress-screen">
@@ -428,58 +238,58 @@ export function ProgressScreen({
         <ScreenHeader
           title="Monthly Progress"
           subtitle={
-            latestSummary
-              ? `${formatMonth(latestSummary.snapshot.month)} snapshot`
+            progress.latestSummary
+              ? `${formatMonth(progress.latestSummary.snapshot.month)} snapshot`
               : getMonthLabel()
           }
         />
 
-        {latestSummary ? (
+        {progress.latestSummary ? (
           <>
             <HeroMetric
               label="Portfolio value"
-              masked={snapshot.preferences.maskWealthValues}
+              masked={progress.preferences.maskWealthValues}
               subValue={`${formatSignedINR(
-                latestSummary.monthlyGain,
-              )} (${formatPercentage(latestSummary.monthlyGainPct)})`}
-              subValueTone={latestSummary.monthlyGain >= 0 ? "positive" : "negative"}
-              value={formatINR(latestSummary.snapshot.portfolioValue)}
+                progress.latestSummary.monthlyGain,
+              )} (${formatPercentage(progress.latestSummary.monthlyGainPct)})`}
+              subValueTone={progress.latestSummary.monthlyGain >= 0 ? "positive" : "negative"}
+              value={formatINR(progress.latestSummary.snapshot.portfolioValue)}
             />
 
             <MetricGroup
               metrics={[
                 {
                   label: "Invested",
-                  masked: snapshot.preferences.maskWealthValues,
-                  value: formatINR(latestSummary.snapshot.monthlyInvestment),
+                  masked: progress.preferences.maskWealthValues,
+                  value: formatINR(progress.latestSummary.snapshot.monthlyInvestment),
                 },
                 {
                   label: "Savings",
                   value:
-                    latestSummary.savingsRate === null
+                    progress.latestSummary.savingsRate === null
                       ? "Not enough data"
-                      : formatPercentage(latestSummary.savingsRate),
+                      : formatPercentage(progress.latestSummary.savingsRate),
                 },
                 {
                   label: "Expense",
                   value:
-                    latestSummary.expenseRate === null
+                    progress.latestSummary.expenseRate === null
                       ? "Not enough data"
-                      : formatPercentage(latestSummary.expenseRate),
+                      : formatPercentage(progress.latestSummary.expenseRate),
                 },
               ]}
             />
 
             <ProgressTrendCards
-              assetSeries={chartData.assetSeries}
-              hasEnoughHistory={chartData.hasEnoughHistory}
-              monthLabels={chartData.monthLabels}
-              portfolioSeries={chartData.portfolioSeries}
+              assetSeries={progress.chartData.assetSeries}
+              hasEnoughHistory={progress.chartData.hasEnoughHistory}
+              monthLabels={progress.chartData.monthLabels}
+              portfolioSeries={progress.chartData.portfolioSeries}
             />
 
             <PremiumCard>
               <SectionHeader title="Asset class snapshot" />
-              {latestSummary.assetSnapshot.map((item) => (
+              {progress.latestSummary.assetSnapshot.map((item) => (
                 <View key={item.assetClass} style={styles.assetRow}>
                   <View style={styles.assetIdentity}>
                     <CategoryIcon assetClass={item.assetClass} />
@@ -497,7 +307,7 @@ export function ProgressScreen({
 
             <PremiumCard>
               <SectionHeader title="Recent snapshots" />
-              {monthlySummaries.map((summary) => (
+              {progress.monthlySummaries.map((summary) => (
                 <View key={summary.snapshot.id} style={styles.snapshotRow}>
                   <View style={styles.snapshotCopy}>
                     <AppText weight="bold">{formatMonth(summary.snapshot.month)}</AppText>
@@ -517,28 +327,28 @@ export function ProgressScreen({
               ))}
             </PremiumCard>
           </>
-        ) : hasData ? (
+        ) : progress.hasData ? (
           <>
             <MetricGroup
               metrics={[
                 {
                   label: "Portfolio",
-                  masked: snapshot.preferences.maskWealthValues,
-                  value: formatINR(portfolioValue),
+                  masked: progress.preferences.maskWealthValues,
+                  value: formatINR(progress.portfolioValue),
                 },
                 {
                   label: "Invested",
-                  masked: snapshot.preferences.maskWealthValues,
-                  value: formatINR(totalInvested),
+                  masked: progress.preferences.maskWealthValues,
+                  value: formatINR(progress.totalInvested),
                 },
                 {
                   label: "Cash",
-                  masked: snapshot.preferences.maskWealthValues,
-                  value: formatINR(cashBalance),
+                  masked: progress.preferences.maskWealthValues,
+                  value: formatINR(progress.cashBalance),
                 },
                 {
                   label: "Savings",
-                  value: monthlyCashAdded === 0 ? "Not enough data" : formatPercentage(savingsRate),
+                  value: progress.monthlyCashAdded === 0 ? "Not enough data" : formatPercentage(progress.savingsRate),
                 },
               ]}
             />
@@ -546,10 +356,10 @@ export function ProgressScreen({
             <PremiumCard>
               <SectionHeader title="What changed this month?" />
               <AppText color="secondary">
-                Monthly investment: {formatINR(monthlyInvestment)}
+                Monthly investment: {formatINR(progress.monthlyInvestment)}
               </AppText>
               <AppText color="secondary">
-                Cash added: {formatINR(monthlyCashAdded)}
+                Cash added: {formatINR(progress.monthlyCashAdded)}
               </AppText>
               <AppText color="secondary">
                 Expense rate needs explicit expense tracking and is not shown in V1.
@@ -557,15 +367,15 @@ export function ProgressScreen({
             </PremiumCard>
 
             <ProgressTrendCards
-              assetSeries={chartData.assetSeries}
-              hasEnoughHistory={chartData.hasEnoughHistory}
-              monthLabels={chartData.monthLabels}
-              portfolioSeries={chartData.portfolioSeries}
+              assetSeries={progress.chartData.assetSeries}
+              hasEnoughHistory={progress.chartData.hasEnoughHistory}
+              monthLabels={progress.chartData.monthLabels}
+              portfolioSeries={progress.chartData.portfolioSeries}
             />
 
             <PremiumCard>
               <SectionHeader title="Asset class snapshot" />
-              {allocation.map((item) => (
+              {progress.allocation.map((item) => (
                 <View key={item.assetClass} style={styles.assetRow}>
                   <View style={styles.assetIdentity}>
                     <CategoryIcon assetClass={item.assetClass} />
@@ -591,111 +401,111 @@ export function ProgressScreen({
         <PremiumCard>
           <SectionHeader title="Record monthly snapshot" />
           <FormTextField
-            error={errors.month}
+            error={progress.errors.month}
             label="Month"
-            onChangeText={(value) => setField("month", value)}
+            onChangeText={(value) => progress.setField("month", value)}
             placeholder="YYYY-MM"
             testID="snapshot-month-input"
-            value={formValues.month}
+            value={progress.formValues.month}
           />
           <FormTextField
-            error={errors.portfolioValue}
+            error={progress.errors.portfolioValue}
             keyboardType="decimal-pad"
             label="Portfolio value"
-            onChangeText={(value) => setField("portfolioValue", value)}
+            onChangeText={(value) => progress.setField("portfolioValue", value)}
             placeholder="1385000"
             testID="snapshot-portfolio-input"
-            value={formValues.portfolioValue}
+            value={progress.formValues.portfolioValue}
           />
           <FormTextField
-            error={errors.investedValue}
+            error={progress.errors.investedValue}
             keyboardType="decimal-pad"
             label="Invested value"
-            onChangeText={(value) => setField("investedValue", value)}
+            onChangeText={(value) => progress.setField("investedValue", value)}
             placeholder="1060000"
             testID="snapshot-invested-input"
-            value={formValues.investedValue}
+            value={progress.formValues.investedValue}
           />
           <View style={styles.fieldGrid}>
             <FormTextField
-              error={errors.equityValue}
+              error={progress.errors.equityValue}
               keyboardType="decimal-pad"
               label="Equity"
-              onChangeText={(value) => setField("equityValue", value)}
+              onChangeText={(value) => progress.setField("equityValue", value)}
               placeholder="880000"
               testID="snapshot-equity-input"
-              value={formValues.equityValue}
+              value={progress.formValues.equityValue}
             />
             <FormTextField
-              error={errors.debtValue}
+              error={progress.errors.debtValue}
               keyboardType="decimal-pad"
               label="Debt"
-              onChangeText={(value) => setField("debtValue", value)}
+              onChangeText={(value) => progress.setField("debtValue", value)}
               placeholder="320000"
               testID="snapshot-debt-input"
-              value={formValues.debtValue}
+              value={progress.formValues.debtValue}
             />
           </View>
           <View style={styles.fieldGrid}>
             <FormTextField
-              error={errors.cryptoValue}
+              error={progress.errors.cryptoValue}
               keyboardType="decimal-pad"
               label="Crypto"
-              onChangeText={(value) => setField("cryptoValue", value)}
+              onChangeText={(value) => progress.setField("cryptoValue", value)}
               placeholder="45000"
               testID="snapshot-crypto-input"
-              value={formValues.cryptoValue}
+              value={progress.formValues.cryptoValue}
             />
             <FormTextField
-              error={errors.cashValue}
+              error={progress.errors.cashValue}
               keyboardType="decimal-pad"
               label="Cash"
-              onChangeText={(value) => setField("cashValue", value)}
+              onChangeText={(value) => progress.setField("cashValue", value)}
               placeholder="140000"
               testID="snapshot-cash-input"
-              value={formValues.cashValue}
+              value={progress.formValues.cashValue}
             />
           </View>
           <View style={styles.fieldGrid}>
             <FormTextField
-              error={errors.monthlyInvestment}
+              error={progress.errors.monthlyInvestment}
               keyboardType="decimal-pad"
               label="Monthly investment"
-              onChangeText={(value) => setField("monthlyInvestment", value)}
+              onChangeText={(value) => progress.setField("monthlyInvestment", value)}
               placeholder="60000"
               testID="snapshot-investment-input"
-              value={formValues.monthlyInvestment}
+              value={progress.formValues.monthlyInvestment}
             />
             <FormTextField
-              error={errors.salary}
+              error={progress.errors.salary}
               keyboardType="decimal-pad"
               label="Salary"
-              onChangeText={(value) => setField("salary", value)}
+              onChangeText={(value) => progress.setField("salary", value)}
               placeholder="160000"
               testID="snapshot-salary-input"
-              value={formValues.salary}
+              value={progress.formValues.salary}
             />
           </View>
           <FormTextField
-            error={errors.monthlyExpense}
+            error={progress.errors.monthlyExpense}
             keyboardType="decimal-pad"
             label="Monthly expense"
-            onChangeText={(value) => setField("monthlyExpense", value)}
+            onChangeText={(value) => progress.setField("monthlyExpense", value)}
             placeholder="Optional"
             testID="snapshot-expense-input"
-            value={formValues.monthlyExpense}
+            value={progress.formValues.monthlyExpense}
           />
           <FormTextField
             label="Notes"
             multiline
-            onChangeText={(value) => setField("notes", value)}
+            onChangeText={(value) => progress.setField("notes", value)}
             placeholder="Optional month-end note"
-            value={formValues.notes}
+            value={progress.formValues.notes}
           />
           <AppButton
             title="Save Monthly Snapshot"
             testID="save-monthly-snapshot-button"
-            onPress={saveSnapshot}
+            onPress={progress.saveSnapshot}
           />
         </PremiumCard>
       </View>

--- a/src/features/progress/__tests__/useProgress.test.tsx
+++ b/src/features/progress/__tests__/useProgress.test.tsx
@@ -1,0 +1,60 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import { createPortfolioStore } from "@/src/store";
+
+import { useProgress } from "../useProgress";
+
+describe("useProgress", () => {
+  it("saves and updates monthly snapshots through the feature controller", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const { result } = renderHook(() => useProgress({ store }));
+
+    act(() => {
+      result.current.setField("month", "2026-05");
+      result.current.setField("portfolioValue", "1385000");
+      result.current.setField("investedValue", "1060000");
+      result.current.setField("equityValue", "880000");
+      result.current.setField("debtValue", "320000");
+      result.current.setField("cryptoValue", "45000");
+      result.current.setField("cashValue", "140000");
+      result.current.setField("monthlyInvestment", "60000");
+      result.current.setField("salary", "160000");
+    });
+    act(() => {
+      result.current.setField("monthlyExpense", "40000");
+    });
+    act(() => {
+      result.current.saveSnapshot();
+    });
+
+    expect(store.getState().monthlySnapshots).toHaveLength(1);
+    expect(store.getState().monthlySnapshots[0]).toMatchObject({
+      month: "2026-05",
+      portfolioValue: 1385000,
+    });
+
+    act(() => {
+      result.current.setField("month", "2026-05");
+      result.current.setField("portfolioValue", "1400000");
+      result.current.setField("investedValue", "1070000");
+      result.current.setField("equityValue", "890000");
+      result.current.setField("debtValue", "320000");
+      result.current.setField("cryptoValue", "50000");
+      result.current.setField("cashValue", "140000");
+      result.current.setField("monthlyInvestment", "70000");
+    });
+    act(() => {
+      result.current.setField("salary", "160000");
+    });
+    act(() => {
+      result.current.saveSnapshot();
+    });
+
+    expect(store.getState().monthlySnapshots).toHaveLength(1);
+    expect(store.getState().monthlySnapshots[0]).toMatchObject({
+      month: "2026-05",
+      portfolioValue: 1400000,
+    });
+  });
+});

--- a/src/features/progress/useProgress.ts
+++ b/src/features/progress/useProgress.ts
@@ -1,0 +1,221 @@
+import { useState, useSyncExternalStore } from "react";
+import type { StoreApi } from "zustand/vanilla";
+
+import {
+  buildMonthlyProgressChartData,
+  calculateAllocation,
+  calculateCashBalance,
+  calculateHoldings,
+  calculateMonthlyProgressSummaries,
+  calculatePortfolioTotal,
+} from "@/src/domain/calculations";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import type { MonthlySnapshot } from "@/src/types";
+import { createId } from "@/src/utils";
+
+function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
+  return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+}
+
+function isCurrentMonth(isoDate: string, now = new Date()) {
+  const date = new Date(isoDate);
+
+  return (
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth()
+  );
+}
+
+export function emptyProgressFormValues() {
+  const now = new Date();
+
+  return {
+    cashValue: "",
+    cryptoValue: "",
+    debtValue: "",
+    equityValue: "",
+    investedValue: "",
+    month: `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`,
+    monthlyExpense: "",
+    monthlyInvestment: "",
+    notes: "",
+    portfolioValue: "",
+    salary: "",
+  };
+}
+
+export type ProgressFormValues = ReturnType<typeof emptyProgressFormValues>;
+export type ProgressFormErrors = Partial<Record<keyof ProgressFormValues, string>>;
+
+const requiredNumberFields: Array<keyof ProgressFormValues> = [
+  "portfolioValue",
+  "investedValue",
+  "equityValue",
+  "debtValue",
+  "cryptoValue",
+  "cashValue",
+  "monthlyInvestment",
+  "salary",
+];
+
+function parseNumberField(
+  values: ProgressFormValues,
+  field: keyof ProgressFormValues,
+  errors: ProgressFormErrors,
+) {
+  const value = values[field].trim();
+  const parsedValue = value.length > 0 ? Number(value) : Number.NaN;
+
+  if (!Number.isFinite(parsedValue) || parsedValue < 0) {
+    errors[field] = "Enter a valid amount.";
+  }
+
+  return parsedValue;
+}
+
+export function validateProgressSnapshotForm(values: ProgressFormValues) {
+  const errors: ProgressFormErrors = {};
+
+  if (!/^\d{4}-\d{2}$/.test(values.month.trim())) {
+    errors.month = "Use YYYY-MM.";
+  }
+
+  const parsedValues = Object.fromEntries(
+    requiredNumberFields.map((field) => [
+      field,
+      parseNumberField(values, field, errors),
+    ]),
+  ) as Record<(typeof requiredNumberFields)[number], number>;
+  const trimmedExpense = values.monthlyExpense.trim();
+  const monthlyExpense =
+    trimmedExpense.length === 0 ? undefined : Number(trimmedExpense);
+
+  if (
+    monthlyExpense !== undefined &&
+    (!Number.isFinite(monthlyExpense) || monthlyExpense < 0)
+  ) {
+    errors.monthlyExpense = "Enter a valid amount.";
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { errors, snapshot: null };
+  }
+
+  return {
+    errors,
+    snapshot: {
+      cashValue: parsedValues.cashValue,
+      cryptoValue: parsedValues.cryptoValue,
+      debtValue: parsedValues.debtValue,
+      equityValue: parsedValues.equityValue,
+      id: createId("snapshot"),
+      investedValue: parsedValues.investedValue,
+      month: values.month.trim(),
+      monthlyExpense,
+      monthlyInvestment: parsedValues.monthlyInvestment,
+      notes: values.notes.trim() || undefined,
+      portfolioValue: parsedValues.portfolioValue,
+      salary: parsedValues.salary,
+    } satisfies MonthlySnapshot,
+  };
+}
+
+export function useProgress({
+  store = getPortfolioStore(),
+}: {
+  store?: StoreApi<PortfolioStoreState>;
+} = {}) {
+  const snapshot = usePortfolioSnapshot(store);
+  const [formValues, setFormValues] = useState(emptyProgressFormValues);
+  const [errors, setErrors] = useState<ProgressFormErrors>({});
+  const holdings = calculateHoldings({
+    assets: snapshot.assets,
+    openingPositions: snapshot.openingPositions,
+    quoteCache: snapshot.quoteCache,
+    trades: snapshot.trades,
+  });
+  const cashBalance = calculateCashBalance(snapshot.cashEntries);
+  const portfolioValue = calculatePortfolioTotal(holdings, snapshot.cashEntries);
+  const totalInvested = holdings.reduce(
+    (total, holding) => total + holding.totalInvested,
+    0,
+  );
+  const monthlyTradeInvestment = snapshot.trades
+    .filter((trade) => trade.type === "buy" && isCurrentMonth(trade.date))
+    .reduce((total, trade) => total + trade.totalValue, 0);
+  const monthlyOpeningInvestment = snapshot.openingPositions
+    .filter((position) => isCurrentMonth(position.date))
+    .reduce(
+      (total, position) =>
+        total + position.quantity * position.averageCostPrice,
+      0,
+    );
+  const monthlyInvestment = monthlyTradeInvestment + monthlyOpeningInvestment;
+  const monthlyCashAdded = snapshot.cashEntries
+    .filter((entry) => entry.type === "addition" && isCurrentMonth(entry.date))
+    .reduce((total, entry) => total + entry.amount, 0);
+  const savingsRate =
+    monthlyCashAdded === 0 ? 0 : (monthlyInvestment / monthlyCashAdded) * 100;
+  const allocation = calculateAllocation({ cashBalance, holdings });
+  const hasData = holdings.length > 0 || snapshot.cashEntries.length > 0;
+  const monthlySummaries = calculateMonthlyProgressSummaries(
+    snapshot.monthlySnapshots,
+  );
+  const latestSummary = monthlySummaries[0];
+  const chartData = buildMonthlyProgressChartData(snapshot.monthlySnapshots);
+
+  function setField(field: keyof ProgressFormValues, value: string) {
+    setFormValues((currentValues) => ({
+      ...currentValues,
+      [field]: value,
+    }));
+    setErrors((currentErrors) => ({
+      ...currentErrors,
+      [field]: undefined,
+    }));
+  }
+
+  function saveSnapshot() {
+    const result = validateProgressSnapshotForm(formValues);
+
+    if (!result.snapshot) {
+      setErrors(result.errors);
+      return;
+    }
+
+    const existingSnapshot = snapshot.monthlySnapshots.find(
+      (monthlySnapshot) => monthlySnapshot.month === result.snapshot.month,
+    );
+
+    if (existingSnapshot) {
+      store.getState().updateMonthlySnapshot({
+        ...result.snapshot,
+        id: existingSnapshot.id,
+      });
+    } else {
+      store.getState().addMonthlySnapshot(result.snapshot);
+    }
+
+    setFormValues(emptyProgressFormValues());
+    setErrors({});
+  }
+
+  return {
+    allocation,
+    cashBalance,
+    chartData,
+    errors,
+    formValues,
+    hasData,
+    latestSummary,
+    monthlyCashAdded,
+    monthlyInvestment,
+    monthlySummaries,
+    portfolioValue,
+    preferences: snapshot.preferences,
+    saveSnapshot,
+    savingsRate,
+    setField,
+    totalInvested,
+  };
+}

--- a/src/features/trades/__tests__/useAddTrade.test.tsx
+++ b/src/features/trades/__tests__/useAddTrade.test.tsx
@@ -1,0 +1,43 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import { createPortfolioStore } from "@/src/store";
+
+import { useAddTrade } from "../useAddTrade";
+
+describe("useAddTrade", () => {
+  it("reviews and confirms a manual buy trade through the feature controller", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const { result } = renderHook(() => useAddTrade({ store }));
+
+    act(() => {
+      result.current.setAssetName("Reliance Industries");
+      result.current.setSymbol("RELIANCE");
+      result.current.setTicker("RELIANCE.NS");
+      result.current.setQuantity("2");
+      result.current.setPricePerUnit("100");
+    });
+
+    act(() => {
+      result.current.handleReview();
+    });
+
+    expect(result.current.reviewTrade).toMatchObject({
+      pricePerUnit: 100,
+      quantity: 2,
+      totalValue: 200,
+      type: "buy",
+    });
+
+    await act(async () => {
+      await result.current.handleConfirm();
+    });
+
+    expect(store.getState().assets).toHaveLength(1);
+    expect(store.getState().trades).toHaveLength(1);
+    expect(store.getState().quoteCache[store.getState().assets[0].id]).toMatchObject({
+      price: 100,
+      source: "manual",
+    });
+  });
+});

--- a/src/features/trades/add-trade-form.tsx
+++ b/src/features/trades/add-trade-form.tsx
@@ -1,5 +1,3 @@
-import * as Haptics from "expo-haptics";
-import { useMemo, useState, useSyncExternalStore } from "react";
 import { Pressable, StyleSheet, View } from "react-native";
 import type { StoreApi } from "zustand/vanilla";
 
@@ -12,219 +10,19 @@ import {
   SectionHeader,
 } from "@/src/components/common";
 import { FormTextField } from "@/src/components/forms";
-import {
-  getDefaultAssetMetadata,
-  isInstrumentType,
-  isSectorType,
-} from "@/src/domain/assets";
-import { validateTradeForm } from "@/src/features/trades/tradeForm";
 import { colors, interaction, radii, spacing } from "@/src/theme";
-import type {
-  Asset,
-  ConvictionScore,
-  InstrumentType,
-  SectorType,
-  Trade,
-  TradeType,
-} from "@/src/types";
-import { createId } from "@/src/utils";
+import type { ConvictionScore, InstrumentType, SectorType } from "@/src/types";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import { useAddTrade } from "./useAddTrade";
 
 type AddTradeFormProps = {
   store?: StoreApi<PortfolioStoreState>;
 };
 
-type FieldErrors = Partial<Record<string, string>>;
-
-const manualAssetId = "__manual_asset__";
 const convictionScores: ConvictionScore[] = [1, 2, 3, 4, 5];
 
-function todayInputValue() {
-  return new Date().toISOString().slice(0, 10);
-}
-
-function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
-  return useSyncExternalStore(store.subscribe, store.getState, store.getState);
-}
-
 export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps) {
-  const snapshot = usePortfolioSnapshot(store);
-  const [type, setType] = useState<TradeType>("buy");
-  const [selectedAssetId, setSelectedAssetId] = useState("");
-  const [assetName, setAssetName] = useState("");
-  const [symbol, setSymbol] = useState("");
-  const [ticker, setTicker] = useState("");
-  const [instrumentType, setInstrumentType] = useState<InstrumentType>("stock");
-  const [sectorType, setSectorType] = useState<SectorType>("financialServices");
-  const [quoteSourceId, setQuoteSourceId] = useState("");
-  const [quantity, setQuantity] = useState("");
-  const [pricePerUnit, setPricePerUnit] = useState("");
-  const [fees, setFees] = useState("");
-  const [date, setDate] = useState(todayInputValue());
-  const [conviction, setConviction] = useState("");
-  const [notes, setNotes] = useState("");
-  const [errors, setErrors] = useState<FieldErrors>({});
-  const [reviewTrade, setReviewTrade] = useState<Trade | undefined>();
-  const [reviewAsset, setReviewAsset] = useState<Asset | undefined>();
-  const [successMessage, setSuccessMessage] = useState("");
-
-  const selectedAsset = useMemo(
-    () => snapshot.assets.find((asset) => asset.id === selectedAssetId),
-    [selectedAssetId, snapshot.assets],
-  );
-  const isManualAsset = !selectedAsset;
-
-  function resetReview() {
-    setReviewTrade(undefined);
-    setReviewAsset(undefined);
-    setSuccessMessage("");
-  }
-
-  function updateType(nextType: TradeType) {
-    setType(nextType);
-    resetReview();
-  }
-
-  function selectAsset(asset: Asset) {
-    const quote = snapshot.quoteCache[asset.id];
-
-    setSelectedAssetId(asset.id);
-    setAssetName(asset.name);
-    setInstrumentType(
-      asset.instrumentType ?? getDefaultAssetMetadata(asset.assetClass).instrumentType,
-    );
-    setQuoteSourceId(asset.quoteSourceId ?? asset.ticker);
-    setSectorType(
-      asset.sectorType ?? getDefaultAssetMetadata(asset.assetClass).sectorType,
-    );
-    setSymbol(asset.symbol);
-    setTicker(asset.ticker);
-    if (quote) {
-      setPricePerUnit(quote.price.toString());
-    }
-    resetReview();
-  }
-
-  function buildManualAsset(): Asset {
-    const trimmedTicker = ticker.trim();
-
-    return {
-      assetClass: "stock",
-      currency: "INR",
-      exchange: "NSE",
-      id: createId("asset"),
-      instrumentType,
-      name: assetName.trim(),
-      quoteSourceId: quoteSourceId.trim() || trimmedTicker,
-      sectorType,
-      symbol: symbol.trim().toUpperCase(),
-      ticker: trimmedTicker.toUpperCase(),
-    };
-  }
-
-  function validateManualAsset() {
-    const nextErrors: FieldErrors = {};
-
-    if (isManualAsset && assetName.trim().length === 0) {
-      nextErrors.assetName = "Asset name is required.";
-    }
-
-    if (isManualAsset && symbol.trim().length === 0) {
-      nextErrors.symbol = "Symbol is required.";
-    }
-
-    if (isManualAsset && ticker.trim().length === 0) {
-      nextErrors.ticker = "Ticker is required.";
-    }
-
-    if (isManualAsset && !isInstrumentType(instrumentType)) {
-      nextErrors.instrumentType = "Instrument type is not supported.";
-    }
-
-    if (isManualAsset && !isSectorType(sectorType)) {
-      nextErrors.sectorType = "Sector type is not supported.";
-    }
-
-    if (type === "sell" && isManualAsset) {
-      nextErrors.assetName = "Select an existing holding to sell.";
-    }
-
-    return nextErrors;
-  }
-
-  function handleReview() {
-    resetReview();
-    const manualErrors = validateManualAsset();
-    const formAssetId = selectedAsset?.id ?? manualAssetId;
-    const result = validateTradeForm(
-      {
-        assetId: formAssetId,
-        conviction,
-        date,
-        pricePerUnit,
-        quantity,
-        type,
-      },
-      snapshot.trades,
-    );
-
-    if (!result.isValid || Object.keys(manualErrors).length > 0) {
-      setErrors({
-        ...manualErrors,
-        ...result.isValid ? {} : result.errors,
-      });
-      return;
-    }
-
-    const asset = selectedAsset ?? buildManualAsset();
-    const feeValue = fees.trim().length > 0 ? Number(fees) : 0;
-
-    if (!Number.isFinite(feeValue) || feeValue < 0) {
-      setErrors({ fees: "Fees must be zero or greater." });
-      return;
-    }
-
-    const grossValue = result.value.quantity * result.value.pricePerUnit;
-    const totalValue =
-      result.value.type === "buy" ? grossValue + feeValue : grossValue - feeValue;
-
-    setErrors({});
-    setReviewAsset(asset);
-    setReviewTrade({
-      assetId: asset.id,
-      conviction: result.value.conviction as ConvictionScore | undefined,
-      date: result.value.date,
-      fees: feeValue || undefined,
-      id: createId("trade"),
-      notes: notes.trim() || undefined,
-      pricePerUnit: result.value.pricePerUnit,
-      quantity: result.value.quantity,
-      totalValue,
-      type: result.value.type,
-    });
-  }
-
-  async function handleConfirm() {
-    if (!reviewTrade || !reviewAsset) {
-      return;
-    }
-
-    if (!selectedAsset) {
-      store.getState().addAsset(reviewAsset);
-    }
-
-    store.getState().addTrade(reviewTrade);
-    store.getState().upsertQuote({
-      asOf: new Date().toISOString(),
-      assetId: reviewAsset.id,
-      currency: "INR",
-      price: reviewTrade.pricePerUnit,
-      source: "manual",
-    });
-    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-    setSuccessMessage("Holding saved.");
-    setReviewTrade(undefined);
-  }
+  const trade = useAddTrade({ store });
 
   return (
     <ScreenContainer scroll testID="add-trade-screen">
@@ -240,15 +38,15 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
           <Pressable
             accessibilityRole="button"
             key={tradeType}
-            onPress={() => updateType(tradeType)}
+            onPress={() => trade.updateType(tradeType)}
             style={({ pressed }) => [
               styles.segment,
-              type === tradeType && styles.segmentActive,
+              trade.type === tradeType && styles.segmentActive,
               pressed && styles.pressed,
             ]}
           >
             <AppText
-              color={type === tradeType ? "inverse" : "secondary"}
+              color={trade.type === tradeType ? "inverse" : "secondary"}
               weight="bold"
             >
               {tradeType === "buy" ? "Buy" : "Sell"}
@@ -257,19 +55,19 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
         ))}
       </View>
 
-      {snapshot.assets.length > 0 ? (
+      {trade.snapshot.assets.length > 0 ? (
         <PremiumCard>
           <AppText color="secondary" variant="caption" weight="medium">
             Existing assets
           </AppText>
           <View style={styles.assetGrid}>
-            {snapshot.assets.map((asset) => (
+            {trade.snapshot.assets.map((asset) => (
               <Pressable
                 key={asset.id}
-                onPress={() => selectAsset(asset)}
+                onPress={() => trade.selectAsset(asset)}
                 style={({ pressed }) => [
                   styles.assetChip,
-                  selectedAssetId === asset.id && styles.assetChipActive,
+                  trade.selectedAssetId === asset.id && styles.assetChipActive,
                   pressed && styles.pressed,
                 ]}
               >
@@ -286,87 +84,81 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
       <PremiumCard>
         <SectionHeader title="Asset" />
         <FormTextField
-          error={errors.assetName}
+          error={trade.errors.assetName}
           label="Asset name"
           onChangeText={(value) => {
-            setAssetName(value);
-            setSelectedAssetId("");
-            resetReview();
+            trade.setAssetName(value);
+            trade.clearSelectedAsset();
           }}
           placeholder="Reliance Industries"
           testID="asset-input"
-          value={assetName}
+          value={trade.assetName}
         />
         <View style={styles.row}>
           <View style={styles.flex}>
             <FormTextField
-              error={errors.symbol}
+              error={trade.errors.symbol}
               label="Symbol"
               onChangeText={(value) => {
-                setSymbol(value);
-                setSelectedAssetId("");
-                resetReview();
+                trade.setSymbol(value);
+                trade.clearSelectedAsset();
               }}
               placeholder="RELIANCE"
               testID="symbol-input"
-              value={symbol}
+              value={trade.symbol}
             />
           </View>
           <View style={styles.flex}>
             <FormTextField
-              error={errors.ticker}
+              error={trade.errors.ticker}
               label="Ticker"
               onChangeText={(value) => {
-                setTicker(value);
-                setSelectedAssetId("");
-                resetReview();
+                trade.setTicker(value);
+                trade.clearSelectedAsset();
               }}
               placeholder="RELIANCE.NS"
               testID="ticker-input"
-              value={ticker}
+              value={trade.ticker}
             />
           </View>
         </View>
         <View style={styles.row}>
           <View style={styles.flex}>
             <FormTextField
-              error={errors.instrumentType}
+              error={trade.errors.instrumentType}
               label="Instrument type"
               onChangeText={(value) => {
-                setInstrumentType(value as InstrumentType);
-                setSelectedAssetId("");
-                resetReview();
+                trade.setInstrumentType(value as InstrumentType);
+                trade.clearSelectedAsset();
               }}
               placeholder="stock"
               testID="instrument-type-input"
-              value={instrumentType}
+              value={trade.instrumentType}
             />
           </View>
           <View style={styles.flex}>
             <FormTextField
-              error={errors.sectorType}
+              error={trade.errors.sectorType}
               label="Sector type"
               onChangeText={(value) => {
-                setSectorType(value as SectorType);
-                setSelectedAssetId("");
-                resetReview();
+                trade.setSectorType(value as SectorType);
+                trade.clearSelectedAsset();
               }}
               placeholder="financialServices"
               testID="sector-type-input"
-              value={sectorType}
+              value={trade.sectorType}
             />
           </View>
         </View>
         <FormTextField
           label="Quote source ID"
           onChangeText={(value) => {
-            setQuoteSourceId(value);
-            setSelectedAssetId("");
-            resetReview();
+            trade.setQuoteSourceId(value);
+            trade.clearSelectedAsset();
           }}
           placeholder="RELIANCE.NS"
           testID="quote-source-id-input"
-          value={quoteSourceId}
+          value={trade.quoteSourceId}
         />
       </PremiumCard>
 
@@ -375,57 +167,53 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
         <View style={styles.row}>
           <View style={styles.flex}>
             <FormTextField
-              error={errors.quantity}
+              error={trade.errors.quantity}
               keyboardType="decimal-pad"
               label="Quantity"
               onChangeText={(value) => {
-                setQuantity(value);
-                resetReview();
+                trade.setQuantity(value);
               }}
               placeholder="2"
               testID="quantity-input"
-              value={quantity}
+              value={trade.quantity}
             />
           </View>
           <View style={styles.flex}>
             <FormTextField
-              error={errors.pricePerUnit}
+              error={trade.errors.pricePerUnit}
               keyboardType="decimal-pad"
               label="Price per unit"
               onChangeText={(value) => {
-                setPricePerUnit(value);
-                resetReview();
+                trade.setPricePerUnit(value);
               }}
               placeholder="100"
               testID="price-input"
-              value={pricePerUnit}
+              value={trade.pricePerUnit}
             />
           </View>
         </View>
         <View style={styles.row}>
           <View style={styles.flex}>
             <FormTextField
-              error={errors.fees}
+              error={trade.errors.fees}
               keyboardType="decimal-pad"
               label="Fees"
               onChangeText={(value) => {
-                setFees(value);
-                resetReview();
+                trade.setFees(value);
               }}
               placeholder="0"
-              value={fees}
+              value={trade.fees}
             />
           </View>
           <View style={styles.flex}>
             <FormTextField
-              error={errors.date}
+              error={trade.errors.date}
               label="Trade date"
               onChangeText={(value) => {
-                setDate(value);
-                resetReview();
+                trade.setDate(value);
               }}
               placeholder="YYYY-MM-DD"
-              value={date}
+              value={trade.date}
             />
           </View>
         </View>
@@ -436,7 +224,7 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
           <View style={styles.convictionRow}>
             {convictionScores.map((score) => {
               const scoreValue = score.toString();
-              const isSelected = conviction === scoreValue;
+              const isSelected = trade.conviction === scoreValue;
 
               return (
                 <Pressable
@@ -445,8 +233,7 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
                   accessibilityState={{ selected: isSelected }}
                   key={score}
                   onPress={() => {
-                    setConviction(isSelected ? "" : scoreValue);
-                    resetReview();
+                    trade.setConviction(isSelected ? "" : scoreValue);
                   }}
                   style={({ pressed }) => [
                     styles.convictionChip,
@@ -465,9 +252,9 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
               );
             })}
           </View>
-          {errors.conviction ? (
+          {trade.errors.conviction ? (
             <AppText selectable style={styles.errorText} variant="caption">
-              {errors.conviction}
+              {trade.errors.conviction}
             </AppText>
           ) : null}
         </View>
@@ -475,32 +262,31 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
           label="Note"
           multiline
           onChangeText={(value) => {
-            setNotes(value);
-            resetReview();
+            trade.setNotes(value);
           }}
           placeholder="Optional note"
-          value={notes}
+          value={trade.notes}
         />
       </PremiumCard>
 
-      {reviewTrade && reviewAsset ? (
+      {trade.reviewTrade && trade.reviewAsset ? (
         <PremiumCard elevated>
           <AppText variant="body" weight="bold">
             Derived preview
           </AppText>
           <AppText color="secondary">
-            {reviewAsset.symbol} · {reviewTrade.quantity} units @ ₹
-            {reviewTrade.pricePerUnit.toFixed(2)}
+            {trade.reviewAsset.symbol} · {trade.reviewTrade.quantity} units @ ₹
+            {trade.reviewTrade.pricePerUnit.toFixed(2)}
           </AppText>
           <AppText selectable weight="bold">
-            Total: ₹{reviewTrade.totalValue.toFixed(2)}
+            Total: ₹{trade.reviewTrade.totalValue.toFixed(2)}
           </AppText>
         </PremiumCard>
       ) : null}
 
-      {successMessage ? (
+      {trade.successMessage ? (
         <AppText selectable style={styles.successText}>
-          {successMessage}
+          {trade.successMessage}
         </AppText>
       ) : null}
 
@@ -508,13 +294,13 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
         <AppButton
           title="Review Holding"
           testID="review-trade-button"
-          onPress={handleReview}
+          onPress={trade.handleReview}
         />
         <AppButton
-          disabled={!reviewTrade}
+          disabled={!trade.reviewTrade}
           testID="save-trade-button"
           title="Save Holding"
-          onPress={handleConfirm}
+          onPress={trade.handleConfirm}
           variant="secondary"
         />
       </View>

--- a/src/features/trades/useAddTrade.ts
+++ b/src/features/trades/useAddTrade.ts
@@ -1,0 +1,261 @@
+import * as Haptics from "expo-haptics";
+import { useMemo, useState, useSyncExternalStore } from "react";
+import type { StoreApi } from "zustand/vanilla";
+
+import {
+  getDefaultAssetMetadata,
+  isInstrumentType,
+  isSectorType,
+} from "@/src/domain/assets";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import type {
+  Asset,
+  ConvictionScore,
+  InstrumentType,
+  SectorType,
+  Trade,
+  TradeType,
+} from "@/src/types";
+import { createId } from "@/src/utils";
+
+import { validateTradeForm } from "./tradeForm";
+
+type FieldErrors = Partial<Record<string, string>>;
+
+const manualAssetId = "__manual_asset__";
+
+function todayInputValue() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
+  return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+}
+
+export function useAddTrade({
+  store = getPortfolioStore(),
+}: {
+  store?: StoreApi<PortfolioStoreState>;
+} = {}) {
+  const snapshot = usePortfolioSnapshot(store);
+  const [type, setType] = useState<TradeType>("buy");
+  const [selectedAssetId, setSelectedAssetId] = useState("");
+  const [assetName, setAssetName] = useState("");
+  const [symbol, setSymbol] = useState("");
+  const [ticker, setTicker] = useState("");
+  const [instrumentType, setInstrumentType] = useState<InstrumentType>("stock");
+  const [sectorType, setSectorType] = useState<SectorType>("financialServices");
+  const [quoteSourceId, setQuoteSourceId] = useState("");
+  const [quantity, setQuantity] = useState("");
+  const [pricePerUnit, setPricePerUnit] = useState("");
+  const [fees, setFees] = useState("");
+  const [date, setDate] = useState(todayInputValue());
+  const [conviction, setConviction] = useState("");
+  const [notes, setNotes] = useState("");
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [reviewTrade, setReviewTrade] = useState<Trade | undefined>();
+  const [reviewAsset, setReviewAsset] = useState<Asset | undefined>();
+  const [successMessage, setSuccessMessage] = useState("");
+
+  const selectedAsset = useMemo(
+    () => snapshot.assets.find((asset) => asset.id === selectedAssetId),
+    [selectedAssetId, snapshot.assets],
+  );
+  const isManualAsset = !selectedAsset;
+
+  function resetReview() {
+    setReviewTrade(undefined);
+    setReviewAsset(undefined);
+    setSuccessMessage("");
+  }
+
+  function updateType(nextType: TradeType) {
+    setType(nextType);
+    resetReview();
+  }
+
+  function selectAsset(asset: Asset) {
+    const quote = snapshot.quoteCache[asset.id];
+
+    setSelectedAssetId(asset.id);
+    setAssetName(asset.name);
+    setInstrumentType(
+      asset.instrumentType ?? getDefaultAssetMetadata(asset.assetClass).instrumentType,
+    );
+    setQuoteSourceId(asset.quoteSourceId ?? asset.ticker);
+    setSectorType(
+      asset.sectorType ?? getDefaultAssetMetadata(asset.assetClass).sectorType,
+    );
+    setSymbol(asset.symbol);
+    setTicker(asset.ticker);
+    if (quote) {
+      setPricePerUnit(quote.price.toString());
+    }
+    resetReview();
+  }
+
+  function clearSelectedAsset() {
+    setSelectedAssetId("");
+    resetReview();
+  }
+
+  function buildManualAsset(): Asset {
+    const trimmedTicker = ticker.trim();
+
+    return {
+      assetClass: "stock",
+      currency: "INR",
+      exchange: "NSE",
+      id: createId("asset"),
+      instrumentType,
+      name: assetName.trim(),
+      quoteSourceId: quoteSourceId.trim() || trimmedTicker,
+      sectorType,
+      symbol: symbol.trim().toUpperCase(),
+      ticker: trimmedTicker.toUpperCase(),
+    };
+  }
+
+  function validateManualAsset() {
+    const nextErrors: FieldErrors = {};
+
+    if (isManualAsset && assetName.trim().length === 0) {
+      nextErrors.assetName = "Asset name is required.";
+    }
+
+    if (isManualAsset && symbol.trim().length === 0) {
+      nextErrors.symbol = "Symbol is required.";
+    }
+
+    if (isManualAsset && ticker.trim().length === 0) {
+      nextErrors.ticker = "Ticker is required.";
+    }
+
+    if (isManualAsset && !isInstrumentType(instrumentType)) {
+      nextErrors.instrumentType = "Instrument type is not supported.";
+    }
+
+    if (isManualAsset && !isSectorType(sectorType)) {
+      nextErrors.sectorType = "Sector type is not supported.";
+    }
+
+    if (type === "sell" && isManualAsset) {
+      nextErrors.assetName = "Select an existing holding to sell.";
+    }
+
+    return nextErrors;
+  }
+
+  function handleReview() {
+    resetReview();
+    const manualErrors = validateManualAsset();
+    const formAssetId = selectedAsset?.id ?? manualAssetId;
+    const result = validateTradeForm(
+      {
+        assetId: formAssetId,
+        conviction,
+        date,
+        pricePerUnit,
+        quantity,
+        type,
+      },
+      snapshot.trades,
+    );
+
+    if (!result.isValid || Object.keys(manualErrors).length > 0) {
+      setErrors({
+        ...manualErrors,
+        ...result.isValid ? {} : result.errors,
+      });
+      return;
+    }
+
+    const asset = selectedAsset ?? buildManualAsset();
+    const feeValue = fees.trim().length > 0 ? Number(fees) : 0;
+
+    if (!Number.isFinite(feeValue) || feeValue < 0) {
+      setErrors({ fees: "Fees must be zero or greater." });
+      return;
+    }
+
+    const grossValue = result.value.quantity * result.value.pricePerUnit;
+    const totalValue =
+      result.value.type === "buy" ? grossValue + feeValue : grossValue - feeValue;
+
+    setErrors({});
+    setReviewAsset(asset);
+    setReviewTrade({
+      assetId: asset.id,
+      conviction: result.value.conviction as ConvictionScore | undefined,
+      date: result.value.date,
+      fees: feeValue || undefined,
+      id: createId("trade"),
+      notes: notes.trim() || undefined,
+      pricePerUnit: result.value.pricePerUnit,
+      quantity: result.value.quantity,
+      totalValue,
+      type: result.value.type,
+    });
+  }
+
+  async function handleConfirm() {
+    if (!reviewTrade || !reviewAsset) {
+      return;
+    }
+
+    if (!selectedAsset) {
+      store.getState().addAsset(reviewAsset);
+    }
+
+    store.getState().addTrade(reviewTrade);
+    store.getState().upsertQuote({
+      asOf: new Date().toISOString(),
+      assetId: reviewAsset.id,
+      currency: "INR",
+      price: reviewTrade.pricePerUnit,
+      source: "manual",
+    });
+    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    setSuccessMessage("Holding saved.");
+    setReviewTrade(undefined);
+  }
+
+  return {
+    assetName,
+    clearSelectedAsset,
+    conviction,
+    date,
+    errors,
+    fees,
+    handleConfirm,
+    handleReview,
+    instrumentType,
+    pricePerUnit,
+    quantity,
+    quoteSourceId,
+    reviewAsset,
+    reviewTrade,
+    sectorType,
+    selectAsset,
+    selectedAssetId,
+    setAssetName,
+    setConviction,
+    setDate,
+    setFees,
+    setInstrumentType,
+    setNotes,
+    setPricePerUnit,
+    setQuantity,
+    setQuoteSourceId,
+    setSectorType,
+    setSymbol,
+    setTicker,
+    snapshot,
+    successMessage,
+    symbol,
+    ticker,
+    type,
+    updateType,
+    notes,
+  };
+}


### PR DESCRIPTION
## Summary
- Extracted Add Holding orchestration into a dedicated useAddOpeningPosition hook so the screen is primarily presentational.
- Extracted Add Trade orchestration into useAddTrade, including validation, review, quote cache persistence, and store writes.
- Extracted Monthly Progress state and derived metrics into useProgress, keeping snapshot form handling out of the screen.
- Added focused hook tests for the new controller boundaries.

## Verification
- npm run typecheck passed.
- npm test passed: 36 suites, 149 tests.
- npm run doctor passed: 17/17 checks.
- git diff --check passed.
- Architecture import scans returned no matches for forbidden domain/component dependency directions.
- Backend/auth/cloud scope scan found only expected local UI/router text and no server framework usage.

Closes #108