### PR TITLE
[V1 UX] Clarify automated snapshot review flow

### DIFF
--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -1,5 +1,7 @@
+import { router } from "expo-router";
+
 import { ProgressScreen } from "@/src/features/progress";
 
 export default function ProgressTabScreen() {
-  return <ProgressScreen />;
+  return <ProgressScreen onReviewSnapshot={() => router.push("/review-snapshot")} />;
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -29,6 +29,7 @@ export default function RootLayout() {
           <Stack.Screen name="add-holding" options={{ headerShown: false }} />
           <Stack.Screen name="sell-redeem" options={{ headerShown: false }} />
           <Stack.Screen name="settings" options={{ headerShown: false }} />
+          <Stack.Screen name="review-snapshot" options={{ headerShown: false }} />
           <Stack.Screen
             name="visual-qa-seed"
             options={{ headerShown: false }}

--- a/app/review-snapshot.tsx
+++ b/app/review-snapshot.tsx
@@ -1,0 +1,14 @@
+import { useRouter } from "expo-router";
+
+import { ReviewSnapshotScreen } from "@/src/features/progress";
+
+export default function ReviewSnapshotRoute() {
+  const router = useRouter();
+
+  return (
+    <ReviewSnapshotScreen
+      onCancel={() => router.back()}
+      onComplete={() => router.back()}
+    />
+  );
+}

--- a/docs/superpowers/plans/2026-07-10-issue-157-snapshot-review-ux.md
+++ b/docs/superpowers/plans/2026-07-10-issue-157-snapshot-review-ux.md
@@ -1,0 +1,23 @@
+# Issue #157: Snapshot Review UX Plan
+
+## 1. Extract The Review Surface
+
+- Add a feature-level `ReviewSnapshotScreen` using the existing `useProgress` form state and validation contract.
+- On first load, run the idempotent automation check and prefill the form from the generated or latest snapshot without overwriting user edits.
+- Add a cancel action and return to Progress after a successful save.
+
+## 2. Wire Navigation
+
+- Add an Expo Router route and stack entry for `review-snapshot`.
+- Replace Progress's local review state and inline form with navigation from the compact status card.
+- Keep the status card and automation message on Progress.
+
+## 3. Preserve Test Coverage
+
+- Move form-save and duplicate-month assertions to review-screen tests.
+- Update Progress tests to assert navigation intent, compact status, and the automatic empty-state explanation.
+
+## 4. Refresh Documentation And Verify
+
+- Update the V1 test plan, PC checklist, core-flow matrix, and Excel parity checklist.
+- Run focused Progress tests and `npm run test:v1:pc`.

--- a/docs/superpowers/specs/2026-07-10-issue-157-snapshot-review-ux.md
+++ b/docs/superpowers/specs/2026-07-10-issue-157-snapshot-review-ux.md
@@ -1,0 +1,32 @@
+# Issue #157: Snapshot Review UX
+
+## Purpose
+
+Monthly Progress automatically creates a missing completed-month snapshot. The review UI must make that automation clear without forcing a long data-entry form into the primary Progress screen.
+
+## Accepted Design
+
+- Monthly Progress keeps a compact `Month-end snapshot` status card near the top of the screen.
+- `Review snapshot` opens a dedicated `Review Snapshot` route, not a modal or an expanded form at the bottom of Progress.
+- The review route is an optional correction flow. It opens with the generated or latest snapshot values prefilled.
+- The review route uses clear language: generated automatically, edit only when a correction is needed, and `Save snapshot changes`.
+- Cancel/back returns to Progress without changing persisted data.
+
+## Behavioural Contract
+
+- Existing `ensureMonthEndSnapshot()` automation, derived calculations, validation, and update-versus-create persistence rules remain unchanged.
+- Saving a review for an existing month updates that snapshot rather than creating a duplicate.
+- Empty Progress copy explains that snapshots are created automatically once portfolio data exists.
+
+## Scope
+
+In scope: dedicated review route, moved form, navigation, tests, and V1 verification documentation.
+
+Out of scope: automation-rule changes, historical-price retrieval changes, chart redesign, background jobs, and notifications.
+
+## Acceptance Evidence
+
+- Progress never implies that a user must manually record a snapshot.
+- The full form is absent from the main Progress screen.
+- Review values prefill from the generated/latest snapshot and save in place.
+- Focused Progress tests and `npm run test:v1:pc` pass.

--- a/docs/testing/excel-parity-checklist.md
+++ b/docs/testing/excel-parity-checklist.md
@@ -95,7 +95,7 @@ Then verify on Android Emulator:
 - Add cash deposit and withdrawal.
 - Open Dashboard and verify total current value, invested value, allocation, and quote status.
 - Open Monthly Progress after seeded portfolio data and verify missing previous-month snapshot generation.
-- Use `Review snapshot` only when manual correction is needed.
+- Use `Review snapshot` only when manual correction is needed; it opens the dedicated Review Snapshot screen.
 - Verify monthly gain, gain %, monthly investment, savings rate, and asset split.
 - Toggle value masking in Settings.
 - Close and reopen the app and verify local data remains.

--- a/docs/testing/v1-core-flow-test-matrix.md
+++ b/docs/testing/v1-core-flow-test-matrix.md
@@ -47,7 +47,7 @@ approved.
 | Holdings derivation | `src/features/holdings/__tests__/HoldingsScreen.test.tsx`, `src/domain/calculations/__tests__/holdings.test.ts` | `e2e/holdings.yaml` asserts holdings after Add Holding | Holding row shows symbol, quantity, value |
 | Quote refresh and fallback | `src/services/quotes/__tests__/quotes.test.ts`, `src/services/quotes/__tests__/useQuoteRefresh.test.tsx`, Holdings tests | Manual emulator pull-to-refresh or Refresh Quotes action where network is available | Failures keep manual prices visible |
 | Cash tracking | `src/features/cash/__tests__/CashScreen.test.tsx`, `src/features/cash/__tests__/useCash.test.tsx` | `e2e/cash.yaml` adds cash by stable IDs | Cash balance and cash history update |
-| Monthly Progress snapshots | `src/features/progress/__tests__/ProgressScreen.test.tsx`, `src/features/progress/__tests__/useProgress.test.tsx`, `src/domain/calculations/__tests__/monthEndSnapshots.test.ts`, `src/store/__tests__/portfolioStore.test.ts` | Manual emulator flow opens Progress after seeded portfolio data and verifies the compact month-end snapshot status | Missing previous-month snapshot is generated automatically; review/edit stays available behind `Review snapshot`; Progress shows monthly gain, investment, savings rate where derivable, and asset split |
+| Monthly Progress snapshots | `src/features/progress/__tests__/ProgressScreen.test.tsx`, `src/features/progress/__tests__/useProgress.test.tsx`, `src/domain/calculations/__tests__/monthEndSnapshots.test.ts`, `src/store/__tests__/portfolioStore.test.ts` | Manual emulator flow opens Progress after seeded portfolio data and verifies the compact month-end snapshot status | Missing previous-month snapshot is generated automatically; review/edit stays available in the dedicated `Review Snapshot` screen; Progress shows monthly gain, investment, savings rate where derivable, and asset split |
 | Excel parity gate | `docs/testing/excel-parity-checklist.md` plus #61-#65 tests | Manual PC-only flow in the checklist | Every parity question passes or has a `[V1 QA]` defect |
 | Value masking | `src/features/settings/__tests__/SettingsScreen.test.tsx`, dashboard/holdings/cash masked-value tests | `e2e/value-masking.yaml` opens `cogvest://settings` and toggles `value-mask-toggle` | Wealth values mask; quantities and percentages remain visible |
 | Persistence after close/reopen | `src/store/__tests__/portfolioStore.test.ts`, storage tests | `e2e/persistence.yaml` saves data, stops app, relaunches, and verifies data remains | State remains after app restart |
@@ -80,7 +80,7 @@ Maestro E2E not run: Maestro unavailable.
 - Open Progress after seeded portfolio data exists.
 - Verify the missing previous completed month snapshot is generated automatically.
 - Verify Progress shows the compact `Month-end snapshot` status card by default.
-- Verify `Review snapshot` reveals the edit form for correction/manual override.
+- Verify `Review snapshot` opens the dedicated Review Snapshot screen for correction/manual override.
 - Verify generated snapshots update Progress charts after enough monthly history exists.
 - Verify fallback/status text appears when historical provider lookup is unavailable and the app uses latest local or manual prices.
 

--- a/docs/testing/v1-pc-verification-checklist.md
+++ b/docs/testing/v1-pc-verification-checklist.md
@@ -30,7 +30,7 @@ Android Emulator, not a physical Android phone.
 - [ ] Cash balance appears on Dashboard.
 - [ ] Monthly Progress automatically generates the missing previous completed month snapshot after portfolio data exists.
 - [ ] Monthly Progress shows compact `Month-end snapshot` status by default.
-- [ ] `Review snapshot` opens the edit form for correction/manual override.
+- [ ] `Review snapshot` opens the dedicated `Review Snapshot` screen for correction/manual override.
 - [ ] Monthly Progress shows monthly gain, gain %, monthly investment, savings rate where derivable, and asset split.
 - [ ] Value masking can be toggled from Settings.
 - [ ] Masked state hides wealth values but not quantities or percentages.

--- a/docs/testing/v1-testing-plan.md
+++ b/docs/testing/v1-testing-plan.md
@@ -48,7 +48,7 @@ Cover:
 - MaskedValue display.
 - Cash add/withdraw rows.
 - Monthly Progress auto-generates missing completed-month snapshots and keeps
-  manual correction behind `Review snapshot`.
+  manual correction in the dedicated `Review Snapshot` screen.
 
 ## Android Emulator QA
 

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -344,9 +344,9 @@ export function DashboardScreen({
           <View style={styles.reviewCardRow}>
             <CategoryIcon assetClass="neutral" />
             <View style={styles.infoCardCopy}>
-              <AppText weight="bold">Record monthly snapshot</AppText>
+              <AppText weight="bold">Review month-end snapshot</AppText>
               <AppText color="secondary" variant="caption">
-                Review this month in Progress when month-end data is ready.
+                Your snapshot is generated automatically. Review it in Progress only if a correction is needed.
               </AppText>
             </View>
             <Pressable

--- a/src/features/dashboard/__tests__/DashboardScreen.test.tsx
+++ b/src/features/dashboard/__tests__/DashboardScreen.test.tsx
@@ -178,7 +178,7 @@ describe("DashboardScreen", () => {
     expect(getByText("Cash")).toBeTruthy();
     expect(getByText("Quotes updated")).toBeTruthy();
     expect(getByText("22 Apr 2026 • Live refresh available")).toBeTruthy();
-    expect(getByText("Record monthly snapshot")).toBeTruthy();
+    expect(getByText("Review month-end snapshot")).toBeTruthy();
     expect(getByText("Open Progress")).toBeTruthy();
     expect(getByText("This Month")).toBeTruthy();
     expect(getByText("Cash change")).toBeTruthy();

--- a/src/features/progress/ProgressScreen.tsx
+++ b/src/features/progress/ProgressScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { Pressable, StyleSheet, View } from "react-native";
 import { LineChart } from "react-native-gifted-charts";
 import type { StoreApi } from "zustand/vanilla";
@@ -29,12 +29,11 @@ import { formatCompactINR, formatINR, formatPercentage } from "@/src/domain/form
 import { useReducedMotionPreference } from "@/src/hooks";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
 import { colors, interaction, spacing } from "@/src/theme";
-import type { MonthlySnapshot } from "@/src/types";
-import { FormTextField } from "@/src/components/forms";
 import { useProgress, type ProgressSnapshotAutomationStatus } from "./useProgress";
 
 type ProgressScreenProps = {
   now?: Date;
+  onReviewSnapshot?: () => void;
   store?: StoreApi<PortfolioStoreState>;
 };
 
@@ -575,34 +574,14 @@ function SnapshotStatusCard({
   );
 }
 
-function setSnapshotFormFields({
-  progress,
-  snapshot,
-}: {
-  progress: ReturnType<typeof useProgress>;
-  snapshot: MonthlySnapshot;
-}) {
-  progress.setField("month", snapshot.month);
-  progress.setField("portfolioValue", String(snapshot.portfolioValue));
-  progress.setField("investedValue", String(snapshot.investedValue));
-  progress.setField("equityValue", String(snapshot.equityValue));
-  progress.setField("debtValue", String(snapshot.debtValue));
-  progress.setField("cryptoValue", String(snapshot.cryptoValue));
-  progress.setField("cashValue", String(snapshot.cashValue));
-  progress.setField("monthlyInvestment", String(snapshot.monthlyInvestment));
-  progress.setField("salary", String(snapshot.salary));
-  progress.setField("monthlyExpense", String(snapshot.monthlyExpense ?? ""));
-  progress.setField("notes", snapshot.notes ?? "");
-}
-
 export function ProgressScreen({
   now,
+  onReviewSnapshot,
   store = getPortfolioStore(),
 }: ProgressScreenProps) {
   const progress = useProgress({ now, store });
   const isReducedMotionEnabled = useReducedMotionPreference();
   const hasRunAutomationRef = useRef(false);
-  const [isReviewingSnapshot, setIsReviewingSnapshot] = useState(false);
 
   useEffect(() => {
     if (hasRunAutomationRef.current) {
@@ -614,15 +593,7 @@ export function ProgressScreen({
   }, [progress]);
 
   function reviewSnapshot() {
-    const reviewSnapshot =
-      progress.snapshotAutomationStatus.snapshot ??
-      progress.latestSummary?.snapshot;
-
-    if (reviewSnapshot) {
-      setSnapshotFormFields({ progress, snapshot: reviewSnapshot });
-    }
-
-    setIsReviewingSnapshot(true);
+    onReviewSnapshot?.();
   }
 
   return (
@@ -796,122 +767,10 @@ export function ProgressScreen({
         ) : (
           <EmptyState
             title="No monthly snapshots yet"
-            message="Record a month-end snapshot to track progress without Excel."
+            message="Snapshots are created automatically once your portfolio has data. Review a snapshot only when a correction is needed."
           />
         )}
 
-        {isReviewingSnapshot ? (
-        <PremiumCard>
-          <SectionHeader title="Record monthly snapshot" />
-          <FormTextField
-            error={progress.errors.month}
-            label="Month"
-            onChangeText={(value) => progress.setField("month", value)}
-            placeholder="YYYY-MM"
-            testID="snapshot-month-input"
-            value={progress.formValues.month}
-          />
-          <FormTextField
-            error={progress.errors.portfolioValue}
-            keyboardType="decimal-pad"
-            label="Portfolio value"
-            onChangeText={(value) => progress.setField("portfolioValue", value)}
-            placeholder="1385000"
-            testID="snapshot-portfolio-input"
-            value={progress.formValues.portfolioValue}
-          />
-          <FormTextField
-            error={progress.errors.investedValue}
-            keyboardType="decimal-pad"
-            label="Invested value"
-            onChangeText={(value) => progress.setField("investedValue", value)}
-            placeholder="1060000"
-            testID="snapshot-invested-input"
-            value={progress.formValues.investedValue}
-          />
-          <View style={styles.fieldGrid}>
-            <FormTextField
-              error={progress.errors.equityValue}
-              keyboardType="decimal-pad"
-              label="Equity"
-              onChangeText={(value) => progress.setField("equityValue", value)}
-              placeholder="880000"
-              testID="snapshot-equity-input"
-              value={progress.formValues.equityValue}
-            />
-            <FormTextField
-              error={progress.errors.debtValue}
-              keyboardType="decimal-pad"
-              label="Debt"
-              onChangeText={(value) => progress.setField("debtValue", value)}
-              placeholder="320000"
-              testID="snapshot-debt-input"
-              value={progress.formValues.debtValue}
-            />
-          </View>
-          <View style={styles.fieldGrid}>
-            <FormTextField
-              error={progress.errors.cryptoValue}
-              keyboardType="decimal-pad"
-              label="Crypto"
-              onChangeText={(value) => progress.setField("cryptoValue", value)}
-              placeholder="45000"
-              testID="snapshot-crypto-input"
-              value={progress.formValues.cryptoValue}
-            />
-            <FormTextField
-              error={progress.errors.cashValue}
-              keyboardType="decimal-pad"
-              label="Cash"
-              onChangeText={(value) => progress.setField("cashValue", value)}
-              placeholder="140000"
-              testID="snapshot-cash-input"
-              value={progress.formValues.cashValue}
-            />
-          </View>
-          <View style={styles.fieldGrid}>
-            <FormTextField
-              error={progress.errors.monthlyInvestment}
-              keyboardType="decimal-pad"
-              label="Monthly investment"
-              onChangeText={(value) => progress.setField("monthlyInvestment", value)}
-              placeholder="60000"
-              testID="snapshot-investment-input"
-              value={progress.formValues.monthlyInvestment}
-            />
-            <FormTextField
-              error={progress.errors.salary}
-              keyboardType="decimal-pad"
-              label="Salary"
-              onChangeText={(value) => progress.setField("salary", value)}
-              placeholder="160000"
-              testID="snapshot-salary-input"
-              value={progress.formValues.salary}
-            />
-          </View>
-          <FormTextField
-            error={progress.errors.monthlyExpense}
-            keyboardType="decimal-pad"
-            label="Monthly expense"
-            onChangeText={(value) => progress.setField("monthlyExpense", value)}
-            placeholder="Optional"
-            testID="snapshot-expense-input"
-            value={progress.formValues.monthlyExpense}
-          />
-          <FormTextField
-            label="Notes"
-            multiline
-            onChangeText={(value) => progress.setField("notes", value)}
-            placeholder="Optional month-end note"
-            value={progress.formValues.notes}
-          />
-          <AppButton
-            title="Save Monthly Snapshot"
-            testID="save-monthly-snapshot-button"
-            onPress={progress.saveSnapshot}
-          />
-        </PremiumCard>
-        ) : null}
       </View>
     </ScreenContainer>
   );
@@ -971,9 +830,6 @@ const styles = StyleSheet.create({
     gap: spacing.cardGap,
     paddingBottom: spacing.lg,
     paddingTop: spacing.md,
-  },
-  fieldGrid: {
-    gap: spacing.sm,
   },
   legendDot: {
     borderRadius: 4,

--- a/src/features/progress/ReviewSnapshotScreen.tsx
+++ b/src/features/progress/ReviewSnapshotScreen.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useRef } from "react";
+import { StyleSheet, View } from "react-native";
+import type { StoreApi } from "zustand/vanilla";
+
+import { AppButton, AppText, PremiumCard, ScreenContainer, ScreenHeader, SectionHeader } from "@/src/components/common";
+import { FormTextField } from "@/src/components/forms";
+import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
+import { spacing } from "@/src/theme";
+import type { MonthlySnapshot } from "@/src/types";
+
+import { useProgress } from "./useProgress";
+
+type ReviewSnapshotScreenProps = {
+  now?: Date;
+  onCancel: () => void;
+  onComplete: () => void;
+  store?: StoreApi<PortfolioStoreState>;
+};
+
+function setSnapshotFormFields({
+  progress,
+  snapshot,
+}: {
+  progress: ReturnType<typeof useProgress>;
+  snapshot: MonthlySnapshot;
+}) {
+  progress.setField("month", snapshot.month);
+  progress.setField("portfolioValue", String(snapshot.portfolioValue));
+  progress.setField("investedValue", String(snapshot.investedValue));
+  progress.setField("equityValue", String(snapshot.equityValue));
+  progress.setField("debtValue", String(snapshot.debtValue));
+  progress.setField("cryptoValue", String(snapshot.cryptoValue));
+  progress.setField("cashValue", String(snapshot.cashValue));
+  progress.setField("monthlyInvestment", String(snapshot.monthlyInvestment));
+  progress.setField("salary", String(snapshot.salary));
+  progress.setField("monthlyExpense", String(snapshot.monthlyExpense ?? ""));
+  progress.setField("notes", snapshot.notes ?? "");
+}
+
+export function ReviewSnapshotScreen({
+  now,
+  onCancel,
+  onComplete,
+  store = getPortfolioStore(),
+}: ReviewSnapshotScreenProps) {
+  const progress = useProgress({ now, store });
+  const hasRunAutomationRef = useRef(false);
+  const hasPrefilledFormRef = useRef(false);
+
+  useEffect(() => {
+    if (hasRunAutomationRef.current) {
+      return;
+    }
+
+    hasRunAutomationRef.current = true;
+    void progress.ensureMonthEndSnapshot();
+  }, [progress]);
+
+  useEffect(() => {
+    if (hasPrefilledFormRef.current) {
+      return;
+    }
+
+    const snapshot =
+      progress.snapshotAutomationStatus.snapshot ?? progress.latestSummary?.snapshot;
+
+    if (!snapshot) {
+      return;
+    }
+
+    setSnapshotFormFields({ progress, snapshot });
+    hasPrefilledFormRef.current = true;
+  }, [progress]);
+
+  function saveSnapshotChanges() {
+    if (progress.saveSnapshot()) {
+      onComplete();
+    }
+  }
+
+  return (
+    <ScreenContainer scroll testID="review-snapshot-screen">
+      <View style={styles.content}>
+        <ScreenHeader
+          title="Review Snapshot"
+          subtitle="Generated automatically - edit only if something needs correction"
+        />
+
+        <PremiumCard>
+          <SectionHeader title="Snapshot details" />
+          <AppText color="secondary" variant="caption">
+            These values are prefilled from your local portfolio records. Saving changes updates this month only.
+          </AppText>
+        </PremiumCard>
+
+        <PremiumCard>
+          <FormTextField
+            error={progress.errors.month}
+            label="Month"
+            onChangeText={(value) => progress.setField("month", value)}
+            placeholder="YYYY-MM"
+            testID="snapshot-month-input"
+            value={progress.formValues.month}
+          />
+          <FormTextField
+            error={progress.errors.portfolioValue}
+            keyboardType="decimal-pad"
+            label="Portfolio value"
+            onChangeText={(value) => progress.setField("portfolioValue", value)}
+            placeholder="1385000"
+            testID="snapshot-portfolio-input"
+            value={progress.formValues.portfolioValue}
+          />
+          <FormTextField
+            error={progress.errors.investedValue}
+            keyboardType="decimal-pad"
+            label="Invested value"
+            onChangeText={(value) => progress.setField("investedValue", value)}
+            placeholder="1060000"
+            testID="snapshot-invested-input"
+            value={progress.formValues.investedValue}
+          />
+          <View style={styles.fieldGrid}>
+            <FormTextField
+              error={progress.errors.equityValue}
+              keyboardType="decimal-pad"
+              label="Equity"
+              onChangeText={(value) => progress.setField("equityValue", value)}
+              placeholder="880000"
+              testID="snapshot-equity-input"
+              value={progress.formValues.equityValue}
+            />
+            <FormTextField
+              error={progress.errors.debtValue}
+              keyboardType="decimal-pad"
+              label="Debt"
+              onChangeText={(value) => progress.setField("debtValue", value)}
+              placeholder="320000"
+              testID="snapshot-debt-input"
+              value={progress.formValues.debtValue}
+            />
+          </View>
+          <View style={styles.fieldGrid}>
+            <FormTextField
+              error={progress.errors.cryptoValue}
+              keyboardType="decimal-pad"
+              label="Crypto"
+              onChangeText={(value) => progress.setField("cryptoValue", value)}
+              placeholder="45000"
+              testID="snapshot-crypto-input"
+              value={progress.formValues.cryptoValue}
+            />
+            <FormTextField
+              error={progress.errors.cashValue}
+              keyboardType="decimal-pad"
+              label="Cash"
+              onChangeText={(value) => progress.setField("cashValue", value)}
+              placeholder="140000"
+              testID="snapshot-cash-input"
+              value={progress.formValues.cashValue}
+            />
+          </View>
+          <View style={styles.fieldGrid}>
+            <FormTextField
+              error={progress.errors.monthlyInvestment}
+              keyboardType="decimal-pad"
+              label="Monthly investment"
+              onChangeText={(value) => progress.setField("monthlyInvestment", value)}
+              placeholder="60000"
+              testID="snapshot-investment-input"
+              value={progress.formValues.monthlyInvestment}
+            />
+            <FormTextField
+              error={progress.errors.salary}
+              keyboardType="decimal-pad"
+              label="Salary"
+              onChangeText={(value) => progress.setField("salary", value)}
+              placeholder="160000"
+              testID="snapshot-salary-input"
+              value={progress.formValues.salary}
+            />
+          </View>
+          <FormTextField
+            error={progress.errors.monthlyExpense}
+            keyboardType="decimal-pad"
+            label="Monthly expense"
+            onChangeText={(value) => progress.setField("monthlyExpense", value)}
+            placeholder="Optional"
+            testID="snapshot-expense-input"
+            value={progress.formValues.monthlyExpense}
+          />
+          <FormTextField
+            label="Notes"
+            multiline
+            onChangeText={(value) => progress.setField("notes", value)}
+            placeholder="Optional month-end note"
+            testID="snapshot-notes-input"
+            value={progress.formValues.notes}
+          />
+          <View style={styles.actions}>
+            <AppButton
+              onPress={onCancel}
+              testID="cancel-snapshot-review-button"
+              title="Cancel"
+              variant="secondary"
+            />
+            <AppButton
+              onPress={saveSnapshotChanges}
+              testID="save-monthly-snapshot-button"
+              title="Save snapshot changes"
+            />
+          </View>
+        </PremiumCard>
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  actions: {
+    flexDirection: "row",
+    gap: spacing.sm,
+    justifyContent: "flex-end",
+  },
+  content: {
+    gap: spacing.lg,
+    paddingVertical: spacing.lg,
+  },
+  fieldGrid: {
+    flexDirection: "row",
+    gap: spacing.md,
+  },
+});

--- a/src/features/progress/__tests__/ProgressScreen.test.tsx
+++ b/src/features/progress/__tests__/ProgressScreen.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render } from "@testing-library/react-native";
 
-import { ProgressScreen } from "@/src/features/progress";
+import { ProgressScreen, ReviewSnapshotScreen } from "@/src/features/progress";
 import { useReducedMotionPreference } from "@/src/hooks";
 import { createMemoryJsonStorage } from "@/src/services/storage";
 import { createPortfolioStore } from "@/src/store";
@@ -97,7 +97,7 @@ describe("ProgressScreen", () => {
 
     expect(getByText("No monthly snapshots yet")).toBeTruthy();
     expect(
-      getByText("Record a month-end snapshot to track progress without Excel."),
+      getByText("Snapshots are created automatically once your portfolio has data. Review a snapshot only when a correction is needed."),
     ).toBeTruthy();
   });
 
@@ -117,11 +117,65 @@ describe("ProgressScreen", () => {
     expect(queryByTestId("snapshot-portfolio-input")).toBeNull();
   });
 
-  it("saves a monthly snapshot from the screen form", () => {
+  it("opens the dedicated snapshot review flow", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
-    const { getByTestId, getByText } = render(<ProgressScreen store={store} />);
+    const onReviewSnapshot = jest.fn();
+    const { getByText, queryByTestId } = render(
+      <ProgressScreen onReviewSnapshot={onReviewSnapshot} store={store} />,
+    );
 
     fireEvent.press(getByText("Review snapshot"));
+
+    expect(onReviewSnapshot).toHaveBeenCalledTimes(1);
+    expect(queryByTestId("snapshot-portfolio-input")).toBeNull();
+  });
+  it("prefills the latest generated snapshot for optional correction", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addMonthlySnapshot(maySnapshot);
+
+    const { getByTestId, getByText } = render(
+      <ReviewSnapshotScreen
+        onCancel={jest.fn()}
+        onComplete={jest.fn()}
+        store={store}
+      />,
+    );
+
+    expect(getByText("Review Snapshot")).toBeTruthy();
+    expect(getByTestId("snapshot-month-input").props.value).toBe("2026-05");
+    expect(getByTestId("snapshot-portfolio-input").props.value).toBe("1385000");
+    expect(getByTestId("snapshot-notes-input").props.value).toBe("May close");
+  });
+
+  it("cancels a review without persisting field changes", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addMonthlySnapshot(maySnapshot);
+    const onCancel = jest.fn();
+    const { getByTestId } = render(
+      <ReviewSnapshotScreen
+        onCancel={onCancel}
+        onComplete={jest.fn()}
+        store={store}
+      />,
+    );
+
+    fireEvent.changeText(getByTestId("snapshot-portfolio-input"), "1400000");
+    fireEvent.press(getByTestId("cancel-snapshot-review-button"));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(store.getState().monthlySnapshots[0]?.portfolioValue).toBe(1385000);
+  });
+  it("saves snapshot changes from the dedicated review screen", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const onComplete = jest.fn();
+    const { getByTestId, getByText } = render(
+      <ReviewSnapshotScreen
+        onCancel={jest.fn()}
+        onComplete={onComplete}
+        store={store}
+      />,
+    );
+
     fireEvent.changeText(getByTestId("snapshot-month-input"), "2026-05");
     fireEvent.changeText(getByTestId("snapshot-portfolio-input"), "1385000");
     fireEvent.changeText(getByTestId("snapshot-invested-input"), "1060000");
@@ -132,7 +186,7 @@ describe("ProgressScreen", () => {
     fireEvent.changeText(getByTestId("snapshot-investment-input"), "60000");
     fireEvent.changeText(getByTestId("snapshot-salary-input"), "160000");
     fireEvent.changeText(getByTestId("snapshot-expense-input"), "40000");
-    fireEvent.press(getByText("Save Monthly Snapshot"));
+    fireEvent.press(getByText("Save snapshot changes"));
 
     expect(store.getState().monthlySnapshots).toHaveLength(1);
     expect(store.getState().monthlySnapshots[0]).toMatchObject({
@@ -147,9 +201,8 @@ describe("ProgressScreen", () => {
       portfolioValue: 1385000,
       salary: 160000,
     });
-    expect(getByText("May 2026")).toBeTruthy();
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
-
   it("renders persisted monthly gain, rates, and asset snapshot", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     store.getState().addMonthlySnapshot(aprilSnapshot);
@@ -274,9 +327,15 @@ describe("ProgressScreen", () => {
   it("updates an existing month instead of creating duplicate snapshots", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     store.getState().addMonthlySnapshot(maySnapshot);
-    const { getByTestId, getByText } = render(<ProgressScreen store={store} />);
+    const onComplete = jest.fn();
+    const { getByTestId, getByText } = render(
+      <ReviewSnapshotScreen
+        onCancel={jest.fn()}
+        onComplete={onComplete}
+        store={store}
+      />,
+    );
 
-    fireEvent.press(getByText("Review snapshot"));
     fireEvent.changeText(getByTestId("snapshot-month-input"), "2026-05");
     fireEvent.changeText(getByTestId("snapshot-portfolio-input"), "1400000");
     fireEvent.changeText(getByTestId("snapshot-invested-input"), "1070000");
@@ -286,7 +345,7 @@ describe("ProgressScreen", () => {
     fireEvent.changeText(getByTestId("snapshot-cash-input"), "140000");
     fireEvent.changeText(getByTestId("snapshot-investment-input"), "70000");
     fireEvent.changeText(getByTestId("snapshot-salary-input"), "160000");
-    fireEvent.press(getByText("Save Monthly Snapshot"));
+    fireEvent.press(getByText("Save snapshot changes"));
 
     expect(store.getState().monthlySnapshots).toHaveLength(1);
     expect(store.getState().monthlySnapshots[0]).toMatchObject({
@@ -295,5 +354,6 @@ describe("ProgressScreen", () => {
       monthlyInvestment: 70000,
       portfolioValue: 1400000,
     });
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/progress/index.ts
+++ b/src/features/progress/index.ts
@@ -1,4 +1,5 @@
 export { ProgressScreen } from "./ProgressScreen";
+export { ReviewSnapshotScreen } from "./ReviewSnapshotScreen";
 export { useMonthEndSnapshotAutomation } from "./useMonthEndSnapshotAutomation";
 export {
   useProgress,

--- a/src/features/progress/useProgress.ts
+++ b/src/features/progress/useProgress.ts
@@ -274,7 +274,7 @@ export function useProgress({
 
     if (!result.snapshot) {
       setErrors(result.errors);
-      return;
+      return false;
     }
 
     const existingSnapshot = snapshot.monthlySnapshots.find(
@@ -292,6 +292,7 @@ export function useProgress({
 
     setFormValues(emptyProgressFormValues());
     setErrors({});
+    return true;
   }
 
   async function ensureMonthEndSnapshot() {


### PR DESCRIPTION
## Summary
- move snapshot correction from the bottom of Monthly Progress into a dedicated Review Snapshot route
- retain automatic month-end generation, generated-value prefill, validation, and update-in-place saving
- replace remaining manual-record copy on Progress and Dashboard with automation-aware review language
- document and test the dedicated correction flow

## Verification
- `npm run test:v1:pc`
- Emulator UI tree verified: Progress shows Month-end snapshot and Review snapshot without inline snapshot fields; Review Snapshot route renders generated-value guidance and the correction form.

Closes #157