### PR TITLE
Polish Add Holding lookup flow

### DIFF
--- a/docs/superpowers/plans/2026-06-21-issue-117-add-holding-lookup-flow.md
+++ b/docs/superpowers/plans/2026-06-21-issue-117-add-holding-lookup-flow.md
@@ -1,0 +1,58 @@
+# Issue 117 Add Holding Lookup Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Polish Add Holding lookup and selection states so users explicitly select, review provider suggestions, and can change/manual-fallback before saving.
+
+**Architecture:** Keep the existing `useAddOpeningPosition` controller and opening-position domain model. Add small selection-summary state to the controller, then refine `AddOpeningPositionForm` copy/layout/tests without changing portfolio calculations.
+
+**Tech Stack:** Expo React Native, TypeScript, React Native Testing Library, existing Yahoo Finance lookup service.
+
+---
+
+### Task 1: Controller Selection Summary
+
+**Files:**
+- Modify: `src/features/openingPositions/useAddOpeningPosition.ts`
+- Modify: `src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx`
+
+- [x] Track the selected lookup result summary separately from persisted existing assets.
+- [x] Clear the selected lookup summary when the user changes manual identity fields.
+- [x] Add a controller action that clears selected asset/lookup state for the UI `Change` action.
+- [x] Keep quote fallback behavior unchanged.
+
+### Task 2: Add Holding UI State Polish
+
+**Files:**
+- Modify: `src/features/openingPositions/AddOpeningPositionForm.tsx`
+
+- [x] Rename visible `Class` phase copy to `Metadata` while preserving compatible testIDs.
+- [x] Show a selected asset summary card with `Change` after lookup/existing asset selection.
+- [x] Keep lookup result list visible only before selection.
+- [x] Add provider suggestion/review copy in the metadata phase.
+- [x] Keep manual fields available for fallback and correction.
+- [x] Update CTA copy to `Review and save` where it moves into derived preview.
+
+### Task 3: Tests and E2E Coverage
+
+**Files:**
+- Modify: `src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx`
+- Modify: `e2e/add-holding-lookup.yaml` if needed
+
+- [x] Add tests for lookup result list and explicit `Select`.
+- [x] Add tests for selected asset summary and `Change`.
+- [x] Add tests for metadata review copy.
+- [x] Confirm current lookup Maestro flow testIDs remain valid or update them.
+
+### Task 4: Verification and Delivery
+
+**Commands:**
+- `npm run typecheck`
+- `npm test -- --runInBand src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx src/features/openingPositions/__tests__/useAddOpeningPosition.test.tsx`
+- `npm test -- --runInBand`
+- `npm run doctor`
+- `npm run android:smoke`
+
+- [x] Record exact smoke output.
+- [ ] Commit with a focused message.
+- [ ] Push branch and open PR with `Closes #117`.

--- a/docs/superpowers/plans/2026-06-21-issue-117-add-holding-lookup-flow.md
+++ b/docs/superpowers/plans/2026-06-21-issue-117-add-holding-lookup-flow.md
@@ -54,5 +54,5 @@
 - `npm run android:smoke`
 
 - [x] Record exact smoke output.
-- [ ] Commit with a focused message.
-- [ ] Push branch and open PR with `Closes #117`.
+- [x] Commit with a focused message.
+- [x] Push branch and open PR with `Closes #117`.

--- a/docs/superpowers/specs/2026-06-21-issue-117-add-holding-lookup-flow.md
+++ b/docs/superpowers/specs/2026-06-21-issue-117-add-holding-lookup-flow.md
@@ -44,7 +44,7 @@ The screen remains a progressive flow:
 The accepted design references mention a five-step mature state. For this issue,
 we will not split the save confirmation into a separate route or add fake
 intermediate behavior. Instead, the UI will make the current four persisted
-phases clearer while using copy such as `Review metadata` and `Position details`
+phases clearer while using copy such as `Confirm details` and `Position details`
 to match the intended journey. A future visual-only split can happen if the V1
 preview is revised.
 

