### PR TITLE
[V1] Bring Settings into parity

### DIFF
--- a/docs/design/v1-screen-baseline.md
+++ b/docs/design/v1-screen-baseline.md
@@ -235,10 +235,11 @@ Settings should build trust.
 
 Baseline groups:
 
-- Privacy: local storage, no account, no cloud, no analytics
-- Display: value masking status and mask preview
-- Quotes: refresh status, provider status, manual fallback status
-- Currency: INR base and foreign/crypto fallback settings
+- Local-first summary: local storage, account not required, cloud sync off,
+  analytics off
+- Value masking: real toggle/control plus mask preview
+- Quotes: refresh status, quote source, manual fallback status
+- Currency & App: INR base currency and Android preview/version context
 - Data: destructive or future data actions separated from normal settings
 
 Do not show unsupported settings as if they work. V2/V3 features may be marked

--- a/docs/superpowers/plans/2026-07-05-issue-135-settings-parity.md
+++ b/docs/superpowers/plans/2026-07-05-issue-135-settings-parity.md
@@ -1,0 +1,687 @@
+# Issue #135 Settings Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the approved trust-first Settings screen contract from issue #135.
+
+**Architecture:** Keep Settings behavior inside `src/features/settings`. Extend the existing `useSettings` hook to expose user-facing quote-source labels, then update `SettingsScreen` to render a compact local-first summary, real value masking control, quote status, compact app info, and disabled/deferred data action. Avoid adding real export, backup, cloud, analytics, account, or clear-data functionality.
+
+**Tech Stack:** React Native, Expo, TypeScript, Zustand store, React Native Testing Library, existing CogVest common components/theme.
+
+---
+
+## File Structure
+
+- Modify: `src/features/settings/useSettings.ts`
+  - Derive user-facing quote source label: `Waiting`, `Live`, `Manual`, or `Mixed`.
+  - Keep existing quote counts/latest quote data.
+- Modify: `src/features/settings/SettingsScreen.tsx`
+  - Implement compact trust-first hierarchy.
+  - Rename user-facing `Provider status` to `Quote source`.
+  - Remove unsupported working-looking rows.
+  - Keep `value-mask-toggle`.
+- Modify: `src/features/settings/__tests__/useSettings.test.tsx`
+  - Cover quote source labels for empty/live/manual/mixed states.
+- Modify: `src/features/settings/__tests__/SettingsScreen.test.tsx`
+  - Cover privacy summary, value masking, quote wording, mixed state, deferred data action, and absent V2/V3 leaks.
+- Optional Modify: `src/components/common/Premium.tsx`
+  - Only if Settings needs a disabled/deferred row affordance that cannot be represented safely with existing `GroupedListRow`.
+- No changes: domain calculations, persistence schema, other screens.
+
+---
+
+## Task 1: Derive User-Facing Quote Source Status
+
+**Files:**
+- Modify: `src/features/settings/useSettings.ts`
+- Test: `src/features/settings/__tests__/useSettings.test.tsx`
+
+- [ ] **Step 1: Write failing hook tests for quote source labels**
+
+Add tests to `src/features/settings/__tests__/useSettings.test.tsx`:
+
+```tsx
+it("labels quote source as Live when only live quotes are cached", () => {
+  const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+  store.getState().upsertQuote({
+    assetId: "asset-live",
+    asOf: "2026-05-15T10:00:00.000Z",
+    currency: "INR",
+    price: 100,
+    source: "yahoo",
+  });
+
+  const { result } = renderHook(() => useSettings({ store }));
+
+  expect(result.current.quoteStatus.quoteSourceLabel).toBe("Live");
+});
+
+it("labels quote source as Manual when only manual quotes are cached", () => {
+  const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+  store.getState().upsertQuote({
+    assetId: "asset-manual",
+    asOf: "2026-05-15T10:00:00.000Z",
+    currency: "INR",
+    price: 100,
+    source: "manual",
+  });
+
+  const { result } = renderHook(() => useSettings({ store }));
+
+  expect(result.current.quoteStatus.quoteSourceLabel).toBe("Manual");
+});
+
+it("labels quote source as Mixed when live and manual quotes are cached", () => {
+  const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+  store.getState().upsertQuote({
+    assetId: "asset-live",
+    asOf: "2026-05-15T10:00:00.000Z",
+    currency: "INR",
+    price: 100,
+    source: "yahoo",
+  });
+  store.getState().upsertQuote({
+    assetId: "asset-manual",
+    asOf: "2026-05-16T10:00:00.000Z",
+    currency: "INR",
+    price: 200,
+    source: "manual",
+  });
+
+  const { result } = renderHook(() => useSettings({ store }));
+
+  expect(result.current.quoteStatus.quoteSourceLabel).toBe("Mixed");
+});
+```
+
+Update the existing empty-state expectation to include:
+
+```tsx
+quoteSourceLabel: "Waiting",
+```
+
+- [ ] **Step 2: Run hook tests and verify they fail**
+
+Run:
+
+```bash
+npm test -- src/features/settings/__tests__/useSettings.test.tsx
+```
+
+Expected: FAIL because `quoteSourceLabel` does not exist.
+
+- [ ] **Step 3: Add quote source label type and derivation**
+
+Modify `src/features/settings/useSettings.ts`:
+
+```ts
+export type SettingsQuoteSourceLabel = "Waiting" | "Live" | "Manual" | "Mixed";
+
+export type SettingsQuoteStatus = {
+  latestQuoteAsOf: string | null;
+  latestQuoteLabel: string;
+  liveQuoteCount: number;
+  manualFallbackCount: number;
+  providerStatus: "Live available" | "Manual only" | "Waiting for holdings";
+  quoteCount: number;
+  quoteSourceLabel: SettingsQuoteSourceLabel;
+};
+
+function getQuoteSourceLabel({
+  liveQuoteCount,
+  manualFallbackCount,
+  quoteCount,
+}: {
+  liveQuoteCount: number;
+  manualFallbackCount: number;
+  quoteCount: number;
+}): SettingsQuoteSourceLabel {
+  if (quoteCount === 0) {
+    return "Waiting";
+  }
+
+  if (liveQuoteCount > 0 && manualFallbackCount > 0) {
+    return "Mixed";
+  }
+
+  if (liveQuoteCount > 0) {
+    return "Live";
+  }
+
+  return "Manual";
+}
+```
+
+Inside `deriveQuoteStatus`, compute:
+
+```ts
+const quoteSourceLabel = getQuoteSourceLabel({
+  liveQuoteCount,
+  manualFallbackCount,
+  quoteCount: quotes.length,
+});
+```
+
+Return `quoteSourceLabel` with the status object.
+
+- [ ] **Step 4: Run hook tests and verify they pass**
+
+Run:
+
+```bash
+npm test -- src/features/settings/__tests__/useSettings.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit hook derivation**
+
+Run:
+
+```bash
+git add src/features/settings/useSettings.ts src/features/settings/__tests__/useSettings.test.tsx
+git commit -m "Derive Settings quote source label"
+```
+
+---
+
+## Task 2: Implement Trust-First Settings Layout
+
+**Files:**
+- Modify: `src/features/settings/SettingsScreen.tsx`
+- Test: `src/features/settings/__tests__/SettingsScreen.test.tsx`
+
+- [ ] **Step 1: Write failing screen tests for the new Settings contract**
+
+Update `src/features/settings/__tests__/SettingsScreen.test.tsx`.
+
+In the first test, assert:
+
+```tsx
+expect(getByText("Local only")).toBeTruthy();
+expect(getByText("Your portfolio stays here")).toBeTruthy();
+expect(getByText("Local storage")).toBeTruthy();
+expect(getByText("Active")).toBeTruthy();
+expect(getByText("Account")).toBeTruthy();
+expect(getByText("Not required")).toBeTruthy();
+expect(getByText("Cloud sync")).toBeTruthy();
+expect(getByText("Off")).toBeTruthy();
+expect(getByText("Analytics")).toBeTruthy();
+expect(getByText("Value masking")).toBeTruthy();
+expect(getByText("Preview ₹••,•••")).toBeTruthy();
+```
+
+In the quote-status test, replace `Provider status` assertions with:
+
+```tsx
+expect(getByText("Quote source")).toBeTruthy();
+expect(queryByText("Provider status")).toBeNull();
+expect(getByText("Mixed")).toBeTruthy();
+```
+
+Also assert unsupported working-looking rows are absent:
+
+```tsx
+expect(queryByText("Foreign asset summary")).toBeNull();
+expect(queryByText("USD & crypto fallback")).toBeNull();
+expect(queryByText(/Export/i)).toBeNull();
+expect(queryByText(/Backup/i)).toBeNull();
+expect(queryByText(/Minimal Mode/i)).toBeNull();
+expect(queryByText(/LTCG/i)).toBeNull();
+```
+
+Assert data action remains deferred and non-button:
+
+```tsx
+expect(getByText("Clear local data")).toBeTruthy();
+expect(getByText("Disabled until confirmation and backup guidance exist.")).toBeTruthy();
+expect(getByText("Deferred")).toBeTruthy();
+expect(queryByTestId("clear-local-data-button")).toBeNull();
+```
+
+- [ ] **Step 2: Run screen tests and verify they fail**
+
+Run:
+
+```bash
+npm test -- src/features/settings/__tests__/SettingsScreen.test.tsx
+```
+
+Expected: FAIL because the new copy/layout is not implemented.
+
+- [ ] **Step 3: Update Settings screen imports**
+
+In `src/features/settings/SettingsScreen.tsx`, keep existing common components.
+
+Add imports if needed:
+
+```ts
+import { Ionicons } from "@expo/vector-icons";
+```
+
+Use `Ionicons` only if the local trust pill or compact checklist needs a check icon. If text-only rows are sufficient with `GroupedListRow`, do not add the import.
+
+- [ ] **Step 4: Implement header with local-only pill**
+
+Replace the bare `ScreenHeader` call with an action pill:
+
+```tsx
+<ScreenHeader
+  action={
+    <View style={styles.localPill}>
+      <View style={styles.localDot} />
+      <AppText style={styles.localPillText} variant="caption" weight="bold">
+        Local only
+      </AppText>
+    </View>
+  }
+  title="Settings"
+  subtitle="Local-first controls"
+/>
+```
+
+Add styles:
+
+```ts
+localDot: {
+  backgroundColor: colors.primary,
+  borderRadius: 4,
+  height: 8,
+  width: 8,
+},
+localPill: {
+  alignItems: "center",
+  backgroundColor: colors.surface.elevated,
+  borderRadius: radii.pill,
+  flexDirection: "row",
+  gap: spacing.xs,
+  paddingHorizontal: spacing.sm,
+  paddingVertical: spacing.xs,
+},
+localPillText: {
+  color: colors.primary,
+},
+```
+
+- [ ] **Step 5: Replace Privacy card with compact trust summary**
+
+Replace the existing `Privacy` `PremiumCard` with:
+
+```tsx
+<PremiumCard>
+  <View style={styles.trustIntro}>
+    <View style={styles.trustCopy}>
+      <AppText variant="title" weight="bold">
+        Your portfolio stays here
+      </AppText>
+      <AppText color="secondary">
+        CogVest V1 is local-first by default. The key privacy guarantees are
+        visible at a glance.
+      </AppText>
+    </View>
+  </View>
+
+  <GroupedListRow
+    icon="phone-portrait-outline"
+    title="Local storage"
+    meta="Portfolio records stay on this Android device."
+    value="Active"
+  />
+  <GroupedListRow
+    icon="person-circle-outline"
+    title="Account"
+    meta="No sign-in or remote profile is required in V1."
+    value="Not required"
+  />
+  <GroupedListRow
+    icon="cloud-offline-outline"
+    title="Cloud sync"
+    meta="No portfolio data is sent to a backend."
+    value="Off"
+  />
+  <GroupedListRow
+    icon="analytics-outline"
+    title="Analytics"
+    meta="No product telemetry is enabled in V1."
+    value="Off"
+  />
+</PremiumCard>
+```
+
+Add styles:
+
+```ts
+trustCopy: {
+  gap: spacing.xs,
+},
+trustIntro: {
+  paddingBottom: spacing.xs,
+},
+```
+
+- [ ] **Step 6: Keep Value Masking as the primary real control**
+
+Keep the existing `Pressable` and `testID="value-mask-toggle"`, but update the helper copy and add preview:
+
+```tsx
+<AppText color="secondary">
+  Hide INR wealth values in shared or public spaces.
+</AppText>
+<AppText color="secondary" variant="caption">
+  Quantities, percentages, and per-unit prices stay visible.
+</AppText>
+<View style={styles.maskPreview}>
+  <AppText color="secondary" variant="caption" weight="medium">
+    Preview ₹••,•••
+  </AppText>
+</View>
+```
+
+Add style:
+
+```ts
+maskPreview: {
+  alignSelf: "flex-start",
+  backgroundColor: colors.surface.elevated,
+  borderRadius: radii.pill,
+  paddingHorizontal: spacing.sm,
+  paddingVertical: spacing.xs,
+},
+```
+
+- [ ] **Step 7: Update Quotes section copy and values**
+
+In the Quotes card:
+
+```tsx
+<SectionHeader title="Quotes" />
+```
+
+Keep `Latest quote refresh`, then replace the provider row with:
+
+```tsx
+<GroupedListRow
+  icon="pulse-outline"
+  title="Quote source"
+  meta={
+    quoteStatus.quoteSourceLabel === "Mixed"
+      ? "Some assets use live quotes; manual fallback stays ready."
+      : quoteStatus.quoteSourceLabel === "Live"
+        ? "Live quotes are available for cached assets."
+        : quoteStatus.quoteSourceLabel === "Manual"
+          ? "Cached prices are manual fallback values."
+          : "Add holdings or refresh quotes to see quote source status."
+  }
+  value={quoteStatus.quoteSourceLabel}
+/>
+```
+
+Keep `Manual fallback`, but make the meta direct:
+
+```tsx
+meta="Manual prices remain available when quote APIs fail."
+```
+
+- [ ] **Step 8: Replace Currency and Display cards with compact Currency & App card**
+
+Remove:
+
+- `Foreign asset summary`
+- `USD & crypto fallback`
+- `Density changes`
+
+Replace the two cards with:
+
+```tsx
+<PremiumCard>
+  <SectionHeader title="Currency & App" />
+  <GroupedListRow
+    icon="cash-outline"
+    title="Base currency"
+    meta="INR-first summaries across CogVest."
+    value="INR"
+  />
+  <GroupedListRow
+    icon="phone-portrait-outline"
+    title="Version"
+    meta="Android preview build for V1 testing."
+    value="Preview"
+  />
+</PremiumCard>
+```
+
+- [ ] **Step 9: Update Data card to separated deferred destructive action**
+
+Keep the Data card or use a distinct `PremiumCard` with destructive row, but update meta:
+
+```tsx
+<PremiumCard>
+  <SectionHeader title="Data" />
+  <GroupedListRow
+    destructive
+    icon="trash-outline"
+    title="Clear local data"
+    meta="Disabled until confirmation and backup guidance exist."
+    value="Deferred"
+  />
+</PremiumCard>
+```
+
+Do not add `onPress`.
+Do not add `clear-local-data-button`.
+
+- [ ] **Step 10: Run screen tests and verify they pass**
+
+Run:
+
+```bash
+npm test -- src/features/settings/__tests__/SettingsScreen.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 11: Commit Settings UI implementation**
+
+Run:
+
+```bash
+git add src/features/settings/SettingsScreen.tsx src/features/settings/__tests__/SettingsScreen.test.tsx
+git commit -m "Align Settings with V1 trust design"
+```
+
+---
+
+## Task 3: Verify Settings Scope And Regression Coverage
+
+**Files:**
+- Modify if needed: `docs/testing/v1-core-flow-test-matrix.md`
+- Modify if needed: `docs/testing/v1-pc-verification-checklist.md`
+
+- [ ] **Step 1: Run all Settings tests**
+
+Run:
+
+```bash
+npm test -- src/features/settings/__tests__
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run related common component tests**
+
+Run:
+
+```bash
+npm test -- src/components/common/__tests__
+```
+
+Expected: PASS. If this path has no tests, record that and continue.
+
+- [ ] **Step 3: Run static project checks**
+
+Run:
+
+```bash
+npm run typecheck
+npm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Update V1 docs only if stale Settings language exists**
+
+Search:
+
+```bash
+Select-String -Path docs\testing\*.md,docs\design\*.md -Pattern "Provider status","Foreign asset summary","USD & crypto fallback","Density changes"
+```
+
+If stale V1 Settings expectations remain, update them to:
+
+- `Quote source`
+- `Currency & App`
+- local-first privacy summary
+- value masking as real control
+- clear local data deferred
+
+Do not update unrelated docs.
+
+- [ ] **Step 5: Commit docs if changed**
+
+If docs changed:
+
+```bash
+git add docs
+git commit -m "Refresh Settings parity docs"
+```
+
+If no docs changed, skip this commit.
+
+---
+
+## Task 4: Android Emulator Visual Verification
+
+**Files:**
+- No source files expected.
+- Evidence artifact can be saved under `G:\tmp`.
+
+- [ ] **Step 1: Install or launch current app on emulator**
+
+If a native build is needed:
+
+```bash
+npm run android
+```
+
+If the app is already installed:
+
+```bash
+npm run android:smoke -- --strict
+```
+
+Expected: emulator detected and `com.abdulshaikh.cogvest` installed.
+
+- [ ] **Step 2: Open Settings screen**
+
+Use the emulator manually, Maestro, or adb/UIAutomator depending on what is most reliable in the session.
+
+Expected visible content:
+
+- `Settings`
+- `Local-first controls`
+- `Local only`
+- `Your portfolio stays here`
+- `Value masking`
+- `Quotes`
+- `Quote source`
+- `Currency & App`
+- `Clear local data`
+
+- [ ] **Step 3: Capture screenshot evidence**
+
+Run:
+
+```bash
+adb -s emulator-5554 shell screencap -p /sdcard/cogvest-settings-parity.png
+adb -s emulator-5554 pull /sdcard/cogvest-settings-parity.png G:\tmp\cogvest-settings-parity.png
+```
+
+Expected: screenshot exists at `G:\tmp\cogvest-settings-parity.png`.
+
+- [ ] **Step 4: Record emulator result in final response**
+
+Document:
+
+- whether emulator was detected
+- whether app package was installed
+- screenshot path
+- any visual compromise or blocker
+
+---
+
+## Task 5: Final Verification And PR
+
+**Files:**
+- No new source changes expected unless verification finds defects.
+
+- [ ] **Step 1: Run V1 PC verification if time allows**
+
+Run:
+
+```bash
+npm run test:v1:pc
+```
+
+Expected: PASS. If too slow or emulator unavailable, document the exact blocker.
+
+- [ ] **Step 2: Check final diff**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git log --oneline -5
+```
+
+Expected:
+
+- no whitespace errors
+- only issue #135 files changed
+- branch contains focused commits
+
+- [ ] **Step 3: Push branch**
+
+Run:
+
+```bash
+git push -u origin v1/issue-135-settings-parity
+```
+
+- [ ] **Step 4: Create PR**
+
+Create PR with body including:
+
+```markdown
+Closes #135
+
+## Summary
+- Reworked Settings into a compact local-first trust surface.
+- Promoted value masking as the primary real control.
+- Replaced technical provider wording with quote source/fallback status.
+- Kept unsupported/destructive data actions deferred and non-interactive.
+
+## Verification
+- npm run typecheck
+- npm test
+- npm run test:v1:pc (or documented blocker)
+- Android emulator Settings screenshot: G:\tmp\cogvest-settings-parity.png
+```
+
+---
+
+## Plan Self-Review
+
+- Spec coverage: The plan covers trust-first IA, value masking, quote source copy, hidden unsupported controls, deferred destructive action, tests, docs, emulator verification, and PR close reference.
+- Placeholder scan: No TODO/TBD placeholders remain.
+- Type consistency: `quoteSourceLabel` is introduced in Task 1 before screen usage in Task 2. Existing `providerStatus` remains internal for compatibility but is not user-facing Settings copy.

--- a/docs/superpowers/specs/2026-07-05-issue-135-settings-parity.md
+++ b/docs/superpowers/specs/2026-07-05-issue-135-settings-parity.md
@@ -1,0 +1,279 @@
+# Issue #135 Settings Parity Design Spec
+
+## Goal
+
+Bring the Settings screen into accepted V1 design and capability parity by
+making it a compact local-first trust surface, not a miscellaneous control dump.
+
+Settings should answer, within the first visible area:
+
+- Is my portfolio data local?
+- Is value masking available?
+- Are quote sources/fallbacks transparent?
+- Are destructive or unsupported actions protected?
+
+## Source Of Truth
+
+This spec is based on the approved Settings preview:
+
+`G:\Projects\2026\cool_projects\CogVest\.superpowers\brainstorm\issue-135-settings-parity\content\settings-trust-first-v1.html`
+
+The implementation must also respect:
+
+- `DESIGN.md`
+- `docs/design/v1-screen-baseline.md`
+- `docs/design/v1-ux-research-baseline.md`
+- GitHub issue #135
+
+The preview is a visual direction, not a pixel-perfect mandate. The React Native
+implementation should use existing CogVest components and Android-friendly
+patterns rather than copying HTML/CSS literally.
+
+## Product Principles
+
+Settings should reinforce trust and reduce uncertainty.
+
+The screen should feel:
+
+- calm
+- private
+- local-first
+- compact
+- clear about what is real in V1
+- honest about deferred or unsupported behavior
+
+The screen should not feel:
+
+- technical
+- cloud-account oriented
+- like a debug/status dashboard
+- like a list of future features pretending to work
+- visually louder than Dashboard, Holdings, Progress, or Cash
+
+## Information Architecture
+
+Use this hierarchy:
+
+1. Header
+2. Local-first privacy summary
+3. Value masking control
+4. Quote source/fallback status
+5. Currency & App information
+6. Deferred/destructive data action
+
+### Header
+
+Keep:
+
+- title: `Settings`
+- subtitle: `Local-first controls`
+- small trust pill: `Local only`
+
+The trust pill should be informational, not a button.
+
+### Local-First Privacy Summary
+
+The first card should communicate that CogVest V1 keeps data on device.
+
+Use the headline:
+
+`Your portfolio stays here`
+
+Use supporting copy close to:
+
+`CogVest V1 is local-first by default. The key privacy guarantees are visible at a glance.`
+
+Show a compact checklist, not a large 2x2 grid:
+
+- `Local storage` -> `Active`
+- `Account` -> `Not required`
+- `Cloud sync` -> `Off`
+- `Analytics` -> `Off`
+
+This avoids repeating the same privacy claims in paragraph and grid form.
+
+### Value Masking
+
+Value masking is the primary real control on this screen.
+
+Show it as a prominent card or grouped row with:
+
+- title: `Value masking`
+- helper copy: `Hide INR wealth values in shared or public spaces.`
+- masked preview: `Preview ₹••,•••`
+- real switch/toggle
+
+The toggle must use the existing `maskWealthValues` preference and remain
+testable through `value-mask-toggle`.
+
+If masking is on, the preview should communicate masked state. If masking is
+off, the preview can still show the masked result so the user understands what
+will happen.
+
+### Quote Source/Fallback Status
+
+Quotes should read as calm evidence, not an error wall.
+
+Use section title:
+
+`Quotes`
+
+Use section note or helper copy:
+
+`Freshness and fallback`
+
+Rows:
+
+- `Latest quote refresh`
+  - value: latest quote date, or `No quotes yet`
+  - meta: count of cached quote records
+- `Quote source`
+  - value: derived from real cache state
+  - avoid the technical label `Provider status`
+- `Manual fallback`
+  - value: manual quote count
+  - meta: manual prices remain available when quote APIs fail
+
+Quote source values should avoid overstating capability:
+
+- no quotes: `Waiting`
+- only live quotes: `Live`
+- only manual quotes: `Manual`
+- live and manual quotes: `Mixed`
+
+The underlying hook may keep richer internal names, but user-facing copy should
+use the simpler labels above.
+
+### Currency & App
+
+Use one compact section named:
+
+`Currency & App`
+
+Rows:
+
+- `Base currency`
+  - value: `INR`
+  - meta: `INR-first summaries across CogVest.`
+- `Version`
+  - value: `Preview`
+  - meta: `Android preview build for V1 testing.`
+
+Do not show foreign asset summary or USD/crypto fallback as working settings if
+they are not real user controls.
+
+Do not show Minimal Mode, LTCG, export, backup, or account/cloud settings as
+working controls in V1.
+
+### Data Action
+
+`Clear local data` should be separated from normal settings.
+
+For V1, this action remains disabled/deferred until a confirmation flow and
+backup guidance exist.
+
+Show:
+
+- title: `Clear local data`
+- meta: `Disabled until confirmation and backup guidance exist.`
+- value/status: `Deferred`
+
+It must not expose a tappable destructive control or `clear-local-data-button`
+testID until the confirmation flow exists.
+
+## Visual Rules
+
+Use existing CogVest design tokens and common components where possible.
+
+Rules:
+
+- true black app background
+- dark elevated cards
+- restrained green accent only for trust/active state
+- no colored glow
+- no generic Material settings template
+- no large repeated card grid
+- no technical status wall
+- no noisy badges
+- compact grouped rows with clear right-side status values
+- destructive/deferred row visually separated from normal settings
+
+The HTML preview used a display/body font pairing to satisfy preview tooling.
+The app implementation should follow the existing React Native font system and
+not introduce a new app-wide font dependency for this issue.
+
+## Accessibility
+
+Requirements:
+
+- `value-mask-toggle` remains accessible as a switch.
+- Switch state must expose checked/unchecked state.
+- Informational rows should not be announced as buttons.
+- Deferred destructive action should not be focusable as an enabled action.
+- Text contrast must remain readable on dark surfaces.
+- The screen should remain usable with Android font scaling as far as current
+  shared components allow.
+
+## Data And Behavior
+
+Settings must reflect real local state only.
+
+Use existing preference/store data:
+
+- `preferences.maskWealthValues`
+- quote cache records
+- quote source counts
+- latest quote timestamp
+
+Do not add backend, auth, cloud sync, analytics, export, backup, or clear-data
+implementation in this issue.
+
+Derived quote status should be pure and testable. It may live in
+`useSettings.ts` if scoped only to Settings.
+
+## Testing Requirements
+
+Update or add tests for:
+
+- privacy summary contains local storage, no account, cloud off, analytics off
+- value masking toggle changes stored preference and updates accessible state
+- quote source label uses `Quote source`, not `Provider status`
+- mixed live/manual quote cache renders `Mixed`
+- no quote cache renders `Waiting` or equivalent non-live state
+- clear local data is shown as `Deferred` but is not exposed as an enabled
+  button
+- V2/V3 leaks remain absent: Minimal Mode, LTCG, export/backup as working
+  controls
+
+Run before PR:
+
+```bash
+npm run typecheck
+npm test
+```
+
+If emulator is available, visually verify Settings after install/launch or
+through the normal Expo emulator loop.
+
+## Acceptance Criteria
+
+- Settings starts with a compact local-first trust summary.
+- Value masking is the primary real control and remains functional.
+- Quote source/fallback status reflects real quote cache state.
+- `Provider status` is not used as user-facing Settings copy.
+- Unsupported/deferred features do not appear as working controls.
+- Clear local data is separated, destructive in tone, and disabled/deferred.
+- Screen follows the approved preview direction without adding new unrelated
+  features.
+- Typecheck and tests pass.
+- Android emulator visual check is captured or a blocker is documented.
+
+## Out Of Scope
+
+- Implementing clear local data.
+- Implementing export or backup.
+- Adding cloud sync, accounts, analytics, or auth.
+- Adding Minimal Mode controls.
+- Adding LTCG/tax controls.
+- Redesigning other screens.
+- Changing core portfolio domain logic.

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -31,10 +31,30 @@ export function SettingsScreen({
     await Haptics.selectionAsync();
   }
 
+  const quoteSourceMeta =
+    quoteStatus.quoteSourceLabel === "Mixed"
+      ? "Some assets use live quotes; manual fallback stays ready."
+      : quoteStatus.quoteSourceLabel === "Live"
+        ? "Live quotes are available for cached assets."
+        : quoteStatus.quoteSourceLabel === "Manual"
+          ? "Cached prices are manual fallback values."
+          : "Add holdings or refresh quotes to see quote source status.";
+
   return (
     <ScreenContainer scroll testID="settings-screen">
       <View style={styles.content}>
-        <ScreenHeader title="Settings" subtitle="Local-first controls" />
+        <ScreenHeader
+          action={
+            <View style={styles.localPill}>
+              <View style={styles.localDot} />
+              <AppText style={styles.localPillText} variant="caption" weight="bold">
+                Local only
+              </AppText>
+            </View>
+          }
+          title="Settings"
+          subtitle="Local-first controls"
+        />
 
         <Pressable
           accessibilityLabel="Toggle value masking"
@@ -60,6 +80,11 @@ export function SettingsScreen({
             <AppText color="secondary" variant="caption">
               Quantities, percentages, and per-unit prices stay visible.
             </AppText>
+            <View style={styles.maskPreview}>
+              <AppText color="secondary" variant="caption" weight="medium">
+                Preview ₹••,•••
+              </AppText>
+            </View>
           </View>
           <View style={[styles.switchTrack, maskWealthValues && styles.switchOn]}>
             <View
@@ -72,35 +97,40 @@ export function SettingsScreen({
         </Pressable>
 
         <PremiumCard>
-          <SectionHeader title="Privacy" />
+          <View style={styles.trustIntro}>
+            <View style={styles.trustCopy}>
+              <AppText variant="title" weight="bold">
+                Your portfolio stays here
+              </AppText>
+              <AppText color="secondary">
+                CogVest V1 is local-first by default. The key privacy guarantees
+                are visible at a glance.
+              </AppText>
+            </View>
+          </View>
           <GroupedListRow
-            icon="lock-closed-outline"
-            title="Local storage active"
-            meta="Portfolio data stays on this Android device."
+            icon="phone-portrait-outline"
+            title="Local storage"
+            meta="Portfolio records stay on this Android device."
             value="Active"
           />
           <GroupedListRow
             icon="person-circle-outline"
-            title="No account"
-            meta="CogVest V1 has no sign-in or remote profile."
-            value="Local"
+            title="Account"
+            meta="No sign-in or remote profile is required in V1."
+            value="Not required"
           />
           <GroupedListRow
             icon="cloud-offline-outline"
-            title="No cloud sync"
+            title="Cloud sync"
             meta="No portfolio data is sent to a backend."
             value="Off"
           />
           <GroupedListRow
             icon="analytics-outline"
-            title="No analytics"
+            title="Analytics"
             meta="No product telemetry is enabled in V1."
             value="Off"
-          />
-          <GroupedListRow
-            icon="phone-portrait-outline"
-            title={maskWealthValues ? "Values masked" : "Values visible"}
-            meta="This preference is stored locally on this device."
           />
         </PremiumCard>
 
@@ -116,11 +146,9 @@ export function SettingsScreen({
           />
           <GroupedListRow
             icon="pulse-outline"
-            title="Provider status"
-            meta={`${quoteStatus.liveQuoteCount} live quote${
-              quoteStatus.liveQuoteCount === 1 ? "" : "s"
-            } cached.`}
-            value={quoteStatus.providerStatus}
+            title="Quote source"
+            meta={quoteSourceMeta}
+            value={quoteStatus.quoteSourceLabel}
           />
           <GroupedListRow
             icon="cloud-offline-outline"
@@ -133,21 +161,19 @@ export function SettingsScreen({
         </PremiumCard>
 
         <PremiumCard>
-          <SectionHeader title="Currency" />
-          <GroupedListRow title="Base currency" value="INR" />
-          <GroupedListRow title="Foreign asset summary" value="On" />
-          <GroupedListRow title="USD & crypto fallback" value="On" />
-        </PremiumCard>
-
-        <PremiumCard>
-          <SectionHeader title="Display & App Info" />
+          <SectionHeader title="Currency & App" />
           <GroupedListRow
-            icon="resize-outline"
-            title="Density changes"
-            meta="Standard density is fixed for V1."
-            value="V1 locked"
+            icon="cash-outline"
+            title="Base currency"
+            meta="INR-first summaries across CogVest."
+            value="INR"
           />
-          <GroupedListRow title="App version 1.0.0" value="Preview" />
+          <GroupedListRow
+            icon="phone-portrait-outline"
+            title="Version"
+            meta="Android preview build for V1 testing."
+            value="Preview"
+          />
         </PremiumCard>
 
         <PremiumCard>
@@ -156,7 +182,7 @@ export function SettingsScreen({
             destructive
             icon="trash-outline"
             title="Clear local data"
-            meta="Disabled until a confirmation flow is implemented."
+            meta="Disabled until confirmation and backup guidance exist."
             value="Deferred"
           />
         </PremiumCard>
@@ -176,6 +202,31 @@ const styles = StyleSheet.create({
     gap: spacing.cardGap,
     paddingBottom: spacing.lg,
     paddingTop: spacing.md,
+  },
+  localDot: {
+    backgroundColor: colors.primary,
+    borderRadius: 4,
+    height: 8,
+    width: 8,
+  },
+  localPill: {
+    alignItems: "center",
+    backgroundColor: colors.surface.elevated,
+    borderRadius: radii.pill,
+    flexDirection: "row",
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+  },
+  localPillText: {
+    color: colors.primary,
+  },
+  maskPreview: {
+    alignSelf: "flex-start",
+    backgroundColor: colors.surface.elevated,
+    borderRadius: radii.pill,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
   },
   pressed: {
     opacity: interaction.pressedOpacity,
@@ -207,5 +258,11 @@ const styles = StyleSheet.create({
     alignItems: "center",
     flexDirection: "row",
     justifyContent: "space-between",
+  },
+  trustCopy: {
+    gap: spacing.xs,
+  },
+  trustIntro: {
+    paddingBottom: spacing.xs,
   },
 });

--- a/src/features/settings/__tests__/SettingsScreen.test.tsx
+++ b/src/features/settings/__tests__/SettingsScreen.test.tsx
@@ -16,26 +16,33 @@ describe("SettingsScreen", () => {
 
   it("shows privacy settings without V2 settings leaks and toggles value masking", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
-    const { getByLabelText, getByTestId, getByText, queryByText } = render(
-      <SettingsScreen store={store} />,
-    );
+    const {
+      getAllByText,
+      getByLabelText,
+      getByTestId,
+      getByText,
+      queryByText,
+    } = render(<SettingsScreen store={store} />);
 
     expect(getByTestId("value-mask-toggle")).toBeTruthy();
     expect(getByText("Settings")).toBeTruthy();
+    expect(getByText("Local only")).toBeTruthy();
+    expect(getByText("Your portfolio stays here")).toBeTruthy();
+    expect(getByText("Local storage")).toBeTruthy();
+    expect(getByText("Active")).toBeTruthy();
+    expect(getByText("Account")).toBeTruthy();
+    expect(getByText("Not required")).toBeTruthy();
+    expect(getByText("Cloud sync")).toBeTruthy();
+    expect(getAllByText("Off")).toHaveLength(2);
+    expect(getByText("Analytics")).toBeTruthy();
     expect(getByText("Value masking")).toBeTruthy();
-    expect(getByText("Values visible")).toBeTruthy();
-    expect(getByText("Local storage active")).toBeTruthy();
-    expect(getByText("No account")).toBeTruthy();
-    expect(getByText("No cloud sync")).toBeTruthy();
-    expect(getByText("No analytics")).toBeTruthy();
-    expect(getByText("App version 1.0.0")).toBeTruthy();
+    expect(getByText("Preview ₹••,•••")).toBeTruthy();
     expect(queryByText(/Minimal Mode/i)).toBeNull();
     expect(queryByText(/LTCG/i)).toBeNull();
 
     fireEvent.press(getByLabelText("Toggle value masking"));
 
     expect(store.getState().preferences.maskWealthValues).toBe(true);
-    expect(getByText("Values masked")).toBeTruthy();
     expect(Haptics.selectionAsync).toHaveBeenCalledTimes(1);
   });
 
@@ -56,17 +63,33 @@ describe("SettingsScreen", () => {
       source: "manual",
     });
 
-    const { getByText, queryByTestId } = render(<SettingsScreen store={store} />);
+    const { getByText, queryByTestId, queryByText } = render(
+      <SettingsScreen store={store} />,
+    );
 
     expect(getByText("Latest quote refresh")).toBeTruthy();
     expect(getByText("16 May 2026")).toBeTruthy();
-    expect(getByText("Provider status")).toBeTruthy();
-    expect(getByText("Live available")).toBeTruthy();
+    expect(getByText("Quote source")).toBeTruthy();
+    expect(queryByText("Provider status")).toBeNull();
+    expect(getByText("Mixed")).toBeTruthy();
     expect(getByText("Manual fallback")).toBeTruthy();
     expect(getByText("1 manual quote")).toBeTruthy();
-    expect(getByText("Density changes")).toBeTruthy();
-    expect(getByText("V1 locked")).toBeTruthy();
+    expect(getByText("Currency & App")).toBeTruthy();
+    expect(getByText("Base currency")).toBeTruthy();
+    expect(getByText("INR")).toBeTruthy();
+    expect(getByText("Version")).toBeTruthy();
+    expect(getByText("Preview")).toBeTruthy();
+    expect(queryByText("Foreign asset summary")).toBeNull();
+    expect(queryByText("USD & crypto fallback")).toBeNull();
+    expect(queryByText("Density changes")).toBeNull();
+    expect(queryByText(/Export/i)).toBeNull();
+    expect(queryByText("Backup")).toBeNull();
+    expect(queryByText(/Minimal Mode/i)).toBeNull();
+    expect(queryByText(/LTCG/i)).toBeNull();
     expect(getByText("Clear local data")).toBeTruthy();
+    expect(
+      getByText("Disabled until confirmation and backup guidance exist."),
+    ).toBeTruthy();
     expect(getByText("Deferred")).toBeTruthy();
     expect(queryByTestId("clear-local-data-button")).toBeNull();
   });

--- a/src/features/settings/__tests__/useSettings.test.tsx
+++ b/src/features/settings/__tests__/useSettings.test.tsx
@@ -34,7 +34,60 @@ describe("useSettings", () => {
       manualFallbackCount: 0,
       providerStatus: "Waiting for holdings",
       quoteCount: 0,
+      quoteSourceLabel: "Waiting",
     });
+  });
+
+  it("labels quote source as Live when only live quotes are cached", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().upsertQuote({
+      assetId: "asset-live",
+      asOf: "2026-05-15T10:00:00.000Z",
+      currency: "INR",
+      price: 100,
+      source: "yahoo",
+    });
+
+    const { result } = renderHook(() => useSettings({ store }));
+
+    expect(result.current.quoteStatus.quoteSourceLabel).toBe("Live");
+  });
+
+  it("labels quote source as Manual when only manual quotes are cached", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().upsertQuote({
+      assetId: "asset-manual",
+      asOf: "2026-05-15T10:00:00.000Z",
+      currency: "INR",
+      price: 100,
+      source: "manual",
+    });
+
+    const { result } = renderHook(() => useSettings({ store }));
+
+    expect(result.current.quoteStatus.quoteSourceLabel).toBe("Manual");
+  });
+
+  it("labels quote source as Mixed when live and manual quotes are cached", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().upsertQuote({
+      assetId: "asset-live",
+      asOf: "2026-05-15T10:00:00.000Z",
+      currency: "INR",
+      price: 100,
+      source: "yahoo",
+    });
+    store.getState().upsertQuote({
+      assetId: "asset-manual",
+      asOf: "2026-05-16T10:00:00.000Z",
+      currency: "INR",
+      price: 200,
+      source: "manual",
+    });
+
+    const { result } = renderHook(() => useSettings({ store }));
+
+    expect(result.current.quoteStatus.quoteSourceLabel).toBe("Mixed");
   });
 
   it("derives quote freshness and manual fallback status from stored quotes", () => {
@@ -63,6 +116,7 @@ describe("useSettings", () => {
       manualFallbackCount: 1,
       providerStatus: "Live available",
       quoteCount: 2,
+      quoteSourceLabel: "Mixed",
     });
   });
 });

--- a/src/features/settings/useSettings.ts
+++ b/src/features/settings/useSettings.ts
@@ -15,6 +15,8 @@ export type UseSettingsResult = {
   toggleMaskWealthValues: () => void;
 };
 
+export type SettingsQuoteSourceLabel = "Waiting" | "Live" | "Manual" | "Mixed";
+
 export type SettingsQuoteStatus = {
   latestQuoteAsOf: string | null;
   latestQuoteLabel: string;
@@ -22,6 +24,7 @@ export type SettingsQuoteStatus = {
   manualFallbackCount: number;
   providerStatus: "Live available" | "Manual only" | "Waiting for holdings";
   quoteCount: number;
+  quoteSourceLabel: SettingsQuoteSourceLabel;
 };
 
 function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
@@ -37,6 +40,30 @@ function getLatestQuote(quotes: Quote[]) {
     )[0];
 }
 
+function getQuoteSourceLabel({
+  liveQuoteCount,
+  manualFallbackCount,
+  quoteCount,
+}: {
+  liveQuoteCount: number;
+  manualFallbackCount: number;
+  quoteCount: number;
+}): SettingsQuoteSourceLabel {
+  if (quoteCount === 0) {
+    return "Waiting";
+  }
+
+  if (liveQuoteCount > 0 && manualFallbackCount > 0) {
+    return "Mixed";
+  }
+
+  if (liveQuoteCount > 0) {
+    return "Live";
+  }
+
+  return "Manual";
+}
+
 function deriveQuoteStatus(quoteCache: PortfolioStoreState["quoteCache"]) {
   const quotes = Object.values(quoteCache);
   const manualFallbackCount = quotes.filter(
@@ -50,6 +77,11 @@ function deriveQuoteStatus(quoteCache: PortfolioStoreState["quoteCache"]) {
       : liveQuoteCount > 0
         ? "Live available"
         : "Manual only";
+  const quoteSourceLabel = getQuoteSourceLabel({
+    liveQuoteCount,
+    manualFallbackCount,
+    quoteCount: quotes.length,
+  });
 
   return {
     latestQuoteAsOf: latestQuote?.asOf ?? null,
@@ -58,6 +90,7 @@ function deriveQuoteStatus(quoteCache: PortfolioStoreState["quoteCache"]) {
     manualFallbackCount,
     providerStatus,
     quoteCount: quotes.length,
+    quoteSourceLabel,
   } satisfies SettingsQuoteStatus;
 }
 


### PR DESCRIPTION
## Summary
- Redesign Settings around V1 trust-first local-only controls, value masking, quotes, currency/app info, and deferred data action.
- Derive a user-facing quote source label from cached quote data instead of exposing provider/status internals.
- Refresh Settings baseline docs and add the issue #135 spec/implementation plan.

## Test Plan
- npm test -- src/features/settings/__tests__
- npm test -- src/components/common/__tests__
- npm run typecheck
- npm test
- npm run test:v1:pc
- Android emulator visual verification on emulator-5554 with installed package com.abdulshaikh.cogvest

## Evidence
- Screenshots captured locally under .superpowers/artifacts/cogvest-settings-parity-*.png
- Expo doctor: 17/17 checks passed through npm run test:v1:pc

Closes #135