### PR TITLE
Polish Monthly Progress chart privacy and motion

### DIFF
--- a/docs/design/v1-screen-baseline.md
+++ b/docs/design/v1-screen-baseline.md
@@ -159,9 +159,11 @@ The V1 screen title is `Monthly Progress`; the tab label can be `Progress`.
 Accepted chart direction:
 
 - first graph: `Value Gap` - total portfolio value vs invested value by month
+- `Value Gap` color contract: Portfolio line is green; Invested line is white
 - second graph: `Asset Momentum` - asset values vs months
 - cash is excluded from the asset-trend graph and tracked separately in Cash
 - charts must use stored monthly snapshots or a clear empty/no-snapshot state
+- chart y-axis labels and chart-native value labels must obey value masking
 - each chart card owns its own timeframe controls
 - use `react-native-gifted-charts` for V1 chart rendering; do not use Victory
   Native for these charts

--- a/docs/superpowers/plans/2026-06-18-issue-134-monthly-progress-chart-polish.md
+++ b/docs/superpowers/plans/2026-06-18-issue-134-monthly-progress-chart-polish.md
@@ -60,5 +60,5 @@
 - `npm run android:smoke`
 
 - [x] Record exact output for emulator smoke.
-- [ ] Commit with a focused message.
-- [ ] Push branch and open a PR with `Closes #134`.
+- [x] Commit with a focused message.
+- [x] Push branch and open a PR with `Closes #134`.

--- a/docs/superpowers/plans/2026-06-18-issue-134-monthly-progress-chart-polish.md
+++ b/docs/superpowers/plans/2026-06-18-issue-134-monthly-progress-chart-polish.md
@@ -1,0 +1,64 @@
+# Issue 134 Monthly Progress Chart Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close Monthly Progress chart privacy, reduced-motion, and line-color contract gaps from issue #134.
+
+**Architecture:** Keep chart data and screen layout unchanged. Add a small reusable reduced-motion hook, thread existing wealth-masking preference into the chart rendering helpers, and update the chart color mapper plus docs/tests to reflect the accepted V1 preview.
+
+**Tech Stack:** React Native `AccessibilityInfo`, React hooks, `react-native-gifted-charts`, TypeScript, Jest / React Native Testing Library.
+
+---
+
+### Task 1: Reduced Motion Hook
+
+**Files:**
+- Create: `src/hooks/useReducedMotionPreference.ts`
+- Create: `src/hooks/index.ts`
+- Test: `src/hooks/__tests__/useReducedMotionPreference.test.tsx`
+
+- [x] Add a hook that initializes from `AccessibilityInfo.isReduceMotionEnabled()`.
+- [x] Subscribe to `AccessibilityInfo.addEventListener("reduceMotionChanged", ...)`.
+- [x] Remove the subscription on unmount.
+- [x] Cover initial false, async true, event update, and cleanup behavior in tests.
+
+### Task 2: Chart Privacy and Color Contract
+
+**Files:**
+- Modify: `src/features/progress/ProgressScreen.tsx`
+- Modify: `src/features/progress/__tests__/ProgressScreen.test.tsx`
+- Modify: `jest.setup.ts`
+
+- [x] Update `getSeriesColor("Portfolio")` to `colors.primary`.
+- [x] Update `getSeriesColor("Invested")` to `colors.text.primary`.
+- [x] Add chart label masking helper that returns `₹••••` for masked wealth labels.
+- [x] Thread `maskWealthValues` into `ProgressTrendCards` and `TrendChart`.
+- [x] Pass masked `formatYLabel` into both `LineChart` variants.
+- [x] Render masked custom y-axis labels when masking is enabled.
+- [x] Use `useReducedMotionPreference()` and set `isAnimated={!reduceMotionEnabled}`.
+- [x] Extend the Gifted chart Jest mock to expose chart props for assertions.
+- [x] Add tests for masked labels, `formatYLabel`, colors, and reduced motion.
+
+### Task 3: Documentation
+
+**Files:**
+- Modify: `docs/design/v1-screen-baseline.md`
+- Modify: `docs/superpowers/specs/2026-06-18-issue-134-monthly-progress-chart-polish.md`
+- Modify: `docs/superpowers/plans/2026-06-18-issue-134-monthly-progress-chart-polish.md`
+
+- [x] Document Portfolio line = green and Invested line = white.
+- [x] Document chart wealth labels must follow value masking.
+- [x] Mark this plan complete after verification evidence exists.
+
+### Task 4: Verification and Delivery
+
+**Commands:**
+- `npm run typecheck`
+- `npm test -- --runInBand src/hooks/__tests__/useReducedMotionPreference.test.tsx src/features/progress/__tests__/ProgressScreen.test.tsx`
+- `npm test -- --runInBand`
+- `npm run doctor`
+- `npm run android:smoke`
+
+- [x] Record exact output for emulator smoke.
+- [ ] Commit with a focused message.
+- [ ] Push branch and open a PR with `Closes #134`.