--- a/docs/superpowers/specs/2026-06-21-issue-117-add-holding-lookup-flow.md
+++ b/docs/superpowers/specs/2026-06-21-issue-117-add-holding-lookup-flow.md
@@ -1,0 +1,86 @@
+# Issue 117 Add Holding Lookup Flow Design
+
+## Context
+
+Issue #117 polishes the Add Holding lookup and selection flow against the
+accepted V1 research preview. The current app already supports lookup, explicit
+selection, manual fallback, opening-position review, and save. This work should
+make those states clearer and more progressive without implementing the richer
+Yahoo Finance metadata derivation reserved for issue #124.
+
+## Goals
+
+- Make Add Holding feel lookup-first and assisted, not like a dense spreadsheet
+  form.
+- Keep explicit selection: search results must never auto-fill fields until the
+  user taps `Select`.
+- After selection, collapse the asset search area into a selected-asset summary
+  with a clear `Change` action.
+- Present provider-derived metadata as reviewable suggestions before position
+  details.
+- Preserve manual entry and manual price fallback when lookup or quote fetch
+  fails.
+- Preserve current opening-position domain behavior and storage model.
+
+## Non-Goals
+
+- Do not implement #124 metadata derivation beyond current Yahoo lookup fields.
+- Do not add a backend or Python yfinance.
+- Do not change holdings, dashboard, or portfolio calculations.
+- Do not redesign the full Add Holding visual system beyond the required flow
+  states.
+
+## Design
+
+### Flow Structure
+
+The screen remains a progressive flow:
+
+1. `Asset` - search, inspect results, select, or enter manually.
+2. `Metadata` - review provider suggestions and asset classification.
+3. `Position` - quantity, average cost, current price, date, conviction, notes.
+4. `Review` - derived preview and save.
+
+The accepted design references mention a five-step mature state. For this issue,
+we will not split the save confirmation into a separate route or add fake
+intermediate behavior. Instead, the UI will make the current four persisted
+phases clearer while using copy such as `Review metadata` and `Position details`
+to match the intended journey. A future visual-only split can happen if the V1
+preview is revised.
+
+### Selected Asset Summary
+
+When a lookup result or existing asset is selected, the Asset phase shows a
+compact summary card:
+
+- asset name
+- symbol, ticker, source/exchange context
+- `Change` action
+
+The summary should reduce visual noise by replacing the feeling that the user
+must edit every identity field. Manual fields remain available for correction
+and fallback.
+
+### Metadata Review
+
+The Metadata phase shows classification and provider-suggested fields as
+reviewable. Copy should clearly say these values are suggestions. The user can
+edit instrument type and sector type before continuing.
+
+### Manual Fallback
+
+Lookup failure and quote failure states remain non-blocking. Users can continue
+by entering details manually. Quote failure clears current price and keeps the
+manual current-price input available in the Position phase.
+
+## Testing Strategy
+
+- Extend Add Holding screen tests for:
+  - result list state with explicit `Select`;
+  - selected asset summary after selecting a lookup result;
+  - `Change` action returning to a selectable/manual asset state;
+  - metadata review copy and editable suggestion fields;
+  - manual fallback state still allowing continuation.
+- Keep existing Maestro testIDs stable where practical.
+- Run typecheck, focused Add Holding tests, full Jest, Expo doctor, and Android
+  smoke before opening the PR.

