### PR TITLE
[V1] Add sell redeem flow

### DIFF
--- a/app/(tabs)/holdings.tsx
+++ b/app/(tabs)/holdings.tsx
@@ -8,6 +8,9 @@ export default function HoldingsScreen() {
       onAddTrade={() => {
         router.push("/add-holding");
       }}
+      onSellRedeem={(assetId) => {
+        router.push({ pathname: "/sell-redeem", params: { assetId } });
+      }}
     />
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -18,6 +18,7 @@ export default function RootLayout() {
         >
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           <Stack.Screen name="add-holding" options={{ title: "Add Holding" }} />
+          <Stack.Screen name="sell-redeem" options={{ headerShown: false }} />
           <Stack.Screen name="settings" options={{ title: "Settings" }} />
           <Stack.Screen
             name="visual-qa-seed"

--- a/app/sell-redeem.tsx
+++ b/app/sell-redeem.tsx
@@ -1,0 +1,16 @@
+import { router, useLocalSearchParams } from "expo-router";
+
+import { SellRedeemScreen } from "@/src/features/sellRedeem";
+
+export default function SellRedeemRoute() {
+  const params = useLocalSearchParams<{ assetId?: string }>();
+
+  return (
+    <SellRedeemScreen
+      assetId={params.assetId ?? ""}
+      onSaved={() => {
+        router.back();
+      }}
+    />
+  );
+}

--- a/docs/superpowers/plans/2026-06-30-issue-146-sell-redeem-flow.md
+++ b/docs/superpowers/plans/2026-06-30-issue-146-sell-redeem-flow.md
@@ -1,0 +1,694 @@
+# Issue #146 Sell / Redeem Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a V1 sell/redeem flow that reduces holding units and links net proceeds into Cash Ledger by default.
+
+**Architecture:** Keep the existing raw-record model. Add domain helpers for available quantity and proceeds, add a focused sell/redeem hook and screen, route Holdings into that screen, and display linked cash proceeds as cash movement evidence. Do not move asset exits into Cash Ledger.
+
+**Tech Stack:** Expo Router, React Native, TypeScript, Zustand vanilla store, Jest, React Native Testing Library.
+
+---
+
+## File Map
+
+- Modify: `src/domain/validators/trade.ts` to calculate available sell quantity from opening positions plus trades.
+- Modify: `src/domain/validators/__tests__/trade.test.ts` to cover opening positions, prior sells, and over-sell rejection.
+- Create: `src/domain/calculations/sellRedeem.ts` for pure proceeds and remaining-position preview calculations.
+- Modify: `src/domain/calculations/index.ts` to export sell/redeem helpers.
+- Create: `src/domain/calculations/__tests__/sellRedeem.test.ts` for proceeds, fee, and remaining-unit calculations.
+- Create: `src/features/sellRedeem/useSellRedeemHolding.ts` for state, validation, preview, and save behavior.
+- Create: `src/features/sellRedeem/SellRedeemScreen.tsx` for the V1 UI.
+- Create: `src/features/sellRedeem/index.ts` for feature exports.
+- Create: `src/features/sellRedeem/__tests__/useSellRedeemHolding.test.tsx` for hook/store behavior.
+- Create: `src/features/sellRedeem/__tests__/SellRedeemScreen.test.tsx` for component behavior.
+- Create: `app/sell-redeem.tsx` for the secondary route.
+- Modify: `app/(tabs)/holdings.tsx` to pass a sell/redeem navigation callback.
+- Modify: `src/features/holdings/HoldingsScreen.tsx` to expose a `Sell / redeem` action in expanded holding details.
+- Modify: `src/features/holdings/__tests__/HoldingsScreen.test.tsx` to verify the entry point.
+- Modify: `src/types/cash.ts` only if the implementation needs a minimal optional link marker for cash rows.
+- Modify: `src/components/cards/CashEntryRow.tsx` only if linked proceeds need distinct movement copy beyond label text.
+- Modify: `src/features/cash/__tests__/CashScreen.test.tsx` only if Cash Ledger row copy changes.
+
+## Task 1: Domain Sell Quantity Validation
+
+**Files:**
+- Modify: `src/domain/validators/trade.ts`
+- Modify: `src/domain/validators/__tests__/trade.test.ts`
+
+- [ ] **Step 1: Add failing tests for opening-position availability**
+
+Add tests that prove sell validation includes opening positions and subtracts previous sells:
+
+```ts
+import type { OpeningPosition, Trade } from "@/src/types";
+
+const openingPosition: OpeningPosition = {
+  assetId: "asset-1",
+  averageCostPrice: 100,
+  currentPrice: 120,
+  date: "2026-04-01",
+  id: "opening-1",
+  quantity: 10,
+};
+
+const previousSell: Trade = {
+  assetId: "asset-1",
+  date: "2026-04-10",
+  id: "sell-1",
+  pricePerUnit: 120,
+  quantity: 3,
+  totalValue: 360,
+  type: "sell",
+};
+
+expect(validateSellQuantity([previousSell], 7, [openingPosition])).toEqual({
+  availableQuantity: 7,
+  isValid: true,
+});
+
+expect(validateSellQuantity([previousSell], 8, [openingPosition])).toEqual({
+  availableQuantity: 7,
+  isValid: false,
+  message: "Sell quantity exceeds available units.",
+});
+```
+
+- [ ] **Step 2: Run the validator tests and confirm failure**
+
+Run: `npm test -- src/domain/validators/__tests__/trade.test.ts`
+
+Expected: TypeScript/Jest failure because `validateSellQuantity` does not accept opening positions yet.
+
+- [ ] **Step 3: Update validator signatures**
+
+Change `getAvailableQuantity` and `validateSellQuantity` to accept optional opening positions:
+
+```ts
+import type { OpeningPosition, Trade, TradeType } from "@/src/types";
+
+export function getAvailableQuantity(
+  trades: Trade[],
+  openingPositions: OpeningPosition[] = [],
+) {
+  const openingQuantity = openingPositions.reduce(
+    (quantity, position) => quantity + position.quantity,
+    0,
+  );
+
+  return trades.reduce((quantity, trade) => {
+    if (trade.type === "sell") {
+      return quantity - trade.quantity;
+    }
+
+    return quantity + trade.quantity;
+  }, openingQuantity);
+}
+
+export function validateSellQuantity(
+  trades: Trade[],
+  sellQuantity: number,
+  openingPositions: OpeningPosition[] = [],
+): SellQuantityResult {
+  const availableQuantity = getAvailableQuantity(trades, openingPositions);
+
+  if (sellQuantity > availableQuantity) {
+    return {
+      availableQuantity,
+      isValid: false,
+      message: "Sell quantity exceeds available units.",
+    };
+  }
+
+  return {
+    availableQuantity,
+    isValid: true,
+  };
+}
+```
+
+- [ ] **Step 4: Run validator tests**
+
+Run: `npm test -- src/domain/validators/__tests__/trade.test.ts`
+
+Expected: PASS.
+
+## Task 2: Pure Sell/Redeem Preview Calculations
+
+**Files:**
+- Create: `src/domain/calculations/sellRedeem.ts`
+- Create: `src/domain/calculations/__tests__/sellRedeem.test.ts`
+- Modify: `src/domain/calculations/index.ts`
+
+- [ ] **Step 1: Add failing calculation tests**
+
+Create tests for gross proceeds, net proceeds, fee rejection, remaining units, and remaining value:
+
+```ts
+import {
+  calculateSellRedeemPreview,
+  validateSellRedeemFees,
+} from "@/src/domain/calculations";
+
+expect(
+  calculateSellRedeemPreview({
+    availableUnits: 10,
+    currentPrice: 150,
+    fees: 25,
+    quantity: 4,
+    sellPrice: 200,
+  }),
+).toEqual({
+  fees: 25,
+  grossProceeds: 800,
+  netProceeds: 775,
+  remainingUnits: 6,
+  remainingValue: 900,
+});
+
+expect(validateSellRedeemFees({ fees: 801, grossProceeds: 800 })).toEqual({
+  isValid: false,
+  message: "Fees cannot exceed gross proceeds.",
+});
+```
+
+- [ ] **Step 2: Run the new calculation tests and confirm failure**
+
+Run: `npm test -- src/domain/calculations/__tests__/sellRedeem.test.ts`
+
+Expected: FAIL because the helper file does not exist.
+
+- [ ] **Step 3: Implement pure helpers**
+
+Create `src/domain/calculations/sellRedeem.ts`:
+
+```ts
+export type SellRedeemPreviewInput = {
+  availableUnits: number;
+  currentPrice: number;
+  fees?: number;
+  quantity: number;
+  sellPrice: number;
+};
+
+export type SellRedeemPreview = {
+  fees: number;
+  grossProceeds: number;
+  netProceeds: number;
+  remainingUnits: number;
+  remainingValue: number;
+};
+
+export function calculateSellRedeemPreview({
+  availableUnits,
+  currentPrice,
+  fees = 0,
+  quantity,
+  sellPrice,
+}: SellRedeemPreviewInput): SellRedeemPreview {
+  const grossProceeds = quantity * sellPrice;
+  const netProceeds = grossProceeds - fees;
+  const remainingUnits = Math.max(0, availableUnits - quantity);
+
+  return {
+    fees,
+    grossProceeds,
+    netProceeds,
+    remainingUnits,
+    remainingValue: remainingUnits * currentPrice,
+  };
+}
+
+export function validateSellRedeemFees({
+  fees,
+  grossProceeds,
+}: {
+  fees: number;
+  grossProceeds: number;
+}) {
+  if (fees > grossProceeds) {
+    return {
+      isValid: false as const,
+      message: "Fees cannot exceed gross proceeds.",
+    };
+  }
+
+  return { isValid: true as const };
+}
+```
+
+Export it from `src/domain/calculations/index.ts`:
+
+```ts
+export * from "./sellRedeem";
+```
+
+- [ ] **Step 4: Run calculation tests**
+
+Run: `npm test -- src/domain/calculations/__tests__/sellRedeem.test.ts`
+
+Expected: PASS.
+
+## Task 3: Sell/Redeem Hook
+
+**Files:**
+- Create: `src/features/sellRedeem/useSellRedeemHolding.ts`
+- Create: `src/features/sellRedeem/index.ts`
+- Create: `src/features/sellRedeem/__tests__/useSellRedeemHolding.test.tsx`
+
+- [ ] **Step 1: Add failing hook tests**
+
+Test these behaviors:
+
+```ts
+const result = renderHook(() =>
+  useSellRedeemHolding({ assetId: "asset-hdfc", store }),
+);
+
+act(() => result.current.setQuantity("5"));
+act(() => result.current.setSellPrice("1700"));
+act(() => result.current.setFees("100"));
+
+expect(result.current.preview?.netProceeds).toBe(8400);
+expect(result.current.linkCashEntry).toBe(true);
+
+act(() => result.current.save());
+
+expect(store.getState().trades).toEqual([
+  expect.objectContaining({
+    assetId: "asset-hdfc",
+    pricePerUnit: 1700,
+    quantity: 5,
+    totalValue: 8400,
+    type: "sell",
+  }),
+]);
+expect(store.getState().cashEntries).toEqual([
+  expect.objectContaining({
+    amount: 8400,
+    label: "HDFC Bank redemption proceeds",
+    type: "addition",
+  }),
+]);
+```
+
+Also test:
+
+- disabling `linkCashEntry` creates only the sell trade
+- over-selling sets a quantity error
+- fees above gross proceeds sets a fees error
+- missing asset or no holding returns a not-found state
+
+- [ ] **Step 2: Run hook tests and confirm failure**
+
+Run: `npm test -- src/features/sellRedeem/__tests__/useSellRedeemHolding.test.tsx`
+
+Expected: FAIL because the hook does not exist.
+
+- [ ] **Step 3: Implement hook state and save behavior**
+
+Implement:
+
+- state: `quantity`, `sellPrice`, `fees`, `date`, `notes`, `linkCashEntry`, `cashAmount`, `cashLabel`, `errors`, `successMessage`
+- derived: `holding`, `availableUnits`, `preview`, `isReady`
+- actions: setters, `toggleLinkCashEntry`, `save`
+
+Use:
+
+- `calculateHoldings` to find the current holding
+- `validateSellQuantity(assetTrades, quantity, assetOpeningPositions)`
+- `calculateSellRedeemPreview`
+- `store.getState().addTrade`
+- `store.getState().addCashEntry` when cash link is enabled
+
+Trade object:
+
+```ts
+{
+  assetId,
+  date,
+  fees: feeValue || undefined,
+  id: createId("trade"),
+  notes: notes.trim() || undefined,
+  pricePerUnit: sellPriceValue,
+  quantity: quantityValue,
+  totalValue: preview.netProceeds,
+  type: "sell",
+}
+```
+
+Cash entry object:
+
+```ts
+{
+  amount: cashAmountValue,
+  date,
+  id: createId("cash"),
+  label: cashLabel.trim(),
+  notes: notes.trim() || `Linked to ${asset.name} sell / redeem`,
+  type: "addition",
+}
+```
+
+- [ ] **Step 4: Run hook tests**
+
+Run: `npm test -- src/features/sellRedeem/__tests__/useSellRedeemHolding.test.tsx`
+
+Expected: PASS.
+
+## Task 4: Sell/Redeem Screen And Route
+
+**Files:**
+- Create: `src/features/sellRedeem/SellRedeemScreen.tsx`
+- Create: `src/features/sellRedeem/__tests__/SellRedeemScreen.test.tsx`
+- Create: `app/sell-redeem.tsx`
+
+- [ ] **Step 1: Add failing screen tests**
+
+Cover:
+
+- selected holding summary renders
+- available units render
+- preview renders after input
+- `Add proceeds to Cash Ledger` is checked by default
+- user can disable linked cash
+- save shows success or calls optional `onSaved`
+- missing asset shows empty/not-found state
+
+Use test IDs:
+
+- `sell-redeem-screen`
+- `sell-redeem-quantity-input`
+- `sell-redeem-price-input`
+- `sell-redeem-fees-input`
+- `sell-redeem-date-input`
+- `sell-redeem-link-cash-toggle`
+- `sell-redeem-cash-amount-input`
+- `sell-redeem-cash-label-input`
+- `sell-redeem-save-button`
+
+- [ ] **Step 2: Run screen tests and confirm failure**
+
+Run: `npm test -- src/features/sellRedeem/__tests__/SellRedeemScreen.test.tsx`
+
+Expected: FAIL because the screen does not exist.
+
+- [ ] **Step 3: Implement screen**
+
+Use existing UI primitives:
+
+- `ScreenContainer`
+- `ScreenHeader`
+- `PremiumCard`
+- `MetricGroup`
+- `AppButton`
+- `FormTextField`
+- `MaskedValue`
+- `EmptyState`
+
+Screen sections:
+
+- header: `Sell / redeem`, subtitle `Record exit • local only`
+- selected holding summary
+- exit details form
+- proceeds preview
+- linked cash movement
+- save button
+
+Keep copy calm:
+
+- `This reduces the holding and can add proceeds to deployable cash.`
+- `Add proceeds to Cash Ledger`
+- `Cash amount`
+- `Cash label`
+
+- [ ] **Step 4: Implement route**
+
+Create `app/sell-redeem.tsx`:
+
+```tsx
+import { router, useLocalSearchParams } from "expo-router";
+
+import { SellRedeemScreen } from "@/src/features/sellRedeem";
+
+export default function SellRedeemRoute() {
+  const params = useLocalSearchParams<{ assetId?: string }>();
+
+  return (
+    <SellRedeemScreen
+      assetId={params.assetId ?? ""}
+      onSaved={() => router.back()}
+    />
+  );
+}
+```
+
+- [ ] **Step 5: Run screen tests**
+
+Run: `npm test -- src/features/sellRedeem/__tests__/SellRedeemScreen.test.tsx`
+
+Expected: PASS.
+
+## Task 5: Holdings Entry Point
+
+**Files:**
+- Modify: `src/features/holdings/HoldingsScreen.tsx`
+- Modify: `src/features/holdings/__tests__/HoldingsScreen.test.tsx`
+- Modify: `app/(tabs)/holdings.tsx`
+
+- [ ] **Step 1: Add failing Holdings test**
+
+Test that expanded holding details show `Sell / redeem` and call a callback with the asset id:
+
+```ts
+const onSellRedeem = jest.fn();
+const { getByTestId, getByText } = render(
+  <HoldingsScreen store={store} onSellRedeem={onSellRedeem} />,
+);
+
+fireEvent.press(getByTestId("holding-row-asset-reliance"));
+fireEvent.press(getByText("Sell / redeem"));
+
+expect(onSellRedeem).toHaveBeenCalledWith("asset-reliance");
+```
+
+- [ ] **Step 2: Run Holdings test and confirm failure**
+
+Run: `npm test -- src/features/holdings/__tests__/HoldingsScreen.test.tsx`
+
+Expected: FAIL because the callback/action does not exist.
+
+- [ ] **Step 3: Add callback prop and action button**
+
+Add prop:
+
+```ts
+onSellRedeem?: (assetId: string) => void;
+```
+
+In expanded holding details, add an `AppButton`:
+
+```tsx
+{onSellRedeem ? (
+  <AppButton
+    title="Sell / redeem"
+    testID={`holding-sell-redeem-${holding.asset.id}`}
+    variant="secondary"
+    onPress={() => onSellRedeem(holding.asset.id)}
+  />
+) : null}
+```
+
+- [ ] **Step 4: Wire route navigation**
+
+Modify `app/(tabs)/holdings.tsx`:
+
+```tsx
+<HoldingsFeatureScreen
+  onAddTrade={() => router.push("/add-holding")}
+  onSellRedeem={(assetId) => {
+    router.push({ pathname: "/sell-redeem", params: { assetId } });
+  }}
+/>
+```
+
+- [ ] **Step 5: Run Holdings tests**
+
+Run: `npm test -- src/features/holdings/__tests__/HoldingsScreen.test.tsx`
+
+Expected: PASS.
+
+## Task 6: Cash Ledger Linked Proceeds Display
+
+**Files:**
+- Modify: `src/components/cards/CashEntryRow.tsx`
+- Modify: `src/features/cash/__tests__/CashScreen.test.tsx`
+
+- [ ] **Step 1: Add Cash Ledger row test for proceeds copy**
+
+Seed a cash addition labelled `HDFC Bank redemption proceeds` and verify the row does not look like a generic deposit:
+
+```ts
+store.getState().addCashEntry({
+  amount: 8400,
+  date: "2026-05-20",
+  id: "cash-proceeds",
+  label: "HDFC Bank redemption proceeds",
+  type: "addition",
+});
+
+expect(getByText("HDFC Bank redemption proceeds")).toBeTruthy();
+expect(getByText("Added from asset exit")).toBeTruthy();
+```
+
+- [ ] **Step 2: Run CashScreen tests and confirm failure**
+
+Run: `npm test -- src/features/cash/__tests__/CashScreen.test.tsx`
+
+Expected: FAIL because the row copy still says `Increased deployable cash`.
+
+- [ ] **Step 3: Add deterministic proceeds detection**
+
+In `CashEntryRow.tsx`, update movement copy:
+
+```ts
+function isAssetExitProceeds(entry: CashEntry) {
+  return /sale proceeds|redemption proceeds/i.test(entry.label);
+}
+
+function getCashEntryMovement(entry: CashEntry) {
+  if (entry.type === "addition" && isAssetExitProceeds(entry)) {
+    return "Added from asset exit";
+  }
+
+  return entry.type === "addition"
+    ? "Increased deployable cash"
+    : "Reduced deployable cash";
+}
+```
+
+- [ ] **Step 4: Run CashScreen tests**
+
+Run: `npm test -- src/features/cash/__tests__/CashScreen.test.tsx`
+
+Expected: PASS.
+
+## Task 7: Integration And Regression Verification
+
+**Files:**
+- Existing tests only, unless failures reveal missing coverage.
+
+- [ ] **Step 1: Run targeted tests**
+
+Run:
+
+```powershell
+npm test -- src/domain/validators/__tests__/trade.test.ts
+npm test -- src/domain/calculations/__tests__/sellRedeem.test.ts
+npm test -- src/features/sellRedeem/__tests__/useSellRedeemHolding.test.tsx
+npm test -- src/features/sellRedeem/__tests__/SellRedeemScreen.test.tsx
+npm test -- src/features/holdings/__tests__/HoldingsScreen.test.tsx
+npm test -- src/features/cash/__tests__/CashScreen.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full static verification**
+
+Run:
+
+```powershell
+npm run typecheck
+npm test
+npm run doctor
+```
+
+Expected: PASS or documented Expo doctor warning that is unrelated to this change.
+
+- [ ] **Step 3: Run Android harness if emulator is available**
+
+Run:
+
+```powershell
+npm run android:doctor
+npm run android:smoke -- --strict
+```
+
+Expected: emulator detected and app package detected if already installed.
+
+- [ ] **Step 4: Run emulator app smoke for the new flow**
+
+Use the local Expo/dev-build loop or installed APK, depending on current environment:
+
+```powershell
+npm run android
+```
+
+Manual emulator checks:
+
+- Holdings opens.
+- Expand a holding.
+- `Sell / redeem` opens the exit flow.
+- Partial sell saves.
+- Holding quantity reduces.
+- Cash Ledger shows the proceeds row.
+- Disabling cash link does not add a proceeds row.
+
+- [ ] **Step 5: Document any deferred visual/E2E work**
+
+If Maestro coverage is not practical in this slice, add a concise note in the PR body under `Deferred` rather than silently skipping it.
+
+## Task 8: Commit And PR
+
+**Files:**
+- All implementation files from Tasks 1-6.
+
+- [ ] **Step 1: Check final diff**
+
+Run:
+
+```powershell
+git status --short
+git diff --stat
+```
+
+Expected: only #146-related files changed.
+
+- [ ] **Step 2: Commit implementation**
+
+Run:
+
+```powershell
+git add app/sell-redeem.tsx app/(tabs)/holdings.tsx src/domain src/features src/components/cards
+git commit -m "feat: add sell redeem flow"
+```
+
+- [ ] **Step 3: Push branch**
+
+Run:
+
+```powershell
+git push -u origin v1/issue-146-sell-redeem-flow
+```
+
+- [ ] **Step 4: Open PR**
+
+PR body must include:
+
+```md
+Closes #146
+
+## Summary
+- adds a holding-owned Sell / redeem flow
+- links net proceeds into Cash Ledger by default
+- validates sell quantity against opening positions and trades
+
+## Verification
+- npm run typecheck
+- npm test
+- npm run doctor
+- npm run android:doctor
+- npm run android:smoke -- --strict
+```
+
+Expected: GitHub shows issue #146 in `closingIssuesReferences`.

--- a/docs/superpowers/specs/2026-06-30-issue-146-sell-redeem-flow-design.md
+++ b/docs/superpowers/specs/2026-06-30-issue-146-sell-redeem-flow-design.md
@@ -1,0 +1,223 @@
+# Issue #146 Sell / Redeem Flow Design
+
+## Status
+
+Approved design direction for V1 implementation.
+
+## Goal
+
+Add a V1 asset exit flow that lets the user sell or redeem part of a holding, reduce the stored position, and link the resulting proceeds into Cash Ledger by default.
+
+## Product Principle
+
+Cash Ledger tracks cash movement. Holdings owns asset exits.
+
+The user should not need to fake a sale by adding a manual cash deposit. CogVest should record the asset exit as a holding transaction and then create the related cash movement as a linked consequence.
+
+## User-Facing Language
+
+Use calm, portfolio-led language:
+
+- `Sell / redeem`
+- `Record exit`
+- `Proceeds`
+- `Remaining units`
+- `Add proceeds to Cash Ledger`
+
+Avoid trading-led language:
+
+- `Place order`
+- `Trade ticket`
+- `Market sell`
+- `Book profit`
+
+## Entry Point
+
+The primary V1 entry point is from a holding row or expanded holding details on the Holdings screen.
+
+The flow should be available only for holdings with positive available units.
+
+## Flow
+
+1. User opens Holdings.
+2. User expands or opens a holding.
+3. User taps `Sell / redeem`.
+4. CogVest opens a focused sell/redeem form for that holding.
+5. Form shows available units and current known price.
+6. User enters quantity, sell price, date, optional fees, and optional note.
+7. CogVest shows a derived preview:
+   - gross proceeds
+   - fees
+   - net proceeds
+   - remaining units
+   - remaining position value
+8. `Add proceeds to Cash Ledger` is checked by default.
+9. User can edit the linked cash amount/label or uncheck the cash link.
+10. Save creates a `sell` trade and, if enabled, a linked cash `addition`.
+
+## Default Cash-Link Behavior
+
+The default behavior is:
+
+- checked: `Add proceeds to Cash Ledger`
+- amount: net proceeds
+- cash type: `addition`
+- label: `<Asset name> redemption proceeds` or `<Asset name> sale proceeds`
+- note: optional user note plus enough deterministic context to understand the link
+
+The user can:
+
+- leave the default as-is
+- edit the cash amount if settlement differs from calculated proceeds
+- edit the cash label
+- uncheck the link if proceeds should not count as deployable cash
+
+## Domain Model Direction
+
+Use the existing raw-record model:
+
+- persist a `Trade` with `type: "sell"`
+- persist a `CashEntry` with `type: "addition"` when cash linking is enabled
+- continue deriving holdings, P&L, allocation, rollups, and snapshots from raw records
+
+Do not persist derived remaining units or proceeds summaries.
+
+## Required Domain Behavior
+
+The sell/redeem validator must account for:
+
+- opening positions
+- buy trades
+- prior sell trades
+
+It must reject sell quantity above currently available units.
+
+The holding calculation already treats sell trades as unit reductions and keeps average cost stable for remaining units. The implementation should preserve that behavior.
+
+## Fees And Proceeds
+
+Use this V1 calculation:
+
+- `gross proceeds = quantity * sell price`
+- `net proceeds = gross proceeds - fees`
+
+Fees must be optional and non-negative.
+
+If fees exceed gross proceeds, reject the form with a clear error.
+
+## UI Requirements
+
+The flow should feel like a premium ledger action, not a trading screen.
+
+Minimum screen sections:
+
+- selected holding summary
+- exit details
+- proceeds preview
+- linked cash movement
+- final save action
+
+The selected holding summary should show:
+
+- asset name
+- symbol/ticker
+- asset class
+- available units
+- current value or current known price
+
+Exit details should capture:
+
+- quantity to sell/redeem
+- sell price
+- date
+- fees
+- optional note
+
+Proceeds preview should show:
+
+- gross proceeds
+- fees
+- net proceeds
+- remaining units
+- remaining value estimate
+
+Linked cash movement should show:
+
+- checked by default
+- cash amount
+- cash label
+- explanation that this adds proceeds to deployable cash
+
+## Cash Ledger Requirements
+
+Cash Ledger should continue exposing only manual cash movement actions:
+
+- Deposit
+- Withdraw
+
+It should not become the entry point for asset exits.
+
+When linked proceeds exist, Cash Ledger rows should make them distinguishable from generic deposits through their label/copy, for example:
+
+- `HDFC Bank redemption proceeds`
+- `Bitcoin sale proceeds`
+
+## Out Of Scope
+
+Do not implement:
+
+- LTCG or tax calculations
+- FIFO tax lots
+- realized P&L reports
+- broker import/export
+- multi-account settlement modeling
+- order execution or broker integration
+- advanced audit trail UI
+
+## Testing Requirements
+
+Unit/domain tests:
+
+- available quantity includes opening positions
+- available quantity subtracts prior sell trades
+- sell quantity above available units is rejected
+- net proceeds subtract fees
+- fees above gross proceeds are rejected
+- saving with cash link creates sell trade plus linked cash addition
+- saving without cash link creates only sell trade
+
+Component tests:
+
+- Holdings exposes `Sell / redeem` for an existing holding
+- Sell/redeem form displays available units
+- preview updates from quantity, price, and fees
+- cash link is checked by default
+- save creates the expected store records
+- over-sell validation is visible
+
+Android verification:
+
+- seed or create a holding
+- record a partial sell/redeem
+- verify holding units reduce
+- verify Cash Ledger shows linked proceeds
+- verify disabling cash link does not add a cash row
+
+## Acceptance Criteria Mapping
+
+- A user can record an asset sell/redeem/exit without using Cash Ledger as the primary entry point.
+- Recording an exit reduces the holding quantity/current position correctly.
+- Sale proceeds are calculated from quantity and sell price.
+- The user can create or confirm a linked cash inflow from sale proceeds.
+- Cash Ledger displays linked proceeds as sale/redemption cash movement.
+- Cash Ledger still only exposes Deposit and Withdraw manual actions.
+- V1 copy clearly separates cash movement from asset exits.
+- Tests cover holding quantity reduction, proceeds calculation, and linked cash inflow behavior.
+- Android emulator evidence covers the sell/redeem flow and resulting Cash Ledger row.
+
+## Open Implementation Notes
+
+- Prefer adding a focused `useSellRedeemHolding` hook rather than expanding `useAddTrade`.
+- Reuse existing `Trade` type where possible.
+- If a `CashEntry` link identifier is needed for future auditability, introduce it in the smallest compatible way. Do not build a full audit trail in V1.
+- If route structure allows it, use a secondary route such as `app/sell-redeem.tsx`; otherwise use a focused modal/screen launched from Holdings.

--- a/src/components/cards/CashEntryRow.tsx
+++ b/src/components/cards/CashEntryRow.tsx
@@ -16,7 +16,15 @@ function formatCashAmount(entry: CashEntry) {
   return entry.type === "addition" ? `+${amount}` : `-${amount}`;
 }
 
+function isAssetExitProceeds(entry: CashEntry) {
+  return /sale proceeds|redemption proceeds/i.test(entry.label);
+}
+
 function getCashEntryMovement(entry: CashEntry) {
+  if (entry.type === "addition" && isAssetExitProceeds(entry)) {
+    return "Added from asset exit";
+  }
+
   return entry.type === "addition"
     ? "Increased deployable cash"
     : "Reduced deployable cash";

--- a/src/domain/calculations/__tests__/sellRedeem.test.ts
+++ b/src/domain/calculations/__tests__/sellRedeem.test.ts
@@ -1,0 +1,49 @@
+import {
+  calculateSellRedeemPreview,
+  validateSellRedeemFees,
+} from "@/src/domain/calculations";
+
+describe("sell/redeem calculations", () => {
+  it("calculates proceeds and remaining position preview", () => {
+    expect(
+      calculateSellRedeemPreview({
+        availableUnits: 10,
+        currentPrice: 150,
+        fees: 25,
+        quantity: 4,
+        sellPrice: 200,
+      }),
+    ).toEqual({
+      fees: 25,
+      grossProceeds: 800,
+      netProceeds: 775,
+      remainingUnits: 6,
+      remainingValue: 900,
+    });
+  });
+
+  it("defaults fees to zero", () => {
+    expect(
+      calculateSellRedeemPreview({
+        availableUnits: 2,
+        currentPrice: 100,
+        quantity: 1,
+        sellPrice: 125,
+      }),
+    ).toMatchObject({
+      fees: 0,
+      grossProceeds: 125,
+      netProceeds: 125,
+    });
+  });
+
+  it("rejects fees above gross proceeds", () => {
+    expect(validateSellRedeemFees({ fees: 801, grossProceeds: 800 })).toEqual({
+      isValid: false,
+      message: "Fees cannot exceed gross proceeds.",
+    });
+    expect(validateSellRedeemFees({ fees: 800, grossProceeds: 800 })).toEqual({
+      isValid: true,
+    });
+  });
+});

--- a/src/domain/calculations/index.ts
+++ b/src/domain/calculations/index.ts
@@ -38,3 +38,11 @@ export type {
   PortfolioRollupTotals,
   PortfolioDayChange,
 } from "./holdings";
+export {
+  calculateSellRedeemPreview,
+  validateSellRedeemFees,
+} from "./sellRedeem";
+export type {
+  SellRedeemPreview,
+  SellRedeemPreviewInput,
+} from "./sellRedeem";

--- a/src/domain/calculations/sellRedeem.ts
+++ b/src/domain/calculations/sellRedeem.ts
@@ -1,0 +1,52 @@
+export type SellRedeemPreviewInput = {
+  availableUnits: number;
+  currentPrice: number;
+  fees?: number;
+  quantity: number;
+  sellPrice: number;
+};
+
+export type SellRedeemPreview = {
+  fees: number;
+  grossProceeds: number;
+  netProceeds: number;
+  remainingUnits: number;
+  remainingValue: number;
+};
+
+export function calculateSellRedeemPreview({
+  availableUnits,
+  currentPrice,
+  fees = 0,
+  quantity,
+  sellPrice,
+}: SellRedeemPreviewInput): SellRedeemPreview {
+  const grossProceeds = quantity * sellPrice;
+  const netProceeds = grossProceeds - fees;
+  const remainingUnits = Math.max(0, availableUnits - quantity);
+
+  return {
+    fees,
+    grossProceeds,
+    netProceeds,
+    remainingUnits,
+    remainingValue: remainingUnits * currentPrice,
+  };
+}
+
+export function validateSellRedeemFees({
+  fees,
+  grossProceeds,
+}: {
+  fees: number;
+  grossProceeds: number;
+}) {
+  if (fees > grossProceeds) {
+    return {
+      isValid: false as const,
+      message: "Fees cannot exceed gross proceeds.",
+    };
+  }
+
+  return { isValid: true as const };
+}

--- a/src/domain/validators/__tests__/trade.test.ts
+++ b/src/domain/validators/__tests__/trade.test.ts
@@ -1,5 +1,5 @@
 import { validateSellQuantity, validateTradeInput } from "@/src/domain/validators";
-import type { Trade } from "@/src/types";
+import type { OpeningPosition, Trade } from "@/src/types";
 
 const existingBuy: Trade = {
   assetId: "asset-1",
@@ -9,6 +9,15 @@ const existingBuy: Trade = {
   quantity: 5,
   totalValue: 500,
   type: "buy",
+};
+
+const existingOpeningPosition: OpeningPosition = {
+  assetId: "asset-1",
+  averageCostPrice: 100,
+  currentPrice: 120,
+  date: "2026-04-01T00:00:00.000Z",
+  id: "opening-1",
+  quantity: 10,
 };
 
 describe("trade validators", () => {
@@ -22,6 +31,33 @@ describe("trade validators", () => {
   it("rejects sell quantity above available units", () => {
     expect(validateSellQuantity([existingBuy], 6)).toEqual({
       availableQuantity: 5,
+      isValid: false,
+      message: "Sell quantity exceeds available units.",
+    });
+  });
+
+  it("includes opening positions when validating sell quantity", () => {
+    expect(validateSellQuantity([], 7, [existingOpeningPosition])).toEqual({
+      availableQuantity: 10,
+      isValid: true,
+    });
+  });
+
+  it("subtracts prior sells from opening positions when validating sell quantity", () => {
+    const priorSell: Trade = {
+      ...existingBuy,
+      id: "trade-sell",
+      quantity: 3,
+      totalValue: 360,
+      type: "sell",
+    };
+
+    expect(validateSellQuantity([priorSell], 7, [existingOpeningPosition])).toEqual({
+      availableQuantity: 7,
+      isValid: true,
+    });
+    expect(validateSellQuantity([priorSell], 8, [existingOpeningPosition])).toEqual({
+      availableQuantity: 7,
       isValid: false,
       message: "Sell quantity exceeds available units.",
     });

--- a/src/domain/validators/trade.ts
+++ b/src/domain/validators/trade.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import type { Trade, TradeType } from "@/src/types";
+import type { OpeningPosition, Trade, TradeType } from "@/src/types";
 
 type ValidationResult =
   | { isValid: true }
@@ -53,21 +53,30 @@ export function createTradeInputSchema(now = new Date()) {
 
 export const tradeInputSchema = createTradeInputSchema();
 
-export function getAvailableQuantity(trades: Trade[]) {
+export function getAvailableQuantity(
+  trades: Trade[],
+  openingPositions: OpeningPosition[] = [],
+) {
+  const openingQuantity = openingPositions.reduce(
+    (quantity, position) => quantity + position.quantity,
+    0,
+  );
+
   return trades.reduce((quantity, trade) => {
     if (trade.type === "sell") {
       return quantity - trade.quantity;
     }
 
     return quantity + trade.quantity;
-  }, 0);
+  }, openingQuantity);
 }
 
 export function validateSellQuantity(
   trades: Trade[],
   sellQuantity: number,
+  openingPositions: OpeningPosition[] = [],
 ): SellQuantityResult {
-  const availableQuantity = getAvailableQuantity(trades);
+  const availableQuantity = getAvailableQuantity(trades, openingPositions);
 
   if (sellQuantity > availableQuantity) {
     return {

--- a/src/features/cash/__tests__/CashScreen.test.tsx
+++ b/src/features/cash/__tests__/CashScreen.test.tsx
@@ -116,6 +116,23 @@ describe("CashScreen", () => {
     expect(queryByText("Investment Transfer")).toBeNull();
   });
 
+  it("shows asset exit proceeds as linked cash movement", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addCashEntry({
+      amount: 8400,
+      date: "2026-05-20",
+      id: "cash-proceeds",
+      label: "HDFC Bank redemption proceeds",
+      type: "addition",
+    });
+
+    const { getByText } = render(<CashScreen store={store} />);
+
+    expect(getByText("HDFC Bank redemption proceeds")).toBeTruthy();
+    expect(getByText("Added from asset exit")).toBeTruthy();
+    expect(getByText("+₹8,400.00")).toBeTruthy();
+  });
+
   it("shows validation errors for invalid cash entries", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     const { getByTestId, getByText } = render(<CashScreen store={store} />);

--- a/src/features/holdings/HoldingsScreen.tsx
+++ b/src/features/holdings/HoldingsScreen.tsx
@@ -4,6 +4,7 @@ import { Pressable, RefreshControl, StyleSheet, View } from "react-native";
 import type { StoreApi } from "zustand/vanilla";
 
 import {
+  AppButton,
   AppText,
   CategoryIcon,
   EmptyState,
@@ -44,6 +45,7 @@ type RefreshQuotes = (
 
 type HoldingsScreenProps = {
   onAddTrade?: () => void;
+  onSellRedeem?: (assetId: string) => void;
   refreshQuotes?: RefreshQuotes;
   store?: StoreApi<PortfolioStoreState>;
 };
@@ -63,6 +65,7 @@ const exposureColors: Record<ExposureSegment["color"], string> = {
 
 export function HoldingsScreen({
   onAddTrade,
+  onSellRedeem,
   refreshQuotes,
   store = getPortfolioStore(),
 }: HoldingsScreenProps) {
@@ -206,6 +209,7 @@ export function HoldingsScreen({
                     item={item}
                     key={item.holding.asset.id}
                     masked={maskWealthValues}
+                    onSellRedeem={onSellRedeem}
                     onPress={() =>
                       setExpandedAssetId((current) =>
                         current === item.holding.asset.id
@@ -376,11 +380,13 @@ function HoldingRow({
   item,
   masked,
   onPress,
+  onSellRedeem,
 }: {
   expanded: boolean;
   item: HoldingReviewItem;
   masked: boolean;
   onPress: () => void;
+  onSellRedeem?: (assetId: string) => void;
 }) {
   const { holding } = item;
   const positive = holding.unrealisedPnL >= 0;
@@ -504,6 +510,15 @@ function HoldingRow({
                 : "Local position price"}
             </AppText>
           </View>
+
+          {onSellRedeem ? (
+            <AppButton
+              title="Sell / redeem"
+              variant="secondary"
+              testID={`holding-sell-redeem-${holding.asset.id}`}
+              onPress={() => onSellRedeem(holding.asset.id)}
+            />
+          ) : null}
         </View>
       ) : null}
     </Pressable>

--- a/src/features/holdings/__tests__/HoldingsScreen.test.tsx
+++ b/src/features/holdings/__tests__/HoldingsScreen.test.tsx
@@ -172,6 +172,19 @@ describe("HoldingsScreen", () => {
     expect(getByTestId(`holding-expanded-${debtAsset.id}`)).toBeTruthy();
   });
 
+  it("exposes a Sell / redeem action from expanded holding details", () => {
+    const store = seedMixedHoldings();
+    const onSellRedeem = jest.fn();
+    const { getByTestId } = render(
+      <HoldingsScreen store={store} onSellRedeem={onSellRedeem} />,
+    );
+
+    fireEvent.press(getByTestId(`holding-row-${asset.id}`));
+    fireEvent.press(getByTestId(`holding-sell-redeem-${asset.id}`));
+
+    expect(onSellRedeem).toHaveBeenCalledWith(asset.id);
+  });
+
   it("wires header Add Holding and value masking actions", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     store.getState().addAsset(asset);

--- a/src/features/sellRedeem/SellRedeemScreen.tsx
+++ b/src/features/sellRedeem/SellRedeemScreen.tsx
@@ -32,6 +32,10 @@ function formatUnits(value: number) {
   return Number.isInteger(value) ? value.toString() : value.toFixed(4).replace(/0+$/, "");
 }
 
+function quantityPlaceholder(availableUnits: number) {
+  return availableUnits > 0 ? `Max ${formatUnits(availableUnits)}` : "0";
+}
+
 export function SellRedeemScreen({
   assetId,
   onSaved,
@@ -113,7 +117,7 @@ export function SellRedeemScreen({
                 keyboardType="decimal-pad"
                 label="Quantity"
                 onChangeText={flow.setQuantity}
-                placeholder="5"
+                placeholder={quantityPlaceholder(flow.availableUnits)}
                 testID="sell-redeem-quantity-input"
                 value={flow.quantity}
               />

--- a/src/features/sellRedeem/SellRedeemScreen.tsx
+++ b/src/features/sellRedeem/SellRedeemScreen.tsx
@@ -1,0 +1,356 @@
+import { Pressable, StyleSheet, View } from "react-native";
+import type { StoreApi } from "zustand/vanilla";
+
+import {
+  AppButton,
+  AppText,
+  CategoryIcon,
+  EmptyState,
+  MaskedValue,
+  MetricGroup,
+  PremiumCard,
+  ScreenContainer,
+  ScreenHeader,
+  SectionHeader,
+  assetClassLabel,
+  getPressedStateStyle,
+} from "@/src/components/common";
+import { FormTextField } from "@/src/components/forms";
+import { formatCompactINR, formatINR } from "@/src/domain/formatters";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import { colors, radii, spacing } from "@/src/theme";
+
+import { useSellRedeemHolding } from "./useSellRedeemHolding";
+
+type SellRedeemScreenProps = {
+  assetId: string;
+  onSaved?: () => void;
+  store?: StoreApi<PortfolioStoreState>;
+};
+
+function formatUnits(value: number) {
+  return Number.isInteger(value) ? value.toString() : value.toFixed(4).replace(/0+$/, "");
+}
+
+export function SellRedeemScreen({
+  assetId,
+  onSaved,
+  store = getPortfolioStore(),
+}: SellRedeemScreenProps) {
+  const flow = useSellRedeemHolding({ assetId, store });
+
+  if (!flow.holding) {
+    return (
+      <ScreenContainer scroll testID="sell-redeem-screen">
+        <View style={styles.content}>
+          <ScreenHeader title="Sell / redeem" subtitle="Record exit • local only" />
+          <EmptyState
+            message="Open Holdings and choose an active position to sell or redeem."
+            title="Holding not found"
+          />
+        </View>
+      </ScreenContainer>
+    );
+  }
+
+  const { holding } = flow;
+
+  function save() {
+    const result = flow.save();
+
+    if (result.isValid) {
+      onSaved?.();
+    }
+  }
+
+  return (
+    <ScreenContainer scroll testID="sell-redeem-screen">
+      <View style={styles.content}>
+        <ScreenHeader title="Sell / redeem" subtitle="Record exit • local only" />
+
+        <PremiumCard style={styles.summaryCard}>
+          <View style={styles.summaryRow}>
+            <View style={styles.assetIcon}>
+              <CategoryIcon assetClass={holding.asset.assetClass} size={24} />
+            </View>
+            <View style={styles.assetCopy}>
+              <AppText variant="title" weight="bold">
+                {holding.asset.name}
+              </AppText>
+              <AppText color="secondary">
+                {holding.asset.symbol} • {assetClassLabel(holding.asset.assetClass)}
+              </AppText>
+            </View>
+          </View>
+          <MetricGroup
+            metrics={[
+              {
+                label: "Available units",
+                value: formatUnits(flow.availableUnits),
+              },
+              {
+                label: "Current price",
+                value: formatCompactINR(holding.currentPrice),
+              },
+              {
+                label: "Current value",
+                masked: false,
+                value: formatCompactINR(holding.currentValue),
+              },
+            ]}
+          />
+        </PremiumCard>
+
+        <PremiumCard>
+          <SectionHeader title="Exit details" />
+          <AppText color="secondary" variant="caption">
+            This reduces the holding and can add proceeds to deployable cash.
+          </AppText>
+          <View style={styles.formRow}>
+            <View style={styles.formField}>
+              <FormTextField
+                error={flow.errors.quantity}
+                keyboardType="decimal-pad"
+                label="Quantity"
+                onChangeText={flow.setQuantity}
+                placeholder="5"
+                testID="sell-redeem-quantity-input"
+                value={flow.quantity}
+              />
+            </View>
+            <View style={styles.formField}>
+              <FormTextField
+                error={flow.errors.sellPrice}
+                keyboardType="decimal-pad"
+                label="Sell price"
+                onChangeText={flow.setSellPrice}
+                placeholder="1700"
+                testID="sell-redeem-price-input"
+                value={flow.sellPrice}
+              />
+            </View>
+          </View>
+          <View style={styles.formRow}>
+            <View style={styles.formField}>
+              <FormTextField
+                error={flow.errors.fees}
+                keyboardType="decimal-pad"
+                label="Fees"
+                onChangeText={flow.setFees}
+                placeholder="0"
+                testID="sell-redeem-fees-input"
+                value={flow.fees}
+              />
+            </View>
+            <View style={styles.formField}>
+              <FormTextField
+                error={flow.errors.date}
+                label="Date"
+                onChangeText={flow.setDate}
+                placeholder="YYYY-MM-DD"
+                testID="sell-redeem-date-input"
+                value={flow.date}
+              />
+            </View>
+          </View>
+          <FormTextField
+            label="Notes"
+            multiline
+            onChangeText={flow.setNotes}
+            placeholder="Optional note"
+            value={flow.notes}
+          />
+        </PremiumCard>
+
+        <PremiumCard>
+          <SectionHeader title="Proceeds preview" />
+          {flow.preview ? (
+            <View style={styles.previewGrid}>
+              <PreviewValue label="Gross proceeds" value={formatINR(flow.preview.grossProceeds)} />
+              <PreviewValue label="Fees" value={formatINR(flow.preview.fees)} />
+              <PreviewValue
+                emphasized
+                label="Net proceeds"
+                value={formatINR(flow.preview.netProceeds)}
+              />
+              <PreviewValue
+                label="Remaining units"
+                value={formatUnits(flow.preview.remainingUnits)}
+              />
+              <PreviewValue
+                label="Remaining value"
+                value={formatINR(flow.preview.remainingValue)}
+              />
+            </View>
+          ) : (
+            <AppText color="secondary" variant="caption">
+              Enter quantity and sell price to preview proceeds.
+            </AppText>
+          )}
+        </PremiumCard>
+
+        <PremiumCard>
+          <Pressable
+            accessibilityRole="checkbox"
+            accessibilityState={{ checked: flow.linkCashEntry }}
+            onPress={() => flow.setLinkCashEntry(!flow.linkCashEntry)}
+            style={({ pressed }) => [
+              styles.cashToggle,
+              getPressedStateStyle({ pressed }),
+            ]}
+            testID="sell-redeem-link-cash-toggle"
+          >
+            <View
+              style={[
+                styles.checkbox,
+                flow.linkCashEntry && styles.checkboxActive,
+              ]}
+            >
+              {flow.linkCashEntry ? <View style={styles.checkboxDot} /> : null}
+            </View>
+            <View style={styles.assetCopy}>
+              <AppText weight="bold">Add proceeds to Cash Ledger</AppText>
+              <AppText color="secondary" variant="caption">
+                Keeps deployable cash aligned with this asset exit.
+              </AppText>
+            </View>
+          </Pressable>
+
+          {flow.linkCashEntry ? (
+            <>
+              <View style={styles.formRow}>
+                <View style={styles.formField}>
+                  <FormTextField
+                    error={flow.errors.cashAmount}
+                    keyboardType="decimal-pad"
+                    label="Cash amount"
+                    onChangeText={flow.setCashAmount}
+                    placeholder="8400"
+                    testID="sell-redeem-cash-amount-input"
+                    value={flow.cashAmount}
+                  />
+                </View>
+                <View style={styles.formField}>
+                  <FormTextField
+                    error={flow.errors.cashLabel}
+                    label="Cash label"
+                    onChangeText={flow.setCashLabel}
+                    placeholder="Redemption proceeds"
+                    testID="sell-redeem-cash-label-input"
+                    value={flow.cashLabel}
+                  />
+                </View>
+              </View>
+            </>
+          ) : null}
+        </PremiumCard>
+
+        {flow.successMessage ? (
+          <AppText style={styles.successText} weight="bold">
+            {flow.successMessage}
+          </AppText>
+        ) : null}
+
+        <AppButton
+          title="Save sell / redeem"
+          testID="sell-redeem-save-button"
+          onPress={save}
+        />
+      </View>
+    </ScreenContainer>
+  );
+}
+
+function PreviewValue({
+  emphasized,
+  label,
+  value,
+}: {
+  emphasized?: boolean;
+  label: string;
+  value: string;
+}) {
+  return (
+    <View style={styles.previewValue}>
+      <AppText color="secondary" variant="caption">
+        {label}
+      </AppText>
+      <MaskedValue
+        masked={false}
+        value={value}
+        variant={emphasized ? "title" : "body"}
+        weight="bold"
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  assetCopy: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  assetIcon: {
+    alignItems: "center",
+    backgroundColor: colors.surface.elevated,
+    borderRadius: radii.pill,
+    height: 48,
+    justifyContent: "center",
+    width: 48,
+  },
+  cashToggle: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: spacing.md,
+  },
+  checkbox: {
+    alignItems: "center",
+    backgroundColor: colors.surface.elevated,
+    borderRadius: radii.pill,
+    height: 28,
+    justifyContent: "center",
+    width: 28,
+  },
+  checkboxActive: {
+    backgroundColor: colors.primary,
+  },
+  checkboxDot: {
+    backgroundColor: colors.text.inverse,
+    borderRadius: radii.pill,
+    height: 8,
+    width: 8,
+  },
+  content: {
+    gap: spacing.cardGap,
+    paddingBottom: spacing.lg,
+    paddingTop: spacing.md,
+  },
+  formField: {
+    flex: 1,
+  },
+  formRow: {
+    flexDirection: "row",
+    gap: spacing.sm,
+  },
+  previewGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.md,
+  },
+  previewValue: {
+    flexBasis: "45%",
+    flexGrow: 1,
+    gap: spacing.xs,
+  },
+  successText: {
+    color: colors.profit,
+  },
+  summaryCard: {
+    gap: spacing.md,
+  },
+  summaryRow: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: spacing.md,
+  },
+});

--- a/src/features/sellRedeem/SellRedeemScreen.tsx
+++ b/src/features/sellRedeem/SellRedeemScreen.tsx
@@ -160,10 +160,9 @@ export function SellRedeemScreen({
             placeholder="Optional note"
             value={flow.notes}
           />
-        </PremiumCard>
 
-        <PremiumCard>
-          <SectionHeader title="Proceeds preview" />
+          <View style={styles.previewPanel}>
+            <SectionHeader title="Proceeds preview" />
           {flow.preview ? (
             <View style={styles.previewGrid}>
               <PreviewValue label="Gross proceeds" value={formatINR(flow.preview.grossProceeds)} />
@@ -184,9 +183,10 @@ export function SellRedeemScreen({
             </View>
           ) : (
             <AppText color="secondary" variant="caption">
-              Enter quantity and sell price to preview proceeds.
+              Enter a valid quantity and sell price to preview proceeds.
             </AppText>
           )}
+          </View>
         </PremiumCard>
 
         <PremiumCard>
@@ -217,7 +217,7 @@ export function SellRedeemScreen({
           </Pressable>
 
           {flow.linkCashEntry ? (
-            <>
+            flow.preview ? (
               <View style={styles.formRow}>
                 <View style={styles.formField}>
                   <FormTextField
@@ -241,7 +241,11 @@ export function SellRedeemScreen({
                   />
                 </View>
               </View>
-            </>
+            ) : (
+              <AppText color="secondary" variant="caption">
+                Cash entry appears after the exit proceeds are valid.
+              </AppText>
+            )
           ) : null}
         </PremiumCard>
 
@@ -252,6 +256,7 @@ export function SellRedeemScreen({
         ) : null}
 
         <AppButton
+          disabled={!flow.canSave}
           title="Save sell / redeem"
           testID="sell-redeem-save-button"
           onPress={save}
@@ -336,6 +341,12 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     flexWrap: "wrap",
     gap: spacing.md,
+  },
+  previewPanel: {
+    backgroundColor: colors.surface.elevated,
+    borderRadius: radii.card,
+    gap: spacing.sm,
+    padding: spacing.cardInner,
   },
   previewValue: {
     flexBasis: "45%",

--- a/src/features/sellRedeem/__tests__/SellRedeemScreen.test.tsx
+++ b/src/features/sellRedeem/__tests__/SellRedeemScreen.test.tsx
@@ -42,9 +42,9 @@ function seedStore() {
 }
 
 describe("SellRedeemScreen", () => {
-  it("renders the selected holding and default linked cash movement", () => {
+  it("renders the selected holding and waits to show linked cash fields until proceeds are valid", () => {
     const store = seedStore();
-    const { getByTestId, getByText } = render(
+    const { getByTestId, getByText, queryByTestId } = render(
       <SellRedeemScreen assetId={asset.id} store={store} />,
     );
 
@@ -54,7 +54,8 @@ describe("SellRedeemScreen", () => {
     expect(getByText("Available units")).toBeTruthy();
     expect(getByText("25")).toBeTruthy();
     expect(getByText("Add proceeds to Cash Ledger")).toBeTruthy();
-    expect(getByTestId("sell-redeem-cash-amount-input")).toBeTruthy();
+    expect(getByText("Cash entry appears after the exit proceeds are valid.")).toBeTruthy();
+    expect(queryByTestId("sell-redeem-cash-amount-input")).toBeNull();
   });
 
   it("updates preview and saves the linked proceeds", async () => {
@@ -106,6 +107,20 @@ describe("SellRedeemScreen", () => {
 
     expect(store.getState().trades).toHaveLength(1);
     expect(store.getState().cashEntries).toEqual([]);
+  });
+
+  it("blocks overselling before save and keeps cash fields hidden", () => {
+    const store = seedStore();
+    const { getByLabelText, getByTestId, getByText, queryByTestId } = render(
+      <SellRedeemScreen assetId={asset.id} store={store} />,
+    );
+
+    fireEvent.changeText(getByLabelText("Quantity"), "26");
+    fireEvent.changeText(getByLabelText("Sell price"), "1700");
+
+    expect(getByText("Sell quantity exceeds available units.")).toBeTruthy();
+    expect(queryByTestId("sell-redeem-cash-amount-input")).toBeNull();
+    expect(getByTestId("sell-redeem-save-button")).toBeDisabled();
   });
 
   it("shows an empty state when the holding is missing", () => {

--- a/src/features/sellRedeem/__tests__/SellRedeemScreen.test.tsx
+++ b/src/features/sellRedeem/__tests__/SellRedeemScreen.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+
+import { SellRedeemScreen } from "@/src/features/sellRedeem";
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import { createPortfolioStore } from "@/src/store";
+import type { Asset } from "@/src/types";
+
+const asset: Asset = {
+  assetClass: "stock",
+  currency: "INR",
+  exchange: "NSE",
+  id: "asset-hdfc",
+  instrumentType: "stock",
+  name: "HDFC Bank",
+  quoteSourceId: "HDFCBANK.NS",
+  sectorType: "financialServices",
+  symbol: "HDFCBANK",
+  ticker: "HDFCBANK.NS",
+};
+
+function seedStore() {
+  const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+
+  store.getState().addAsset(asset);
+  store.getState().addOpeningPosition({
+    assetId: asset.id,
+    averageCostPrice: 1450,
+    currentPrice: 1678,
+    date: "2026-04-15",
+    id: "opening-hdfc",
+    quantity: 25,
+  });
+  store.getState().upsertQuote({
+    asOf: "2026-05-20T10:00:00.000Z",
+    assetId: asset.id,
+    currency: "INR",
+    price: 1700,
+    source: "yahoo",
+  });
+
+  return store;
+}
+
+describe("SellRedeemScreen", () => {
+  it("renders the selected holding and default linked cash movement", () => {
+    const store = seedStore();
+    const { getByTestId, getByText } = render(
+      <SellRedeemScreen assetId={asset.id} store={store} />,
+    );
+
+    expect(getByTestId("sell-redeem-screen")).toBeTruthy();
+    expect(getByText("Sell / redeem")).toBeTruthy();
+    expect(getByText("HDFC Bank")).toBeTruthy();
+    expect(getByText("Available units")).toBeTruthy();
+    expect(getByText("25")).toBeTruthy();
+    expect(getByText("Add proceeds to Cash Ledger")).toBeTruthy();
+    expect(getByTestId("sell-redeem-cash-amount-input")).toBeTruthy();
+  });
+
+  it("updates preview and saves the linked proceeds", async () => {
+    const store = seedStore();
+    const onSaved = jest.fn();
+    const { getByLabelText, getByTestId, getByText } = render(
+      <SellRedeemScreen assetId={asset.id} store={store} onSaved={onSaved} />,
+    );
+
+    fireEvent.changeText(getByLabelText("Quantity"), "5");
+    fireEvent.changeText(getByLabelText("Sell price"), "1700");
+    fireEvent.changeText(getByLabelText("Fees"), "100");
+    fireEvent.changeText(getByLabelText("Date"), "2026-05-20");
+
+    await waitFor(() => {
+      expect(getByText("Net proceeds")).toBeTruthy();
+      expect(getByText("₹8,400.00")).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId("sell-redeem-save-button"));
+
+    expect(store.getState().trades[0]).toMatchObject({
+      quantity: 5,
+      totalValue: 8400,
+      type: "sell",
+    });
+    expect(store.getState().cashEntries[0]).toMatchObject({
+      amount: 8400,
+      label: "HDFC Bank redemption proceeds",
+      type: "addition",
+    });
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets the user disable linked cash proceeds", () => {
+    const store = seedStore();
+    const { getByLabelText, getByTestId, queryByTestId } = render(
+      <SellRedeemScreen assetId={asset.id} store={store} />,
+    );
+
+    fireEvent.press(getByTestId("sell-redeem-link-cash-toggle"));
+
+    expect(queryByTestId("sell-redeem-cash-amount-input")).toBeNull();
+
+    fireEvent.changeText(getByLabelText("Quantity"), "1");
+    fireEvent.changeText(getByLabelText("Sell price"), "1700");
+    fireEvent.changeText(getByLabelText("Date"), "2026-05-20");
+    fireEvent.press(getByTestId("sell-redeem-save-button"));
+
+    expect(store.getState().trades).toHaveLength(1);
+    expect(store.getState().cashEntries).toEqual([]);
+  });
+
+  it("shows an empty state when the holding is missing", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const { getByText } = render(
+      <SellRedeemScreen assetId={asset.id} store={store} />,
+    );
+
+    expect(getByText("Holding not found")).toBeTruthy();
+    expect(getByText("Open Holdings and choose an active position to sell or redeem.")).toBeTruthy();
+  });
+});

--- a/src/features/sellRedeem/__tests__/SellRedeemScreen.test.tsx
+++ b/src/features/sellRedeem/__tests__/SellRedeemScreen.test.tsx
@@ -44,7 +44,7 @@ function seedStore() {
 describe("SellRedeemScreen", () => {
   it("renders the selected holding and waits to show linked cash fields until proceeds are valid", () => {
     const store = seedStore();
-    const { getByTestId, getByText, queryByTestId } = render(
+    const { getByPlaceholderText, getByTestId, getByText, queryByTestId } = render(
       <SellRedeemScreen assetId={asset.id} store={store} />,
     );
 
@@ -53,6 +53,7 @@ describe("SellRedeemScreen", () => {
     expect(getByText("HDFC Bank")).toBeTruthy();
     expect(getByText("Available units")).toBeTruthy();
     expect(getByText("25")).toBeTruthy();
+    expect(getByPlaceholderText("Max 25")).toBeTruthy();
     expect(getByText("Add proceeds to Cash Ledger")).toBeTruthy();
     expect(getByText("Cash entry appears after the exit proceeds are valid.")).toBeTruthy();
     expect(queryByTestId("sell-redeem-cash-amount-input")).toBeNull();

--- a/src/features/sellRedeem/__tests__/useSellRedeemHolding.test.tsx
+++ b/src/features/sellRedeem/__tests__/useSellRedeemHolding.test.tsx
@@ -1,0 +1,151 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import { useSellRedeemHolding } from "@/src/features/sellRedeem";
+import { createMemoryJsonStorage } from "@/src/services/storage";
+import { createPortfolioStore } from "@/src/store";
+import type { Asset } from "@/src/types";
+
+const hdfc: Asset = {
+  assetClass: "stock",
+  currency: "INR",
+  exchange: "NSE",
+  id: "asset-hdfc",
+  instrumentType: "stock",
+  name: "HDFC Bank",
+  quoteSourceId: "HDFCBANK.NS",
+  sectorType: "financialServices",
+  symbol: "HDFCBANK",
+  ticker: "HDFCBANK.NS",
+};
+
+function seedStore() {
+  const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+
+  store.getState().addAsset(hdfc);
+  store.getState().addOpeningPosition({
+    assetId: hdfc.id,
+    averageCostPrice: 1450,
+    currentPrice: 1678,
+    date: "2026-04-15",
+    id: "opening-hdfc",
+    quantity: 25,
+  });
+  store.getState().upsertQuote({
+    asOf: "2026-05-20T10:00:00.000Z",
+    assetId: hdfc.id,
+    currency: "INR",
+    price: 1700,
+    source: "yahoo",
+  });
+
+  return store;
+}
+
+describe("useSellRedeemHolding", () => {
+  it("creates a sell trade and linked cash proceeds by default", () => {
+    const store = seedStore();
+    const { result } = renderHook(() =>
+      useSellRedeemHolding({ assetId: hdfc.id, store }),
+    );
+
+    act(() => result.current.setQuantity("5"));
+    act(() => result.current.setSellPrice("1700"));
+    act(() => result.current.setFees("100"));
+    act(() => result.current.setDate("2026-05-20"));
+
+    expect(result.current.preview).toMatchObject({
+      grossProceeds: 8500,
+      netProceeds: 8400,
+      remainingUnits: 20,
+    });
+    expect(result.current.linkCashEntry).toBe(true);
+    expect(result.current.cashAmount).toBe("8400");
+
+    act(() => {
+      result.current.save();
+    });
+
+    expect(store.getState().trades).toEqual([
+      expect.objectContaining({
+        assetId: hdfc.id,
+        fees: 100,
+        pricePerUnit: 1700,
+        quantity: 5,
+        totalValue: 8400,
+        type: "sell",
+      }),
+    ]);
+    expect(store.getState().cashEntries).toEqual([
+      expect.objectContaining({
+        amount: 8400,
+        date: "2026-05-20",
+        label: "HDFC Bank redemption proceeds",
+        type: "addition",
+      }),
+    ]);
+    expect(result.current.successMessage).toBe("Sell / redeem recorded.");
+  });
+
+  it("can save without linked cash proceeds", () => {
+    const store = seedStore();
+    const { result } = renderHook(() =>
+      useSellRedeemHolding({ assetId: hdfc.id, store }),
+    );
+
+    act(() => result.current.setQuantity("2"));
+    act(() => result.current.setSellPrice("1600"));
+    act(() => result.current.setDate("2026-05-21"));
+    act(() => result.current.setLinkCashEntry(false));
+    act(() => {
+      result.current.save();
+    });
+
+    expect(store.getState().trades).toHaveLength(1);
+    expect(store.getState().cashEntries).toEqual([]);
+  });
+
+  it("rejects selling more than available units", () => {
+    const store = seedStore();
+    const { result } = renderHook(() =>
+      useSellRedeemHolding({ assetId: hdfc.id, store }),
+    );
+
+    act(() => result.current.setQuantity("26"));
+    act(() => result.current.setSellPrice("1700"));
+    act(() => {
+      result.current.save();
+    });
+
+    expect(result.current.errors.quantity).toBe(
+      "Sell quantity exceeds available units.",
+    );
+    expect(store.getState().trades).toEqual([]);
+  });
+
+  it("rejects fees above gross proceeds", () => {
+    const store = seedStore();
+    const { result } = renderHook(() =>
+      useSellRedeemHolding({ assetId: hdfc.id, store }),
+    );
+
+    act(() => result.current.setQuantity("1"));
+    act(() => result.current.setSellPrice("100"));
+    act(() => result.current.setFees("101"));
+    act(() => {
+      result.current.save();
+    });
+
+    expect(result.current.errors.fees).toBe("Fees cannot exceed gross proceeds.");
+    expect(store.getState().trades).toEqual([]);
+  });
+
+  it("reports a missing holding state", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const { result } = renderHook(() =>
+      useSellRedeemHolding({ assetId: hdfc.id, store }),
+    );
+
+    expect(result.current.status).toBe("not-found");
+    expect(result.current.holding).toBeNull();
+  });
+});

--- a/src/features/sellRedeem/index.ts
+++ b/src/features/sellRedeem/index.ts
@@ -1,0 +1,5 @@
+export { SellRedeemScreen } from "./SellRedeemScreen";
+export {
+  useSellRedeemHolding,
+  type UseSellRedeemHoldingResult,
+} from "./useSellRedeemHolding";

--- a/src/features/sellRedeem/useSellRedeemHolding.ts
+++ b/src/features/sellRedeem/useSellRedeemHolding.ts
@@ -27,6 +27,7 @@ type SaveResult =
 
 export type UseSellRedeemHoldingResult = {
   availableUnits: number;
+  canSave: boolean;
   cashAmount: string;
   cashLabel: string;
   date: string;
@@ -107,8 +108,34 @@ export function useSellRedeemHolding({
   const quantityValue = parseNumber(quantity);
   const sellPriceValue = parseNumber(sellPrice);
   const feeValue = parseOptionalNumber(fees);
+  const quantityValidationMessage = useMemo(() => {
+    if (!holding || !Number.isFinite(quantityValue) || quantityValue <= 0) {
+      return undefined;
+    }
+
+    const assetTrades = snapshot.trades.filter((trade) => trade.assetId === assetId);
+    const assetOpeningPositions = snapshot.openingPositions.filter(
+      (position) => position.assetId === assetId,
+    );
+    const sellQuantityResult = validateSellQuantity(
+      assetTrades,
+      quantityValue,
+      assetOpeningPositions,
+    );
+
+    return sellQuantityResult.isValid ? undefined : sellQuantityResult.message;
+  }, [
+    assetId,
+    holding,
+    quantityValue,
+    snapshot.openingPositions,
+    snapshot.trades,
+  ]);
   const preview =
-    holding && Number.isFinite(quantityValue) && Number.isFinite(sellPriceValue)
+    holding &&
+    Number.isFinite(quantityValue) &&
+    Number.isFinite(sellPriceValue) &&
+    !quantityValidationMessage
       ? calculateSellRedeemPreview({
           availableUnits,
           currentPrice: holding.currentPrice,
@@ -136,6 +163,12 @@ export function useSellRedeemHolding({
     }
   }, [cashAmountWasEdited, preview]);
 
+  useEffect(() => {
+    if (!preview && !cashAmountWasEdited) {
+      setCashAmount("");
+    }
+  }, [cashAmountWasEdited, preview]);
+
   function updateCashAmount(value: string) {
     setCashAmountWasEdited(true);
     setCashAmount(value);
@@ -153,20 +186,8 @@ export function useSellRedeemHolding({
       nextErrors.quantity = "Quantity must be a valid number.";
     } else if (quantityValue <= 0) {
       nextErrors.quantity = "Quantity must be greater than zero.";
-    } else {
-      const assetTrades = snapshot.trades.filter((trade) => trade.assetId === assetId);
-      const assetOpeningPositions = snapshot.openingPositions.filter(
-        (position) => position.assetId === assetId,
-      );
-      const sellQuantityResult = validateSellQuantity(
-        assetTrades,
-        quantityValue,
-        assetOpeningPositions,
-      );
-
-      if (!sellQuantityResult.isValid) {
-        nextErrors.quantity = sellQuantityResult.message;
-      }
+    } else if (quantityValidationMessage) {
+      nextErrors.quantity = quantityValidationMessage;
     }
 
     if (!Number.isFinite(sellPriceValue)) {
@@ -214,6 +235,13 @@ export function useSellRedeemHolding({
 
     return nextErrors;
   }
+
+  const displayErrors = {
+    ...errors,
+    quantity: errors.quantity ?? quantityValidationMessage,
+  };
+  const canSave =
+    Boolean(preview) && Object.keys(validate()).length === 0;
 
   function save(): SaveResult {
     setSuccessMessage("");
@@ -267,10 +295,11 @@ export function useSellRedeemHolding({
 
   return {
     availableUnits,
+    canSave,
     cashAmount,
     cashLabel,
     date,
-    errors,
+    errors: displayErrors,
     fees,
     holding,
     linkCashEntry,

--- a/src/features/sellRedeem/useSellRedeemHolding.ts
+++ b/src/features/sellRedeem/useSellRedeemHolding.ts
@@ -1,0 +1,293 @@
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import type { StoreApi } from "zustand/vanilla";
+
+import {
+  calculateHoldings,
+  calculateSellRedeemPreview,
+  validateSellRedeemFees,
+  type SellRedeemPreview,
+} from "@/src/domain/calculations";
+import { validateSellQuantity } from "@/src/domain/validators";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import type { CashEntry, Holding, Trade } from "@/src/types";
+import { createId } from "@/src/utils";
+
+type UseSellRedeemHoldingInput = {
+  assetId: string;
+  store?: StoreApi<PortfolioStoreState>;
+};
+
+type FieldErrors = Partial<
+  Record<"cashAmount" | "cashLabel" | "date" | "fees" | "quantity" | "sellPrice", string>
+>;
+
+type SaveResult =
+  | { cashEntry?: CashEntry; isValid: true; trade: Trade }
+  | { errors: FieldErrors; isValid: false };
+
+export type UseSellRedeemHoldingResult = {
+  availableUnits: number;
+  cashAmount: string;
+  cashLabel: string;
+  date: string;
+  errors: FieldErrors;
+  fees: string;
+  holding: Holding | null;
+  linkCashEntry: boolean;
+  notes: string;
+  preview: SellRedeemPreview | null;
+  quantity: string;
+  save: () => SaveResult;
+  sellPrice: string;
+  setCashAmount: (value: string) => void;
+  setCashLabel: (value: string) => void;
+  setDate: (value: string) => void;
+  setFees: (value: string) => void;
+  setLinkCashEntry: (value: boolean) => void;
+  setNotes: (value: string) => void;
+  setQuantity: (value: string) => void;
+  setSellPrice: (value: string) => void;
+  status: "not-found" | "ready";
+  successMessage: string;
+};
+
+function todayInputValue() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function parseNumber(value: string) {
+  const trimmed = value.trim();
+
+  return trimmed.length > 0 ? Number(trimmed) : Number.NaN;
+}
+
+function parseOptionalNumber(value: string) {
+  const trimmed = value.trim();
+
+  return trimmed.length > 0 ? Number(trimmed) : 0;
+}
+
+function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
+  return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+}
+
+function defaultCashLabel(holding: Holding | null) {
+  return holding ? `${holding.asset.name} redemption proceeds` : "";
+}
+
+export function useSellRedeemHolding({
+  assetId,
+  store = getPortfolioStore(),
+}: UseSellRedeemHoldingInput): UseSellRedeemHoldingResult {
+  const snapshot = usePortfolioSnapshot(store);
+  const [quantity, setQuantity] = useState("");
+  const [sellPrice, setSellPrice] = useState("");
+  const [fees, setFees] = useState("");
+  const [date, setDate] = useState(todayInputValue());
+  const [notes, setNotes] = useState("");
+  const [linkCashEntry, setLinkCashEntry] = useState(true);
+  const [cashAmount, setCashAmount] = useState("");
+  const [cashAmountWasEdited, setCashAmountWasEdited] = useState(false);
+  const [cashLabel, setCashLabel] = useState("");
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [successMessage, setSuccessMessage] = useState("");
+
+  const holdings = useMemo(
+    () =>
+      calculateHoldings({
+        assets: snapshot.assets,
+        openingPositions: snapshot.openingPositions,
+        quoteCache: snapshot.quoteCache,
+        trades: snapshot.trades,
+      }),
+    [snapshot.assets, snapshot.openingPositions, snapshot.quoteCache, snapshot.trades],
+  );
+  const holding = holdings.find((candidate) => candidate.asset.id === assetId) ?? null;
+  const availableUnits = holding?.totalUnits ?? 0;
+  const quantityValue = parseNumber(quantity);
+  const sellPriceValue = parseNumber(sellPrice);
+  const feeValue = parseOptionalNumber(fees);
+  const preview =
+    holding && Number.isFinite(quantityValue) && Number.isFinite(sellPriceValue)
+      ? calculateSellRedeemPreview({
+          availableUnits,
+          currentPrice: holding.currentPrice,
+          fees: Number.isFinite(feeValue) ? feeValue : 0,
+          quantity: quantityValue,
+          sellPrice: sellPriceValue,
+        })
+      : null;
+
+  useEffect(() => {
+    if (holding && sellPrice.trim().length === 0 && holding.currentPrice > 0) {
+      setSellPrice(String(holding.currentPrice));
+    }
+  }, [holding, sellPrice]);
+
+  useEffect(() => {
+    if (holding && cashLabel.trim().length === 0) {
+      setCashLabel(defaultCashLabel(holding));
+    }
+  }, [cashLabel, holding]);
+
+  useEffect(() => {
+    if (preview && !cashAmountWasEdited) {
+      setCashAmount(String(preview.netProceeds));
+    }
+  }, [cashAmountWasEdited, preview]);
+
+  function updateCashAmount(value: string) {
+    setCashAmountWasEdited(true);
+    setCashAmount(value);
+  }
+
+  function validate() {
+    const nextErrors: FieldErrors = {};
+
+    if (!holding) {
+      nextErrors.quantity = "Holding was not found.";
+      return nextErrors;
+    }
+
+    if (!Number.isFinite(quantityValue)) {
+      nextErrors.quantity = "Quantity must be a valid number.";
+    } else if (quantityValue <= 0) {
+      nextErrors.quantity = "Quantity must be greater than zero.";
+    } else {
+      const assetTrades = snapshot.trades.filter((trade) => trade.assetId === assetId);
+      const assetOpeningPositions = snapshot.openingPositions.filter(
+        (position) => position.assetId === assetId,
+      );
+      const sellQuantityResult = validateSellQuantity(
+        assetTrades,
+        quantityValue,
+        assetOpeningPositions,
+      );
+
+      if (!sellQuantityResult.isValid) {
+        nextErrors.quantity = sellQuantityResult.message;
+      }
+    }
+
+    if (!Number.isFinite(sellPriceValue)) {
+      nextErrors.sellPrice = "Sell price must be a valid number.";
+    } else if (sellPriceValue <= 0) {
+      nextErrors.sellPrice = "Sell price must be greater than zero.";
+    }
+
+    if (!Number.isFinite(feeValue)) {
+      nextErrors.fees = "Fees must be a valid number.";
+    } else if (feeValue < 0) {
+      nextErrors.fees = "Fees must be zero or greater.";
+    }
+
+    if (date.trim().length === 0) {
+      nextErrors.date = "Date is required.";
+    } else if (Number.isNaN(new Date(date).getTime())) {
+      nextErrors.date = "Date must be valid.";
+    }
+
+    if (preview) {
+      const feeResult = validateSellRedeemFees({
+        fees: feeValue,
+        grossProceeds: preview.grossProceeds,
+      });
+
+      if (!feeResult.isValid) {
+        nextErrors.fees = feeResult.message;
+      }
+    }
+
+    if (linkCashEntry) {
+      const cashAmountValue = parseNumber(cashAmount);
+
+      if (!Number.isFinite(cashAmountValue)) {
+        nextErrors.cashAmount = "Cash amount must be a valid number.";
+      } else if (cashAmountValue < 0) {
+        nextErrors.cashAmount = "Cash amount must be zero or greater.";
+      }
+
+      if (cashLabel.trim().length === 0) {
+        nextErrors.cashLabel = "Cash label is required.";
+      }
+    }
+
+    return nextErrors;
+  }
+
+  function save(): SaveResult {
+    setSuccessMessage("");
+    const nextErrors = validate();
+
+    if (!holding || !preview || Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors);
+      return {
+        errors: nextErrors,
+        isValid: false,
+      };
+    }
+
+    const trimmedNotes = notes.trim();
+    const trade: Trade = {
+      assetId,
+      date: date.trim(),
+      fees: feeValue || undefined,
+      id: createId("trade"),
+      notes: trimmedNotes || undefined,
+      pricePerUnit: sellPriceValue,
+      quantity: quantityValue,
+      totalValue: preview.netProceeds,
+      type: "sell",
+    };
+    let cashEntry: CashEntry | undefined;
+
+    store.getState().addTrade(trade);
+
+    if (linkCashEntry) {
+      cashEntry = {
+        amount: parseNumber(cashAmount),
+        date: date.trim(),
+        id: createId("cash"),
+        label: cashLabel.trim(),
+        notes: trimmedNotes || `Linked to ${holding.asset.name} sell / redeem`,
+        type: "addition",
+      };
+      store.getState().addCashEntry(cashEntry);
+    }
+
+    setErrors({});
+    setSuccessMessage("Sell / redeem recorded.");
+
+    return {
+      cashEntry,
+      isValid: true,
+      trade,
+    };
+  }
+
+  return {
+    availableUnits,
+    cashAmount,
+    cashLabel,
+    date,
+    errors,
+    fees,
+    holding,
+    linkCashEntry,
+    notes,
+    preview,
+    quantity,
+    save,
+    sellPrice,
+    setCashAmount: updateCashAmount,
+    setCashLabel,
+    setDate,
+    setFees,
+    setLinkCashEntry,
+    setNotes,
+    setQuantity,
+    setSellPrice,
+    status: holding ? "ready" : "not-found",
+    successMessage,
+  };
+}

--- a/src/features/trades/tradeForm.ts
+++ b/src/features/trades/tradeForm.ts
@@ -6,7 +6,7 @@ import {
   tradeTypeSchema,
   validateSellQuantity,
 } from "@/src/domain/validators";
-import type { Trade, TradeType } from "@/src/types";
+import type { OpeningPosition, Trade, TradeType } from "@/src/types";
 
 export type TradeFormValues = {
   assetId: string;
@@ -126,8 +126,15 @@ export const tradeFormSchema = createTradeFormSchema();
 export function validateTradeForm(
   values: TradeFormValues,
   existingTrades: Trade[],
-  now = new Date(),
+  nowOrOpeningPositions: Date | OpeningPosition[] = new Date(),
+  maybeNow = new Date(),
 ): TradeFormValidationResult {
+  const openingPositions = Array.isArray(nowOrOpeningPositions)
+    ? nowOrOpeningPositions
+    : [];
+  const now = Array.isArray(nowOrOpeningPositions)
+    ? maybeNow
+    : nowOrOpeningPositions;
   const result = createTradeFormSchema(now).safeParse(values);
 
   if (!result.success) {
@@ -143,7 +150,14 @@ export function validateTradeForm(
     const assetTrades = existingTrades.filter(
       (trade) => trade.assetId === value.assetId,
     );
-    const sellQuantityResult = validateSellQuantity(assetTrades, value.quantity);
+    const assetOpeningPositions = openingPositions.filter(
+      (position) => position.assetId === value.assetId,
+    );
+    const sellQuantityResult = validateSellQuantity(
+      assetTrades,
+      value.quantity,
+      assetOpeningPositions,
+    );
 
     if (!sellQuantityResult.isValid) {
       return {

--- a/src/features/trades/useAddTrade.ts
+++ b/src/features/trades/useAddTrade.ts
@@ -160,6 +160,7 @@ export function useAddTrade({
         type,
       },
       snapshot.trades,
+      snapshot.openingPositions,
     );
 
     if (!result.isValid || Object.keys(manualErrors).length > 0) {


### PR DESCRIPTION
## Summary
- Adds a Sell / redeem flow reachable from expanded Holdings rows.
- Records sell trades with proceeds preview, fee validation, and optional linked Cash Ledger addition enabled by default.
- Extends sell quantity validation to include opening positions and labels linked asset-exit cash rows clearly.

## Verification
- `npm run test:v1:pc` passed: typecheck, 42 Jest suites / 196 tests, Expo doctor 17/17, Android doctor, strict installed-app smoke.
- Android emulator `emulator-5554`: opened Holdings, tapped expanded holding `Sell / redeem`, verified `sell-redeem-screen`, `Sell / redeem`, `Record exit`, `Proceeds preview`, `Add proceeds to Cash Ledger`, `Cash amount`, and `Save sell / redeem` in UI tree.
- Crash buffer check after route verification returned no crash output.

Closes #146
