### PR TITLE
Polish Android design interactions

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -76,6 +76,9 @@ Rules:
 
 - Green is an accent, not decoration.
 - Use green to signal brand, progress, selected state, and clear positive outcomes.
+- In code, use the semantic `primary` token for actions, active tabs, and
+  selected states; use the semantic `profit` token for financial gains. These
+  currently share `#34C759`, but they must not be treated as interchangeable.
 - Do not flood dashboards with green.
 - Avoid saturated gradient cards unless an issue explicitly asks for them.
 - Use `Positive` and `Negative` only for financial state, not generic ornament.

--- a/app.json
+++ b/app.json
@@ -24,7 +24,7 @@
         "backgroundColor": "#1C1B1F"
       },
       "edgeToEdgeEnabled": true,
-      "predictiveBackGestureEnabled": false
+      "predictiveBackGestureEnabled": true
     },
     "plugins": [
       "expo-router",

--- a/docs/superpowers/plans/2026-06-17-issue-133-design-tokens-android-polish.md
+++ b/docs/superpowers/plans/2026-06-17-issue-133-design-tokens-android-polish.md
@@ -1,0 +1,91 @@
+# Issue 133 Design Tokens and Android Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align CogVest's shared V1 UI foundation with DESIGN.md by fixing green tokens, Android touch targets, pressed-state feedback, and predictive back configuration.
+
+**Architecture:** Keep this as a shared-layer change. Theme tokens live in `src/theme/index.ts`; common press behavior should be reusable from `src/components/common`; screen-specific chips should adopt the shared interaction/touch constants without changing screen business logic.
+
+**Tech Stack:** React Native `Pressable`, Expo app config, TypeScript, Jest / React Native Testing Library.
+
+---
+
+### Task 1: Token Contract
+
+**Files:**
+- Modify: `src/theme/index.ts`
+- Modify: `src/theme/__tests__/theme.test.ts`
+- Modify: `DESIGN.md`
+
+- [x] Update `colors.primary` to `#34C759` and `colors.deepGreen` to `#248A3D`, matching DESIGN.md.
+- [x] Keep `colors.profit` as a separate semantic token even though it currently shares the same hex. This preserves the rule that CTA/selected state and financial gains are conceptually different.
+- [x] Add interaction tokens for Android touch behavior:
+  - `minimumTouchTarget: 48`
+  - `stateLayerOpacity: 0.12`
+  - `rippleColor: "rgba(255,255,255,0.12)"`
+  - `primaryRippleColor: "rgba(0,0,0,0.18)"`
+- [x] Update `theme.test.ts` to assert the final token values.
+- [x] Update DESIGN.md wording to state the semantic distinction: Primary Green and Positive currently share `#34C759`, but agents must use `colors.primary` for actions/selected states and `colors.profit` for financial gains.
+
+### Task 2: Shared Pressable Helpers
+
+**Files:**
+- Create: `src/components/common/pressableStyles.ts`
+- Modify: `src/components/common/index.ts`
+- Modify: `src/components/common/__tests__/commonComponents.test.tsx`
+
+- [x] Create `pressableStyles.ts` with:
+  - `androidRipple(color = interaction.rippleColor)`
+  - `minimumTouchTargetStyle`
+  - `getPressedStateStyle({ disabled, pressed })`
+- [x] Keep opacity fallback for non-disabled pressed state, but centralize it.
+- [x] Test helper output directly so screens can rely on the shared contract.
+- [x] Export helpers from `src/components/common/index.ts`.
+
+### Task 3: Common Components
+
+**Files:**
+- Modify: `src/components/common/AppButton.tsx`
+- Modify: `src/components/common/Premium.tsx`
+- Modify: `src/components/common/__tests__/commonComponents.test.tsx`
+
+- [x] Update `AppButton` to use shared pressed-state helper and `android_ripple`.
+- [x] Update `IconButton` to be 48x48 with Android ripple.
+- [x] Update `GroupedListRow` pressables to use Android ripple and shared pressed-state helper.
+- [x] Add tests that `IconButton` renders a 48dp touch target.
+
+### Task 4: Screen-Specific Chips
+
+**Files:**
+- Modify: `src/features/progress/ProgressScreen.tsx`
+- Modify: `src/features/holdings/HoldingsScreen.tsx`
+- Modify: `src/features/progress/__tests__/ProgressScreen.test.tsx`
+- Modify: `src/features/holdings/__tests__/HoldingsScreen.test.tsx`
+
+- [x] Add Android ripple to Progress chart range chips.
+- [x] Make Progress range chips at least 48dp tall.
+- [x] Add Android ripple to Holdings filter chips.
+- [x] Make Holdings filter chips at least 48dp tall.
+- [x] Preserve existing testIDs and behavior.
+- [x] Verify existing screen tests still assert the chip controls render and remain usable.
+
+### Task 5: Predictive Back
+
+**Files:**
+- Modify: `app.json`
+- Modify: `src/__tests__/androidIdentity.test.ts`
+
+- [x] Set `expo.android.predictiveBackGestureEnabled` to `true`.
+- [x] Add a test assertion documenting that predictive back is enabled for Android-first V1 behavior.
+
+### Task 6: Verification and PR
+
+**Commands:**
+- `npm run typecheck`
+- `npm test`
+- `npm run doctor`
+- `npm run android:smoke`
+
+- [x] If emulator is unavailable, record the exact `adb`/smoke output instead of claiming emulator verification.
+- [ ] Commit with a focused message.
+- [ ] Push branch and open a PR with `Closes #133`.

--- a/docs/superpowers/plans/2026-06-17-issue-133-design-tokens-android-polish.md
+++ b/docs/superpowers/plans/2026-06-17-issue-133-design-tokens-android-polish.md
@@ -87,5 +87,5 @@
 - `npm run android:smoke`
 
 - [x] If emulator is unavailable, record the exact `adb`/smoke output instead of claiming emulator verification.
-- [ ] Commit with a focused message.
-- [ ] Push branch and open a PR with `Closes #133`.
+- [x] Commit with a focused message.
+- [x] Push branch and open a PR with `Closes #133`.

--- a/src/__tests__/androidIdentity.test.ts
+++ b/src/__tests__/androidIdentity.test.ts
@@ -16,6 +16,7 @@ describe("Android app identity", () => {
     expect(expo.android.package).toBe("com.abdulshaikh.cogvest");
     expect(expo.android.versionCode).toBeGreaterThanOrEqual(1);
     expect(Number.isInteger(expo.android.versionCode)).toBe(true);
+    expect(expo.android.predictiveBackGestureEnabled).toBe(true);
   });
 
   it("links the Expo project for EAS builds", () => {

--- a/src/components/common/AppButton.tsx
+++ b/src/components/common/AppButton.tsx
@@ -10,6 +10,7 @@ import {
 import { colors, interaction, radii, spacing } from "@/src/theme";
 
 import { AppText } from "./AppText";
+import { androidRipple, getPressedStateStyle } from "./pressableStyles";
 
 type ButtonVariant = "primary" | "secondary" | "ghost";
 
@@ -27,15 +28,7 @@ export function getButtonInteractionStyle({
   disabled?: boolean;
   pressed: boolean;
 }) {
-  if (disabled) {
-    return styles.disabled;
-  }
-
-  if (pressed) {
-    return styles.pressed;
-  }
-
-  return undefined;
+  return getPressedStateStyle({ disabled, pressed });
 }
 
 export function AppButton({
@@ -53,6 +46,11 @@ export function AppButton({
   return (
     <Pressable
       {...props}
+      android_ripple={androidRipple(
+        variant === "primary"
+          ? interaction.primaryRippleColor
+          : interaction.rippleColor,
+      )}
       disabled={disabled}
       style={({ pressed }) => [
         styles.base,
@@ -73,21 +71,15 @@ const styles = StyleSheet.create({
     alignItems: "center",
     borderRadius: radii.button,
     justifyContent: "center",
-    minHeight: 48,
+    minHeight: interaction.minimumTouchTarget,
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.cardInner,
-  },
-  disabled: {
-    opacity: interaction.disabledOpacity,
   },
   ghost: {
     backgroundColor: "transparent",
   },
   primary: {
     backgroundColor: colors.primary,
-  },
-  pressed: {
-    opacity: interaction.pressedOpacity,
   },
   secondary: {
     backgroundColor: colors.surface.elevated,

--- a/src/components/common/Premium.tsx
+++ b/src/components/common/Premium.tsx
@@ -13,6 +13,11 @@ import type { AssetClass } from "@/src/types";
 
 import { AppText } from "./AppText";
 import { MaskedValue } from "./MaskedValue";
+import {
+  androidRipple,
+  getPressedStateStyle,
+  minimumTouchTargetStyle,
+} from "./pressableStyles";
 
 type PremiumCardProps = {
   children: ReactNode;
@@ -106,8 +111,13 @@ export function IconButton({
     <Pressable
       accessibilityLabel={accessibilityLabel}
       accessibilityRole="button"
+      android_ripple={androidRipple()}
       onPress={onPress}
-      style={({ pressed }) => [styles.iconButton, pressed && styles.pressed]}
+      style={({ pressed }) => [
+        styles.iconButton,
+        minimumTouchTargetStyle,
+        getPressedStateStyle({ pressed }),
+      ]}
       testID={testID}
     >
       <Ionicons color={colors.text.primary} name={icon} size={20} />
@@ -251,8 +261,12 @@ export function GroupedListRow({
     return (
       <Pressable
         accessibilityRole="button"
+        android_ripple={androidRipple()}
         onPress={onPress}
-        style={({ pressed }) => [styles.groupedRow, pressed && styles.pressed]}
+        style={({ pressed }) => [
+          styles.groupedRow,
+          getPressedStateStyle({ pressed }),
+        ]}
         testID={testID}
       >
         {content}
@@ -311,9 +325,9 @@ const styles = StyleSheet.create({
     alignItems: "center",
     backgroundColor: colors.surface.elevated,
     borderRadius: 14,
-    height: 42,
+    height: interaction.minimumTouchTarget,
     justifyContent: "center",
-    width: 42,
+    width: interaction.minimumTouchTarget,
   },
   metricCell: {
     flex: 1,
@@ -343,9 +357,6 @@ const styles = StyleSheet.create({
   },
   positiveText: {
     color: colors.profit,
-  },
-  pressed: {
-    opacity: interaction.pressedOpacity,
   },
   secondaryText: {
     color: colors.text.secondary,

--- a/src/components/common/__tests__/commonComponents.test.tsx
+++ b/src/components/common/__tests__/commonComponents.test.tsx
@@ -4,7 +4,11 @@ import {
   AppButton,
   AppText,
   EmptyState,
+  IconButton,
   MaskedValue,
+  androidRipple,
+  getPressedStateStyle,
+  minimumTouchTargetStyle,
 } from "@/src/components/common";
 import { getButtonInteractionStyle } from "@/src/components/common/AppButton";
 import { colors, interaction } from "@/src/theme";
@@ -24,6 +28,9 @@ describe("common UI primitives", () => {
     expect(
       getButtonInteractionStyle({ disabled: false, pressed: true }),
     ).toEqual({ opacity: interaction.pressedOpacity });
+    expect(getPressedStateStyle({ disabled: false, pressed: true })).toEqual({
+      opacity: interaction.pressedOpacity,
+    });
     expect(
       getButtonInteractionStyle({ disabled: false, pressed: false }),
     ).toBeUndefined();
@@ -44,6 +51,35 @@ describe("common UI primitives", () => {
     expect(
       getButtonInteractionStyle({ disabled: true, pressed: true }),
     ).toEqual({ opacity: interaction.disabledOpacity });
+  });
+
+  it("exposes Android ripple and 48dp touch target helpers", () => {
+    expect(androidRipple()).toEqual({
+      borderless: false,
+      color: interaction.rippleColor,
+      foreground: true,
+    });
+    expect(minimumTouchTargetStyle).toEqual({
+      minHeight: interaction.minimumTouchTarget,
+      minWidth: interaction.minimumTouchTarget,
+    });
+  });
+
+  it("renders icon buttons with the minimum Android touch target", () => {
+    const { getByTestId } = render(
+      <IconButton
+        accessibilityLabel="Mask values"
+        icon="eye-outline"
+        testID="mask-toggle"
+      />,
+    );
+
+    expect(getByTestId("mask-toggle")).toHaveStyle({
+      height: interaction.minimumTouchTarget,
+      minHeight: interaction.minimumTouchTarget,
+      minWidth: interaction.minimumTouchTarget,
+      width: interaction.minimumTouchTarget,
+    });
   });
 
   it("masks INR wealth values without masking percentages", () => {

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -15,4 +15,9 @@ export {
   SectionHeader,
 } from "./Premium";
 export { PlaceholderScreen } from "./PlaceholderScreen";
+export {
+  androidRipple,
+  getPressedStateStyle,
+  minimumTouchTargetStyle,
+} from "./pressableStyles";
 export { ScreenContainer } from "./ScreenContainer";

--- a/src/components/common/pressableStyles.ts
+++ b/src/components/common/pressableStyles.ts
@@ -1,0 +1,40 @@
+import type { PressableProps, ViewStyle } from "react-native";
+
+import { interaction } from "@/src/theme";
+
+export function androidRipple(
+  color: string = interaction.rippleColor,
+): PressableProps["android_ripple"] {
+  return {
+    borderless: false,
+    color,
+    foreground: true,
+  };
+}
+
+export const minimumTouchTargetStyle: ViewStyle = {
+  minHeight: interaction.minimumTouchTarget,
+  minWidth: interaction.minimumTouchTarget,
+};
+
+export function getPressedStateStyle({
+  disabled,
+  pressed,
+}: {
+  disabled?: boolean;
+  pressed: boolean;
+}) {
+  if (disabled) {
+    return {
+      opacity: interaction.disabledOpacity,
+    };
+  }
+
+  if (pressed) {
+    return {
+      opacity: interaction.pressedOpacity,
+    };
+  }
+
+  return undefined;
+}

--- a/src/features/holdings/HoldingsScreen.tsx
+++ b/src/features/holdings/HoldingsScreen.tsx
@@ -12,12 +12,15 @@ import {
   PremiumCard,
   ScreenContainer,
   ScreenHeader,
+  androidRipple,
+  getPressedStateStyle,
+  minimumTouchTargetStyle,
 } from "@/src/components/common";
 import { FormTextField } from "@/src/components/forms";
 import { formatCompactINR, formatDate } from "@/src/domain/formatters";
 import type { RefreshQuotesInput, QuoteRefreshResult } from "@/src/services/quotes";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
-import { colors, spacing } from "@/src/theme";
+import { colors, interaction, spacing } from "@/src/theme";
 import type { AssetClass, Holding } from "@/src/types";
 
 import { useHoldings } from "./useHoldings";
@@ -189,11 +192,18 @@ export function HoldingsScreen({
           {filters.map((filter) => (
             <Pressable
               accessibilityRole="button"
+              android_ripple={androidRipple(
+                selectedFilter === filter.key
+                  ? interaction.primaryRippleColor
+                  : interaction.rippleColor,
+              )}
               key={filter.key}
               onPress={() => setSelectedFilter(filter.key)}
-              style={[
+              style={({ pressed }) => [
                 styles.filterChip,
+                minimumTouchTargetStyle,
                 selectedFilter === filter.key && styles.filterChipActive,
+                getPressedStateStyle({ pressed }),
               ]}
               testID={`holdings-filter-${filter.key}`}
             >
@@ -335,8 +345,10 @@ const styles = StyleSheet.create({
     gap: spacing.sm,
   },
   filterChip: {
+    alignItems: "center",
     backgroundColor: colors.surface.elevated,
     borderRadius: 999,
+    justifyContent: "center",
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.sm,
   },

--- a/src/features/progress/ProgressScreen.tsx
+++ b/src/features/progress/ProgressScreen.tsx
@@ -12,7 +12,10 @@ import {
   ScreenContainer,
   ScreenHeader,
   SectionHeader,
+  androidRipple,
   assetClassLabel,
+  getPressedStateStyle,
+  minimumTouchTargetStyle,
 } from "@/src/components/common";
 import type { MonthlyProgressChartSeries } from "@/src/domain/calculations";
 import {
@@ -23,7 +26,7 @@ import {
 } from "@/src/domain/calculations";
 import { formatCompactINR, formatINR, formatPercentage } from "@/src/domain/formatters";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
-import { colors, spacing } from "@/src/theme";
+import { colors, interaction, spacing } from "@/src/theme";
 import { FormTextField } from "@/src/components/forms";
 import { useProgress } from "./useProgress";
 
@@ -314,11 +317,18 @@ function ChartRangeSelector({
           <Pressable
             accessibilityLabel={`Show ${range} monthly progress charts`}
             accessibilityRole="button"
+            android_ripple={androidRipple(
+              isSelected
+                ? interaction.primaryRippleColor
+                : interaction.rippleColor,
+            )}
             key={range}
             onPress={() => onChange(range)}
-            style={[
+            style={({ pressed }) => [
               styles.rangeChip,
+              minimumTouchTargetStyle,
               isSelected ? styles.rangeChipSelected : null,
+              getPressedStateStyle({ pressed }),
             ]}
             testID={`${testIDPrefix}-${range}`}
           >
@@ -865,6 +875,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     borderRadius: 999,
     flex: 1,
+    justifyContent: "center",
     paddingVertical: spacing.sm,
   },
   rangeChipSelected: {

--- a/src/theme/__tests__/theme.test.ts
+++ b/src/theme/__tests__/theme.test.ts
@@ -1,15 +1,23 @@
-import { colors, radii, spacing } from "@/src/theme";
+import { colors, interaction, radii, spacing } from "@/src/theme";
 
 describe("theme tokens", () => {
   it("matches the V1 premium true-dark palette", () => {
     expect(colors.background).toBe("#000000");
     expect(colors.surface.card).toBe("#1C1C1E");
     expect(colors.surface.elevated).toBe("#2C2C2E");
-    expect(colors.primary).toBe("#2E7D52");
+    expect(colors.primary).toBe("#34C759");
+    expect(colors.deepGreen).toBe("#248A3D");
     expect(colors.profit).toBe("#34C759");
     expect(colors.text.primary).toBe("#FFFFFF");
     expect(colors.text.secondary).toBe("#8E8E93");
     expect(colors.border.subtle).toBe("rgba(255,255,255,0.10)");
+  });
+
+  it("captures Android interaction rules", () => {
+    expect(interaction.minimumTouchTarget).toBe(48);
+    expect(interaction.rippleColor).toBe("rgba(255,255,255,0.12)");
+    expect(interaction.primaryRippleColor).toBe("rgba(0,0,0,0.18)");
+    expect(interaction.stateLayerOpacity).toBe(0.12);
   });
 
   it("captures the V1 spacing and radius rules", () => {

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -4,8 +4,8 @@ export const colors = {
   blue: "#0A84FF",
   cashBlue: "#64D2FF",
   cryptoAmber: "#FFD60A",
-  deepGreen: "#0E6B4F",
-  primary: "#2E7D52",
+  deepGreen: "#248A3D",
+  primary: "#34C759",
   profit: "#34C759",
   loss: "#FF453A",
   warning: "#FF9F0A",
@@ -60,7 +60,11 @@ export const typography = {
 } as const;
 
 export const interaction = {
+  minimumTouchTarget: 48,
+  primaryRippleColor: "rgba(0,0,0,0.18)",
   pressedOpacity: 0.75,
+  rippleColor: "rgba(255,255,255,0.12)",
+  stateLayerOpacity: 0.12,
   disabledOpacity: 0.48,
 } as const;
 


### PR DESCRIPTION
## Summary
- align V1 primary/deep green tokens with DESIGN.md while keeping profit as a separate semantic token
- add shared Android ripple, pressed-state, and 48dp touch-target helpers for common controls
- apply ripple/touch polish to buttons, icon buttons, grouped rows, holdings filters, and progress chart range chips
- enable Android predictive back and cover it in config tests

## Verification
- npm test -- --runInBand src/theme/__tests__/theme.test.ts src/components/common/__tests__/commonComponents.test.tsx src/__tests__/androidIdentity.test.ts src/features/progress/__tests__/ProgressScreen.test.tsx src/features/holdings/__tests__/HoldingsScreen.test.tsx
- npm run typecheck
- npm test -- --runInBand
- npm run doctor
- npm run android:smoke

Closes #133