--- a/docs/superpowers/specs/2026-06-18-issue-134-monthly-progress-chart-polish.md
+++ b/docs/superpowers/specs/2026-06-18-issue-134-monthly-progress-chart-polish.md
@@ -1,0 +1,49 @@
+# Issue 134 Monthly Progress Chart Polish Design
+
+## Context
+
+Issue #134 is a narrow follow-up to the V1 Monthly Progress chart work. The chart feature is already implemented with `react-native-gifted-charts`; this task only closes privacy, motion, and visual-contract gaps without redesigning the Progress screen.
+
+## Goals
+
+- Mask Monthly Progress chart axis/chart labels whenever value masking is enabled.
+- Respect reduced-motion accessibility preferences for chart animation.
+- Lock the accepted preview color contract: Portfolio line is green, Invested line is white.
+- Keep V1 on `react-native-gifted-charts`; do not introduce Victory Native or a new chart library.
+
+## Non-Goals
+
+- Do not redesign the Monthly Progress screen.
+- Do not change chart data/domain calculations.
+- Do not add custom date ranges or advanced chart interactions.
+- Do not change existing metric-card masking behavior.
+
+## Design
+
+### Chart Privacy
+
+`ProgressScreen` will pass the current `maskWealthValues` preference into the chart section. The chart y-axis labels and Gifted chart `formatYLabel` formatter will return a stable masked label when masking is enabled, so readable INR magnitudes are not exposed by either the custom y-axis or chart-native labels.
+
+The masked chart label should be intentionally coarse, not value-shaped. Use a compact placeholder such as `₹••••` for chart axis/tooltip labels. Percent values, chart titles, timeframe labels, and non-wealth copy remain visible.
+
+### Reduced Motion
+
+Add a tiny shared hook that reads `AccessibilityInfo.isReduceMotionEnabled()` and listens for `reduceMotionChanged`. `ProgressScreen` will use it and pass `isAnimated={!reduceMotionEnabled}` to both Gifted chart variants.
+
+The hook belongs under `src/hooks/` because reduced-motion behavior will likely be reused by future UI polish, but this issue only wires it to Monthly Progress charts.
+
+### Chart Color Contract
+
+The accepted V1 preview uses Portfolio as the green line and Invested as the white line. `getSeriesColor("Portfolio")` will return `colors.primary`; `getSeriesColor("Invested")` will return `colors.text.primary`. Asset chart colors stay unchanged.
+
+Update `docs/design/v1-screen-baseline.md` to make this color contract explicit.
+
+## Testing Strategy
+
+- Extend the existing Gifted chart Jest mock to expose props via testIDs.
+- Add Progress screen tests that verify:
+  - masked custom y-axis labels are rendered when masking is on;
+  - Gifted chart `formatYLabel` returns a masked label when masking is on;
+  - Portfolio/Invested color props match the accepted contract;
+  - reduced motion disables `isAnimated`.
+- Run full typecheck, Jest, Expo doctor, and Android smoke before completion.

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -15,6 +15,10 @@ jest.mock("react-native-gifted-charts", () => {
   const { View } = require("react-native");
 
   return {
-    LineChart: () => React.createElement(View, { testID: "gifted-line-chart" }),
+    LineChart: (props: Record<string, unknown>) =>
+      React.createElement(View, {
+        ...props,
+        testID: props.testID ?? "gifted-line-chart",
+      }),
   };
 });

--- a/src/features/progress/ProgressScreen.tsx
+++ b/src/features/progress/ProgressScreen.tsx
@@ -25,6 +25,7 @@ import {
   type MonthlyProgressChartData,
 } from "@/src/domain/calculations";
 import { formatCompactINR, formatINR, formatPercentage } from "@/src/domain/formatters";
+import { useReducedMotionPreference } from "@/src/hooks";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
 import { colors, interaction, spacing } from "@/src/theme";
 import { FormTextField } from "@/src/components/forms";
@@ -81,13 +82,14 @@ const chartWidth = 228;
 const chartYAxisWidth = 0;
 const chartInitialSpacing = 18;
 const chartEndSpacing = 36;