--- a/src/features/openingPositions/AddOpeningPositionForm.tsx
+++ b/src/features/openingPositions/AddOpeningPositionForm.tsx
@@ -53,6 +53,7 @@ export function AddOpeningPositionForm({
     assetClass,
     assetName,
     averageCostPrice,
+    changeSelectedAsset,
     clearSelectedAsset,
     continueFromAsset,
     continueFromClass,
@@ -82,6 +83,7 @@ export function AddOpeningPositionForm({
     selectAsset,
     selectLookupResult,
     selectedAssetId,
+    selectedLookupResult,
     setAssetName,
     setAverageCostPrice,
     setConviction,
@@ -102,6 +104,12 @@ export function AddOpeningPositionForm({
     ticker,
     updateAssetClass,
   } = holding;
+  const hasSelectedAssetSummary = Boolean(selectedAssetId || selectedLookupResult);
+  const selectedAssetSourceLabel = selectedLookupResult
+    ? `${selectedLookupResult.sourceLabel} suggestion`
+    : selectedAssetId
+      ? "Existing asset"
+      : "";
 
   function renderStepper() {
     const currentIndex = getPhaseIndex(currentPhase);
@@ -188,49 +196,73 @@ export function AddOpeningPositionForm({
       {currentPhase === "asset" ? (
       <PremiumCard testID="add-holding-phase-asset">
         <SectionHeader title="Asset" />
-        <FormTextField
-          label="Search asset"
-          onChangeText={(value) => {
-            setLookupQuery(value);
-            setQuoteStatus("");
-          }}
-          placeholder="Search HDFC Bank, NIFTYBEES, Bitcoin..."
-          returnKeyType="search"
-          testID="asset-lookup-input"
-          value={lookupQuery}
-        />
-        {lookupStatus ? (
-          <AppText color="secondary" variant="caption">
-            {isLookupSearching ? "Searching..." : lookupStatus}
-          </AppText>
-        ) : null}
-        {lookupResults.length > 0 ? (
-          <View style={styles.lookupResults}>
-            {lookupResults.map((result) => (
-              <TouchableOpacity
-                accessibilityRole="button"
-                activeOpacity={0.74}
-                key={result.id}
-                onPress={() => {
-                  void selectLookupResult(result);
-                }}
-                style={styles.lookupResult}
-                testID={`asset-lookup-result-${result.id}`}
-              >
-                <CategoryIcon assetClass={result.assetClass} size={18} />
-                <View style={styles.lookupResultCopy}>
-                  <AppText weight="bold">{result.name}</AppText>
-                  <AppText color="secondary" variant="caption">
-                    {result.symbol} • {result.ticker} • {result.sourceLabel}
-                  </AppText>
-                </View>
-                <AppText color="secondary" variant="caption" weight="bold">
-                  Select
-                </AppText>
-              </TouchableOpacity>
-            ))}
+        {hasSelectedAssetSummary ? (
+          <View style={styles.selectedAssetSummary} testID="selected-asset-summary">
+            <CategoryIcon assetClass={assetClass} size={20} />
+            <View style={styles.summaryCopy}>
+              <AppText weight="bold">{assetName}</AppText>
+              <AppText color="secondary" variant="caption">
+                {symbol} • {ticker} • {selectedAssetSourceLabel}
+              </AppText>
+            </View>
+            <TouchableOpacity
+              accessibilityRole="button"
+              activeOpacity={0.74}
+              onPress={changeSelectedAsset}
+              testID="selected-asset-change"
+            >
+              <AppText color="secondary" variant="caption" weight="bold">
+                Change
+              </AppText>
+            </TouchableOpacity>
           </View>
-        ) : null}
+        ) : (
+          <>
+            <FormTextField
+              label="Search asset"
+              onChangeText={(value) => {
+                setLookupQuery(value);
+                setQuoteStatus("");
+              }}
+              placeholder="Search HDFC Bank, NIFTYBEES, Bitcoin..."
+              returnKeyType="search"
+              testID="asset-lookup-input"
+              value={lookupQuery}
+            />
+            {lookupStatus ? (
+              <AppText color="secondary" variant="caption">
+                {isLookupSearching ? "Searching..." : lookupStatus}
+              </AppText>
+            ) : null}
+            {lookupResults.length > 0 ? (
+              <View style={styles.lookupResults} testID="asset-lookup-results">
+                {lookupResults.map((result) => (
+                  <TouchableOpacity
+                    accessibilityRole="button"
+                    activeOpacity={0.74}
+                    key={result.id}
+                    onPress={() => {
+                      void selectLookupResult(result);
+                    }}
+                    style={styles.lookupResult}
+                    testID={`asset-lookup-result-${result.id}`}
+                  >
+                    <CategoryIcon assetClass={result.assetClass} size={18} />
+                    <View style={styles.lookupResultCopy}>
+                      <AppText weight="bold">{result.name}</AppText>
+                      <AppText color="secondary" variant="caption">
+                        {result.symbol} • {result.ticker} • {result.sourceLabel}
+                      </AppText>
+                    </View>
+                    <AppText color="secondary" variant="caption" weight="bold">
+                      Select
+                    </AppText>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            ) : null}
+          </>
+        )}
         {quoteStatus ? (
           <AppText color="secondary" variant="caption">
             {quoteStatus}
@@ -294,7 +326,14 @@ export function AddOpeningPositionForm({
 
       {currentPhase === "class" ? (
       <PremiumCard testID="add-holding-phase-class">
-        <SectionHeader title="Classification" />
+        <SectionHeader title="Review metadata" />
+        <AppText
+          color="secondary"
+          testID="provider-metadata-review-copy"
+          variant="caption"
+        >
+          Provider details are suggestions. Review and edit them before saving.
+        </AppText>
         <View style={styles.summaryCard}>
           <CategoryIcon assetClass={assetClass} size={20} />
           <View style={styles.summaryCopy}>
@@ -582,7 +621,7 @@ export function AddOpeningPositionForm({
             <AppButton
               onPress={continueFromPosition}
               testID="review-holding-button"
-              title="Review Holding"
+              title="Review and save"
             />
             <AppButton
               onPress={() => moveToPhase("class")}
@@ -716,6 +755,14 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: "row",
     gap: spacing.sm,
+  },
+  selectedAssetSummary: {
+    alignItems: "center",
+    backgroundColor: colors.surface.elevated,
+    borderRadius: radii.card,
+    flexDirection: "row",
+    gap: spacing.sm,
+    padding: spacing.md,
   },
   successText: {
     color: colors.profit,

--- a/src/features/openingPositions/AddOpeningPositionForm.tsx
+++ b/src/features/openingPositions/AddOpeningPositionForm.tsx
@@ -326,7 +326,7 @@ export function AddOpeningPositionForm({
 
       {currentPhase === "class" ? (
       <PremiumCard testID="add-holding-phase-class">
-        <SectionHeader title="Review metadata" />
+        <SectionHeader title="Confirm details" />
         <AppText
           color="secondary"
           testID="provider-metadata-review-copy"

--- a/src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
+++ b/src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
@@ -52,7 +52,7 @@ describe("AddOpeningPositionForm", () => {
     expect(getByText("Ticker is required.")).toBeTruthy();
   });
 
-  it("moves through Asset, Class, Position, and Review phases", () => {
+  it("moves through Asset, Metadata, Position, and Review phases", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     const { getByLabelText, getByTestId, getByText, queryByTestId } = render(
       <AddOpeningPositionForm store={store} />,
@@ -65,6 +65,8 @@ describe("AddOpeningPositionForm", () => {
     fireEvent.press(getByText("Continue to classification"));
 
     expect(getByTestId("add-holding-phase-class")).toBeTruthy();
+    expect(getByText("Review metadata")).toBeTruthy();
+    expect(getByTestId("provider-metadata-review-copy")).toBeTruthy();
     expect(queryByTestId("add-holding-phase-asset")).toBeNull();
 
     fireEvent.press(getByText("Continue to position"));
@@ -74,7 +76,7 @@ describe("AddOpeningPositionForm", () => {
     fireEvent.changeText(getByLabelText("Average cost"), "1450");
     fireEvent.changeText(getByLabelText("Current price"), "1678.25");
     fireEvent.changeText(getByLabelText("Date acquired"), "2026-04-15");
-    fireEvent.press(getByText("Review Holding"));
+    fireEvent.press(getByText("Review and save"));
 
     expect(getByTestId("add-holding-phase-review")).toBeTruthy();
     expect(getByTestId("derived-preview")).toBeTruthy();
@@ -144,7 +146,7 @@ describe("AddOpeningPositionForm", () => {
     fireEvent.press(getByTestId("conviction-4"));
     fireEvent.changeText(getByLabelText("Note"), "Excel opening position");
 
-    fireEvent.press(getByText("Review Holding"));
+    fireEvent.press(getByText("Review and save"));
     expect(getByTestId("derived-preview")).toBeTruthy();
     expect(getByText("₹36,250.00")).toBeTruthy();
     expect(getByText("₹41,956.25")).toBeTruthy();
@@ -203,7 +205,7 @@ describe("AddOpeningPositionForm", () => {
     fireEvent.changeText(getByLabelText("Current price"), "5711");
     fireEvent.changeText(getByLabelText("Date acquired"), "2026-04-15");
 
-    fireEvent.press(getByText("Review Holding"));
+    fireEvent.press(getByText("Review and save"));
     fireEvent.press(getByText("Save Holding"));
 
     await waitFor(() => {
@@ -234,7 +236,7 @@ describe("AddOpeningPositionForm", () => {
     fireEvent.changeText(getByLabelText("Current price"), "5800000");
     fireEvent.changeText(getByLabelText("Date acquired"), "2026-04-15");
 
-    fireEvent.press(getByText("Review Holding"));
+    fireEvent.press(getByText("Review and save"));
     fireEvent.press(getByText("Save Holding"));
 
     await waitFor(() => {
@@ -284,7 +286,7 @@ describe("AddOpeningPositionForm", () => {
         },
       }),
     );
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getByTestId, getByText, queryByTestId } = render(
       <AddOpeningPositionForm
         resolveQuote={resolveQuote}
         searchAssetLookupResults={searchAssetLookupResults}
@@ -300,8 +302,9 @@ describe("AddOpeningPositionForm", () => {
     await waitFor(() => {
       expect(getByText("HDFC Bank Limited")).toBeTruthy();
     });
+    expect(getByTestId("asset-lookup-results")).toBeTruthy();
 
-    fireEvent.press(getByText("HDFC Bank Limited"));
+    fireEvent.press(getByTestId("asset-lookup-result-yahoo:HDFCBANK.NS"));
 
     await waitFor(() => {
       expect(getByLabelText("Asset name")).toHaveProp(
@@ -309,6 +312,8 @@ describe("AddOpeningPositionForm", () => {
         "HDFC Bank Limited",
       );
     });
+    expect(getByTestId("selected-asset-summary")).toBeTruthy();
+    expect(queryByTestId("asset-lookup-results")).toBeNull();
     expect(getByLabelText("Symbol")).toHaveProp("value", "HDFCBANK");
     expect(getByLabelText("Ticker")).toHaveProp("value", "HDFCBANK.NS");
     expect(getByLabelText("Quote source ID")).toHaveProp(
@@ -317,8 +322,70 @@ describe("AddOpeningPositionForm", () => {
     );
     expect(getByText("Live price autofilled from Yahoo Finance.")).toBeTruthy();
     fireEvent.press(getByText("Continue to classification"));
+    expect(getByText("Review metadata")).toBeTruthy();
+    expect(getByTestId("provider-metadata-review-copy")).toBeTruthy();
     fireEvent.press(getByText("Continue to position"));
     expect(getByLabelText("Current price")).toHaveProp("value", "1678.25");
+  });
+
+  it("lets the user change a selected lookup asset before continuing", async () => {
+    jest.useFakeTimers();
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const lookupResult: AssetLookupResult = {
+      assetClass: "stock",
+      currency: "INR",
+      exchange: "NSE",
+      id: "yahoo:HDFCBANK.NS",
+      instrumentType: "stock",
+      name: "HDFC Bank Limited",
+      provider: "yahoo",
+      quoteSourceId: "HDFCBANK.NS",
+      sectorType: "financialServices",
+      sourceLabel: "Yahoo Finance",
+      symbol: "HDFCBANK",
+      ticker: "HDFCBANK.NS",
+    };
+    const searchAssetLookupResults = jest.fn().mockResolvedValue({
+      failures: [],
+      results: [lookupResult],
+    });
+    const resolveQuote = jest.fn().mockResolvedValue({
+      ok: true,
+      quote: {
+        assetId: "asset-id",
+        asOf: "2026-05-10T10:00:00.000Z",
+        currency: "INR",
+        price: 1678.25,
+        source: "yahoo",
+      },
+    });
+    const { getByLabelText, getByTestId, queryByTestId } = render(
+      <AddOpeningPositionForm
+        resolveQuote={resolveQuote}
+        searchAssetLookupResults={searchAssetLookupResults}
+        store={store}
+      />,
+    );
+
+    fireEvent.changeText(getByLabelText("Search asset"), "hdfc bank");
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("asset-lookup-result-yahoo:HDFCBANK.NS")).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId("asset-lookup-result-yahoo:HDFCBANK.NS"));
+
+    await waitFor(() => {
+      expect(getByTestId("selected-asset-summary")).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId("selected-asset-change"));
+
+    expect(queryByTestId("selected-asset-summary")).toBeNull();
+    expect(getByTestId("asset-lookup-input")).toBeTruthy();
   });
 
   it("does not autofill exact lookup matches before explicit selection", async () => {

--- a/src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
+++ b/src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
@@ -65,7 +65,7 @@ describe("AddOpeningPositionForm", () => {
     fireEvent.press(getByText("Continue to classification"));
 
     expect(getByTestId("add-holding-phase-class")).toBeTruthy();
-    expect(getByText("Review metadata")).toBeTruthy();
+    expect(getByText("Confirm details")).toBeTruthy();
     expect(getByTestId("provider-metadata-review-copy")).toBeTruthy();
     expect(queryByTestId("add-holding-phase-asset")).toBeNull();
 
@@ -322,7 +322,7 @@ describe("AddOpeningPositionForm", () => {
     );
     expect(getByText("Live price autofilled from Yahoo Finance.")).toBeTruthy();
     fireEvent.press(getByText("Continue to classification"));
-    expect(getByText("Review metadata")).toBeTruthy();
+    expect(getByText("Confirm details")).toBeTruthy();
     expect(getByTestId("provider-metadata-review-copy")).toBeTruthy();
     fireEvent.press(getByText("Continue to position"));
     expect(getByLabelText("Current price")).toHaveProp("value", "1678.25");

--- a/src/features/openingPositions/useAddOpeningPosition.ts
+++ b/src/features/openingPositions/useAddOpeningPosition.ts
@@ -43,7 +43,7 @@ export const assetClasses: AssetClass[] = ["stock", "etf", "debt", "crypto"];
 export const convictionScores: ConvictionScore[] = [1, 2, 3, 4, 5];
 export const phases: Array<{ key: AddHoldingPhase; label: string }> = [
   { key: "asset", label: "Asset" },
-  { key: "class", label: "Class" },
+  { key: "class", label: "Metadata" },
   { key: "position", label: "Position" },
   { key: "review", label: "Review" },
 ];
@@ -96,6 +96,8 @@ export function useAddOpeningPosition({
   );
   const [lookupQuery, setLookupQuery] = useState("");
   const [lookupResults, setLookupResults] = useState<AssetLookupResult[]>([]);
+  const [selectedLookupResult, setSelectedLookupResult] =
+    useState<AssetLookupResult | undefined>();
   const [isLookupSearching, setIsLookupSearching] = useState(false);
   const [lookupStatus, setLookupStatus] = useState("");
   const [quoteStatus, setQuoteStatus] = useState("");
@@ -335,12 +337,26 @@ export function useAddOpeningPosition({
     if (selectedAssetId) {
       setSelectedAssetId("");
     }
+    if (selectedLookupResult) {
+      setSelectedLookupResult(undefined);
+    }
+  }
+
+  function changeSelectedAsset() {
+    setSelectedAssetId("");
+    setSelectedLookupResult(undefined);
+    setLookupQuery("");
+    setLookupResults([]);
+    setLookupStatus("");
+    setQuoteStatus("");
+    resetReview();
   }
 
   function selectAsset(asset: Asset) {
     const quote = snapshot.quoteCache[asset.id];
 
     setSelectedAssetId(asset.id);
+    setSelectedLookupResult(undefined);
     setAssetClass(asset.assetClass);
     setAssetName(asset.name);
     setInstrumentType(asset.instrumentType ?? getDefaultAssetMetadata(asset.assetClass).instrumentType);
@@ -388,6 +404,7 @@ export function useAddOpeningPosition({
 
   async function selectLookupResult(result: AssetLookupResult) {
     setSelectedAssetId("");
+    setSelectedLookupResult(result);
     setAssetClass(result.assetClass);
     setAssetName(result.name);
     setInstrumentType(result.instrumentType);
@@ -490,6 +507,7 @@ export function useAddOpeningPosition({
     assetClass,
     assetName,
     averageCostPrice,
+    changeSelectedAsset,
     clearSelectedAsset,
     continueFromAsset,
     continueFromClass,
@@ -520,6 +538,7 @@ export function useAddOpeningPosition({
     selectAsset,
     selectLookupResult,
     selectedAssetId,
+    selectedLookupResult,
     setAssetName,
     setAverageCostPrice,
     setConviction,


### PR DESCRIPTION
## Summary
- Adds an explicit selected-asset summary and Change action after Add Holding lookup selection.
- Renames the visible classification step to Metadata and adds provider-suggestion review copy.
- Extends Add Holding tests for lookup result selection, selected summary, Change, and metadata review states.

## Verification
- npm run typecheck
- npm test -- --runInBand src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx src/features/openingPositions/__tests__/useAddOpeningPosition.test.tsx
- npm test -- --runInBand
- npm run doctor
- npm run android:smoke
- npm run test:v1:pc

Closes #117