+const maskedChartValueLabel = "₹••••";
 
 function getSeriesColor(label: string) {
   switch (label) {
     case "Portfolio":
-      return colors.text.primary;
-    case "Invested":
       return colors.profit;
+    case "Invested":
+      return colors.text.primary;
     case "Equity":
       return colors.primary;
     case "Debt":
@@ -108,10 +110,20 @@ function getChartMaxValue(series: MonthlyProgressChartSeries[]) {
   return niceMultiplier * magnitude;
 }
 
-function getYAxisLabels(series: MonthlyProgressChartSeries[]) {
+function formatChartYLabel(value: number | string, masked: boolean) {
+  if (masked) {
+    return maskedChartValueLabel;
+  }
+
+  return formatCompactINR(Number(value));
+}
+
+function getYAxisLabels(series: MonthlyProgressChartSeries[], masked: boolean) {
   const maxValue = getChartMaxValue(series);
 
-  return [maxValue, maxValue / 2, 0].map((value) => formatCompactINR(value));
+  return [maxValue, maxValue / 2, 0].map((value) =>
+    formatChartYLabel(value, masked),
+  );
 }
 
 function formatChartAxisLabel(monthLabel: string) {
@@ -184,10 +196,14 @@ function TrendLegend({
 }
 
 function TrendChart({
+  isReducedMotionEnabled,
+  maskWealthValues,
   monthLabels,
   series,
   testIDPrefix,
 }: {
+  isReducedMotionEnabled: boolean;
+  maskWealthValues: boolean;
   monthLabels: string[];
   series: MonthlyProgressChartSeries[];
   testIDPrefix: string;
@@ -201,8 +217,13 @@ function TrendChart({
     <View style={styles.chartBlock}>
       <View style={styles.chartWithAxis}>
         <View style={styles.yAxisLabels}>
-          {getYAxisLabels(series).map((label) => (
-            <AppText key={label} color="secondary" variant="caption">
+          {getYAxisLabels(series, maskWealthValues).map((label, index) => (
+            <AppText
+              key={`${label}-${index}`}
+              color="secondary"
+              testID={`${testIDPrefix}-y-axis-${index}`}
+              variant="caption"
+            >
               {label}
             </AppText>
           ))}
@@ -225,12 +246,12 @@ function TrendChart({
             endFillColor="rgba(52,199,89,0)"
             endOpacity={0}
             endSpacing={chartEndSpacing}
-            formatYLabel={(label) => formatCompactINR(Number(label))}
+            formatYLabel={(label) => formatChartYLabel(label, maskWealthValues)}
             height={chartHeight}
             hideOrigin
             initialSpacing={chartInitialSpacing}
             intersectionAreaConfig={{ fillColor: "rgba(52,199,89,0.14)" }}
-            isAnimated
+            isAnimated={!isReducedMotionEnabled}
             maxValue={maxValue}
             noOfSections={3}
             pointerConfig={{
@@ -267,11 +288,11 @@ function TrendChart({
             }))}
             disableScroll
             endSpacing={chartEndSpacing}
-            formatYLabel={(label) => formatCompactINR(Number(label))}
+            formatYLabel={(label) => formatChartYLabel(label, maskWealthValues)}
             height={chartHeight}
             hideOrigin
             initialSpacing={chartInitialSpacing}
-            isAnimated
+            isAnimated={!isReducedMotionEnabled}
             maxValue={maxValue}
             noOfSections={3}
             pointerConfig={{
@@ -427,6 +448,8 @@ function AssetInsightRows({ insights }: { insights: AssetChartInsight[] }) {
 function ProgressTrendCards({
   assetChartData,
   assetChartRange,
+  isReducedMotionEnabled,
+  maskWealthValues,
   onAssetRangeChange,
   onPortfolioRangeChange,
   portfolioChartData,
@@ -434,6 +457,8 @@ function ProgressTrendCards({
 }: {
   assetChartData: MonthlyProgressChartData;
   assetChartRange: MonthlyChartRange;
+  isReducedMotionEnabled: boolean;
+  maskWealthValues: boolean;
   onAssetRangeChange: (range: MonthlyChartRange) => void;
   onPortfolioRangeChange: (range: MonthlyChartRange) => void;
   portfolioChartData: MonthlyProgressChartData;
@@ -478,6 +503,8 @@ function ProgressTrendCards({
           testIDPrefix="portfolio-monthly-chart-range"
         />
         <TrendChart
+          isReducedMotionEnabled={isReducedMotionEnabled}
+          maskWealthValues={maskWealthValues}
           monthLabels={portfolioChartData.monthLabels}
           series={portfolioChartData.portfolioSeries}
           testIDPrefix="portfolio-trend"
@@ -506,6 +533,8 @@ function ProgressTrendCards({
           testIDPrefix="asset-monthly-chart-range"
         />
         <TrendChart
+          isReducedMotionEnabled={isReducedMotionEnabled}
+          maskWealthValues={maskWealthValues}
           monthLabels={assetChartData.monthLabels}
           series={assetChartData.assetSeries}
           testIDPrefix="asset-trend"
@@ -520,6 +549,7 @@ export function ProgressScreen({
   store = getPortfolioStore(),
 }: ProgressScreenProps) {
   const progress = useProgress({ store });
+  const isReducedMotionEnabled = useReducedMotionPreference();
 
   return (
     <ScreenContainer scroll testID="progress-screen">
@@ -569,6 +599,8 @@ export function ProgressScreen({
             <ProgressTrendCards
               assetChartData={progress.assetChartData}
               assetChartRange={progress.assetChartRange}
+              isReducedMotionEnabled={isReducedMotionEnabled}
+              maskWealthValues={progress.preferences.maskWealthValues}
               onAssetRangeChange={progress.setAssetChartRange}
               onPortfolioRangeChange={progress.setPortfolioChartRange}
               portfolioChartData={progress.portfolioChartData}
@@ -657,6 +689,8 @@ export function ProgressScreen({
             <ProgressTrendCards
               assetChartData={progress.assetChartData}
               assetChartRange={progress.assetChartRange}
+              isReducedMotionEnabled={isReducedMotionEnabled}
+              maskWealthValues={progress.preferences.maskWealthValues}
               onAssetRangeChange={progress.setAssetChartRange}
               onPortfolioRangeChange={progress.setPortfolioChartRange}
               portfolioChartData={progress.portfolioChartData}

--- a/src/features/progress/__tests__/ProgressScreen.test.tsx
+++ b/src/features/progress/__tests__/ProgressScreen.test.tsx
@@ -1,9 +1,15 @@
 import { fireEvent, render } from "@testing-library/react-native";
 
 import { ProgressScreen } from "@/src/features/progress";
+import { useReducedMotionPreference } from "@/src/hooks";
 import { createMemoryJsonStorage } from "@/src/services/storage";
 import { createPortfolioStore } from "@/src/store";
+import { colors } from "@/src/theme";
 import type { MonthlySnapshot } from "@/src/types";
+
+jest.mock("@/src/hooks", () => ({
+  useReducedMotionPreference: jest.fn(() => false),
+}));
 
 const aprilSnapshot: MonthlySnapshot = {
   cashValue: 120000,
@@ -49,6 +55,10 @@ const marchSnapshot: MonthlySnapshot = {
 };
 
 describe("ProgressScreen", () => {
+  beforeEach(() => {
+    jest.mocked(useReducedMotionPreference).mockReturnValue(false);
+  });
+
   it("shows the no-snapshot state before monthly records exist", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
 
@@ -126,9 +136,13 @@ describe("ProgressScreen", () => {
     store.getState().addMonthlySnapshot(maySnapshot);
     store.getState().addMonthlySnapshot(aprilSnapshot);
 
-    const { getByTestId, getByText, queryByTestId, queryByText } = render(
-      <ProgressScreen store={store} />,
-    );
+    const {
+      getAllByTestId,
+      getByTestId,
+      getByText,
+      queryByTestId,
+      queryByText,
+    } = render(<ProgressScreen store={store} />);
 
     expect(getByText("Value Gap")).toBeTruthy();
     expect(getByText("Portfolio value against invested capital")).toBeTruthy();
@@ -139,10 +153,49 @@ describe("ProgressScreen", () => {
     expect(getByText("Crypto +12.50%")).toBeTruthy();
     expect(getByTestId("portfolio-trend-Portfolio")).toBeTruthy();
     expect(getByTestId("portfolio-trend-Invested")).toBeTruthy();
+    const [portfolioChart] = getAllByTestId("gifted-line-chart");
+
+    expect(portfolioChart.props.color1).toBe(
+      colors.primary,
+    );
+    expect(portfolioChart.props.color2).toBe(
+      colors.text.primary,
+    );
     expect(getByTestId("asset-trend-Equity")).toBeTruthy();
     expect(getByTestId("asset-trend-Debt")).toBeTruthy();
     expect(getByTestId("asset-trend-Crypto")).toBeTruthy();
     expect(queryByTestId("asset-trend-Cash")).toBeNull();
+  });
+
+  it("masks chart axis and chart-native y labels when wealth masking is enabled", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addMonthlySnapshot(maySnapshot);
+    store.getState().addMonthlySnapshot(aprilSnapshot);
+    store.getState().updatePreferences({ maskWealthValues: true });
+
+    const { getAllByTestId, getByTestId, getAllByText, queryByText } = render(
+      <ProgressScreen store={store} />,
+    );
+    const [portfolioChart] = getAllByTestId("gifted-line-chart");
+
+    expect(getByTestId("portfolio-trend-y-axis-0")).toHaveTextContent("₹••••");
+    expect(getAllByText("₹••••").length).toBeGreaterThanOrEqual(3);
+    expect(queryByText("₹20L")).toBeNull();
+    expect(portfolioChart.props.formatYLabel("2000000")).toBe("₹••••");
+  });
+
+  it("disables chart animation when reduced motion is enabled", () => {
+    jest.mocked(useReducedMotionPreference).mockReturnValue(true);
+
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addMonthlySnapshot(maySnapshot);
+    store.getState().addMonthlySnapshot(aprilSnapshot);
+
+    const { getAllByTestId } = render(<ProgressScreen store={store} />);
+    const [portfolioChart, assetChart] = getAllByTestId("gifted-line-chart");
+
+    expect(portfolioChart.props.isAnimated).toBe(false);
+    expect(assetChart.props.isAnimated).toBe(false);
   });
 
   it("renders chart-local timeframe chips and updates selected range", () => {

--- a/src/hooks/__tests__/useReducedMotionPreference.test.tsx
+++ b/src/hooks/__tests__/useReducedMotionPreference.test.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+import { AccessibilityInfo } from "react-native";
+
+import { useReducedMotionPreference } from "@/src/hooks";
+
+describe("useReducedMotionPreference", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("uses the current OS reduced-motion preference", async () => {
+    jest
+      .spyOn(AccessibilityInfo, "isReduceMotionEnabled")
+      .mockResolvedValue(true);
+    jest.spyOn(AccessibilityInfo, "addEventListener").mockReturnValue({
+      remove: jest.fn(),
+    } as never);
+
+    const { result } = renderHook(() => useReducedMotionPreference());
+
+    expect(result.current).toBe(false);
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+
+  it("updates when the OS reduced-motion preference changes", async () => {
+    let listener: (value: boolean) => void = () => {};
+
+    jest
+      .spyOn(AccessibilityInfo, "isReduceMotionEnabled")
+      .mockResolvedValue(false);
+    jest
+      .spyOn(AccessibilityInfo, "addEventListener")
+      .mockImplementation((_eventName, callback) => {
+        listener = callback as unknown as (value: boolean) => void;
+
+        return { remove: jest.fn() } as never;
+      });
+
+    const { result } = renderHook(() => useReducedMotionPreference());
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+
+    act(() => {
+      listener(true);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("removes the reduced-motion listener on unmount", () => {
+    const remove = jest.fn();
+
+    jest
+      .spyOn(AccessibilityInfo, "isReduceMotionEnabled")
+      .mockResolvedValue(false);
+    jest.spyOn(AccessibilityInfo, "addEventListener").mockReturnValue({
+      remove,
+    } as never);
+
+    const { unmount } = renderHook(() => useReducedMotionPreference());
+
+    unmount();
+
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useReducedMotionPreference } from "./useReducedMotionPreference";

--- a/src/hooks/useReducedMotionPreference.ts
+++ b/src/hooks/useReducedMotionPreference.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { AccessibilityInfo } from "react-native";
+
+export function useReducedMotionPreference() {
+  const [isReducedMotionEnabled, setIsReducedMotionEnabled] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    void AccessibilityInfo.isReduceMotionEnabled().then((value) => {
+      if (isMounted) {
+        setIsReducedMotionEnabled(value);
+      }
+    });
+
+    const subscription = AccessibilityInfo.addEventListener(
+      "reduceMotionChanged",
+      setIsReducedMotionEnabled,
+    );
+
+    return () => {
+      isMounted = false;
+      subscription.remove();
+    };
+  }, []);
+
+  return isReducedMotionEnabled;
+}


### PR DESCRIPTION
## Summary
- mask Monthly Progress chart y-axis and chart-native value labels when value masking is enabled
- add a reusable reduced-motion hook and disable Gifted chart animation when reduced motion is on
- lock the accepted Portfolio/Invested line-color contract: Portfolio green, Invested white
- document the chart contract and add issue #134 spec/plan artifacts

## Verification
- npm run typecheck
- npm test -- --runInBand src/hooks/__tests__/useReducedMotionPreference.test.tsx src/features/progress/__tests__/ProgressScreen.test.tsx
- npm test -- --runInBand
- npm run doctor
- npm run android:smoke

Closes #134