### PR TITLE
fix: conserve cash across investment transactions

### DIFF
--- a/docs/cogvest-master-spec.md
+++ b/docs/cogvest-master-spec.md
@@ -91,6 +91,24 @@ Derive:
 
 All domain calculations must be pure functions under `src/domain/`.
 
+### V1 Cash Accounting Contract
+
+- Opening positions represent an external baseline and do not create cash
+  movements.
+- A new buy must be funded from deployable tracked cash. Saving the buy and its
+  linked cash withdrawal is one atomic store transition, and a buy above the
+  available balance is rejected before mutation.
+- A sale must add its net proceeds to deployable cash in the same atomic store
+  transition. Money leaving the tracked portfolio is recorded separately as a
+  withdrawal.
+- Cash additions are typed as income, capital contribution, or legacy
+  uncategorized data. Purchase funding, sale proceeds, and withdrawals are
+  distinct linked movement purposes.
+- Monthly investment rate uses typed income only. Capital contributions, sale
+  proceeds, and migrated legacy additions must not be treated as income.
+- Persisted pre-contract additions migrate to legacy uncategorized entries so
+  historical cash remains visible without inventing income semantics.
+
 ## Screen Contract
 
 Primary tabs:

--- a/e2e/funded-buy-cash.yaml
+++ b/e2e/funded-buy-cash.yaml
@@ -1,0 +1,72 @@
+appId: com.abdulshaikh.cogvest
+---
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "dashboard-screen"
+- tapOn:
+    id: "tab-cash"
+- tapOn:
+    id: "cash-amount-input"
+- inputText: "1000"
+- hideKeyboard
+- tapOn:
+    id: "cash-label-input"
+- inputText: "Test contribution"
+- hideKeyboard
+- tapOn:
+    id: "cash-date-input"
+- inputText: "2026-07-18"
+- hideKeyboard
+- scrollUntilVisible:
+    element:
+      id: "save-cash-entry-button"
+    direction: DOWN
+- tapOn:
+    id: "save-cash-entry-button"
+- assertVisible: "₹1,000.00"
+- openLink: "cogvest:///add-trade"
+- assertVisible:
+    id: "add-trade-screen"
+- tapOn:
+    id: "asset-input"
+- inputText: "Accounting Test Asset"
+- hideKeyboard
+- tapOn:
+    id: "symbol-input"
+- inputText: "ACCT"
+- tapOn:
+    id: "ticker-input"
+- inputText: "ACCT.NS"
+- hideKeyboard
+- scrollUntilVisible:
+    element:
+      id: "quantity-input"
+    direction: DOWN
+- tapOn:
+    id: "quantity-input"
+- inputText: "2"
+- tapOn:
+    id: "price-input"
+- inputText: "100"
+- hideKeyboard
+- scrollUntilVisible:
+    element:
+      id: "review-trade-button"
+    direction: DOWN
+- tapOn:
+    id: "review-trade-button"
+- assertVisible: "Total: ₹200.00"
+- scrollUntilVisible:
+    element:
+      id: "save-trade-button"
+    direction: DOWN
+- tapOn:
+    id: "save-trade-button"
+- assertVisible: "Holding saved."
+- tapOn:
+    id: "tab-cash"
+- assertVisible: "₹800.00"
+- tapOn:
+    id: "tab-holdings"
+- assertVisible: "Accounting Test Asset"

--- a/scripts/maestro-run.mjs
+++ b/scripts/maestro-run.mjs
@@ -9,6 +9,7 @@ const defaultFlows = [
   "e2e/add-holding-lookup.yaml",
   "e2e/holdings.yaml",
   "e2e/cash.yaml",
+  "e2e/funded-buy-cash.yaml",
   "e2e/value-masking.yaml",
   "e2e/persistence.yaml",
 ];

--- a/src/components/cards/CashEntryRow.tsx
+++ b/src/components/cards/CashEntryRow.tsx
@@ -16,18 +16,23 @@ function formatCashAmount(entry: CashEntry) {
   return entry.type === "addition" ? `+${amount}` : `-${amount}`;
 }
 
-function isAssetExitProceeds(entry: CashEntry) {
-  return /sale proceeds|redemption proceeds/i.test(entry.label);
-}
-
 function getCashEntryMovement(entry: CashEntry) {
-  if (entry.type === "addition" && isAssetExitProceeds(entry)) {
-    return "Added from asset exit";
+  switch (entry.purpose) {
+    case "capitalContribution":
+      return "Capital added to deployable cash";
+    case "income":
+      return "Income added to deployable cash";
+    case "purchaseFunding":
+      return "Funded an investment purchase";
+    case "saleProceeds":
+      return "Added from asset exit";
+    case "withdrawal":
+      return "Withdrawn from deployable cash";
+    case "legacyUncategorized":
+      return entry.type === "addition"
+        ? "Legacy cash addition"
+        : "Legacy cash withdrawal";
   }
-
-  return entry.type === "addition"
-    ? "Increased deployable cash"
-    : "Reduced deployable cash";
 }
 
 export function CashEntryRow({ entry, masked = false }: CashEntryRowProps) {

--- a/src/domain/calculations/__tests__/holdings.test.ts
+++ b/src/domain/calculations/__tests__/holdings.test.ts
@@ -1,6 +1,7 @@
 import {
   calculateAllocation,
   calculateCashBalance,
+  calculateCashMonthlyMetrics,
   calculateConsolidatedHoldingRows,
   calculateHolding,
   calculateHoldings,
@@ -294,6 +295,7 @@ describe("portfolio calculations", () => {
       date: "2026-04-20T00:00:00.000Z",
       id: "cash-1",
       label: "Deposit",
+      purpose: "capitalContribution",
       type: "addition",
     },
     {
@@ -301,6 +303,7 @@ describe("portfolio calculations", () => {
       date: "2026-04-21T00:00:00.000Z",
       id: "cash-2",
       label: "Withdraw",
+      purpose: "withdrawal",
       type: "withdrawal",
     },
   ];
@@ -314,6 +317,130 @@ describe("portfolio calculations", () => {
 
     expect(calculateCashBalance(cashEntries)).toBe(8500);
     expect(calculatePortfolioTotal([holding], cashEntries)).toBe(9700);
+  });
+
+  it("conserves portfolio wealth across funded buys and sales before market movement", () => {
+    const contribution: CashEntry = {
+      amount: 100000,
+      date: "2026-05-01T00:00:00.000Z",
+      id: "cash-contribution",
+      label: "Capital contribution",
+      purpose: "capitalContribution",
+      type: "addition",
+    };
+    const purchaseFunding: CashEntry = {
+      amount: 80000,
+      date: "2026-05-05T00:00:00.000Z",
+      id: "cash-trade-buy",
+      label: "Reliance Industries purchase",
+      linkedTradeId: "trade-buy",
+      purpose: "purchaseFunding",
+      type: "withdrawal",
+    };
+    const buy = trade({
+      date: "2026-05-05T00:00:00.000Z",
+      id: "trade-buy",
+      pricePerUnit: 100,
+      quantity: 800,
+      totalValue: 80000,
+    });
+    const holdingAfterBuy = calculateHolding({
+      asset: reliance,
+      currentPrice: 100,
+      trades: [buy],
+    });
+
+    expect(
+      calculatePortfolioTotal(
+        [holdingAfterBuy],
+        [contribution, purchaseFunding],
+      ),
+    ).toBe(100000);
+
+    const saleProceeds: CashEntry = {
+      amount: 22000,
+      date: "2026-05-20T00:00:00.000Z",
+      id: "cash-trade-sale",
+      label: "Reliance Industries sale proceeds",
+      linkedTradeId: "trade-sale",
+      purpose: "saleProceeds",
+      type: "addition",
+    };
+    const sale = trade({
+      date: "2026-05-20T00:00:00.000Z",
+      id: "trade-sale",
+      pricePerUnit: 110,
+      quantity: 200,
+      totalValue: 22000,
+      type: "sell",
+    });
+    const holdingAfterSale = calculateHolding({
+      asset: reliance,
+      currentPrice: 110,
+      trades: [buy, sale],
+    });
+
+    expect(
+      calculatePortfolioTotal(
+        [holdingAfterSale],
+        [contribution, purchaseFunding, saleProceeds],
+      ),
+    ).toBe(108000);
+  });
+
+  it("uses only typed income for the monthly investment rate", () => {
+    const monthlyEntries: CashEntry[] = [
+      {
+        amount: 50000,
+        date: "2026-05-01T00:00:00.000Z",
+        id: "cash-income",
+        label: "Salary",
+        purpose: "income",
+        type: "addition",
+      },
+      {
+        amount: 25000,
+        date: "2026-05-02T00:00:00.000Z",
+        id: "cash-contribution",
+        label: "Capital contribution",
+        purpose: "capitalContribution",
+        type: "addition",
+      },
+      {
+        amount: 10000,
+        date: "2026-05-03T00:00:00.000Z",
+        id: "cash-trade-buy",
+        label: "Funded purchase",
+        linkedTradeId: "trade-buy",
+        purpose: "purchaseFunding",
+        type: "withdrawal",
+      },
+      {
+        amount: 12000,
+        date: "2026-05-04T00:00:00.000Z",
+        id: "cash-trade-sale",
+        label: "Sale proceeds",
+        linkedTradeId: "trade-sale",
+        purpose: "saleProceeds",
+        type: "addition",
+      },
+    ];
+
+    expect(
+      calculateCashMonthlyMetrics({
+        cashEntries: monthlyEntries,
+        now: new Date("2026-05-20T00:00:00.000Z"),
+        openingPositions: [],
+        trades: [],
+      }),
+    ).toEqual({
+      added: 75000,
+      available: 77000,
+      contributions: 25000,
+      income: 50000,
+      investmentRate: 20,
+      invested: 10000,
+    });
   });
 
   it("calculates day change from holding values and quote change", () => {

--- a/src/domain/calculations/__tests__/monthEndSnapshots.test.ts
+++ b/src/domain/calculations/__tests__/monthEndSnapshots.test.ts
@@ -88,6 +88,7 @@ function cashEntry(overrides: Partial<CashEntry>): CashEntry {
     date: "2026-07-05T00:00:00.000Z",
     id: `cash-${Math.random()}`,
     label: "Deposit",
+    purpose: "capitalContribution",
     type: "addition",
     ...overrides,
   };

--- a/src/domain/calculations/holdings.ts
+++ b/src/domain/calculations/holdings.ts
@@ -76,8 +76,10 @@ export type MonthlyProgressSummary = {
 export type CashMonthlyMetrics = {
   added: number;
   available: number;
+  contributions: number;
+  income: number;
+  investmentRate: number | null;
   invested: number;
-  savingsRate: number | null;
 };
 
 export type PortfolioDayChange = {
@@ -230,34 +232,46 @@ function isSameMonth(isoDate: string, now: Date) {
 export function calculateCashMonthlyMetrics({
   cashEntries,
   now = new Date(),
-  openingPositions,
-  trades,
 }: {
   cashEntries: CashEntry[];
   now?: Date;
   openingPositions: OpeningPosition[];
   trades: Trade[];
 }): CashMonthlyMetrics {
-  const added = cashEntries
-    .filter((entry) => entry.type === "addition" && isSameMonth(entry.date, now))
+  const monthlyEntries = cashEntries.filter((entry) =>
+    isSameMonth(entry.date, now),
+  );
+  const income = monthlyEntries
+    .filter(
+      (entry) => entry.type === "addition" && entry.purpose === "income",
+    )
     .reduce((total, entry) => total + entry.amount, 0);
-  const tradeInvested = trades
-    .filter((trade) => trade.type === "buy" && isSameMonth(trade.date, now))
-    .reduce((total, trade) => total + trade.totalValue, 0);
-  const openingInvested = openingPositions
-    .filter((position) => isSameMonth(position.date, now))
-    .reduce(
-      (total, position) =>
-        total + position.quantity * position.averageCostPrice,
-      0,
-    );
-  const invested = tradeInvested + openingInvested;
+  const contributions = monthlyEntries
+    .filter(
+      (entry) =>
+        entry.type === "addition" && entry.purpose === "capitalContribution",
+    )
+    .reduce((total, entry) => total + entry.amount, 0);
+  const legacyAdded = monthlyEntries
+    .filter(
+      (entry) =>
+        entry.type === "addition" && entry.purpose === "legacyUncategorized",
+    )
+    .reduce((total, entry) => total + entry.amount, 0);
+  const invested = monthlyEntries
+    .filter(
+      (entry) =>
+        entry.type === "withdrawal" && entry.purpose === "purchaseFunding",
+    )
+    .reduce((total, entry) => total + entry.amount, 0);
 
   return {
-    added,
+    added: income + contributions + legacyAdded,
     available: calculateCashBalance(cashEntries),
+    contributions,
+    income,
+    investmentRate: income > 0 ? round((invested / income) * 100) : null,
     invested,
-    savingsRate: added > 0 ? round((invested / added) * 100) : null,
   };
 }
 

--- a/src/features/cash/CashScreen.tsx
+++ b/src/features/cash/CashScreen.tsx
@@ -19,7 +19,7 @@ import { FormTextField } from "@/src/components/forms";
 import { formatCompactINR, formatINR } from "@/src/domain/formatters";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
 import { colors, interaction, radii, spacing } from "@/src/theme";
-import type { CashEntryType } from "@/src/types";
+import type { CashEntryPurpose, CashEntryType } from "@/src/types";
 
 import { useCash } from "./useCash";
 
@@ -30,6 +30,15 @@ type CashScreenProps = {
 
 type FieldErrors = Partial<Record<"amount" | "date" | "label", string>>;
 type CashEntryMode = CashEntryType;
+type AdditionPurpose = Extract<
+  CashEntryPurpose,
+  "capitalContribution" | "income"
+>;
+
+const additionPurposes: { label: string; value: AdditionPurpose }[] = [
+  { label: "Contribution", value: "capitalContribution" },
+  { label: "Income", value: "income" },
+];
 
 function validateCashEntry({
   amount,
@@ -90,8 +99,10 @@ function getCashEntryModeCopy(mode: CashEntryMode) {
       };
 }
 
-function formatSavingsRate(savingsRate: number | null) {
-  return savingsRate === null ? "Not enough data" : `${savingsRate.toFixed(2)}%`;
+function formatInvestmentRate(investmentRate: number | null) {
+  return investmentRate === null
+    ? "Not enough data"
+    : `${investmentRate.toFixed(2)}%`;
 }
 
 export function CashScreen({
@@ -108,6 +119,8 @@ export function CashScreen({
     monthlyMovementSummary,
   } = useCash({ now, store });
   const [mode, setMode] = useState<CashEntryMode>("addition");
+  const [additionPurpose, setAdditionPurpose] =
+    useState<AdditionPurpose>("capitalContribution");
   const [amount, setAmount] = useState("");
   const [label, setLabel] = useState("");
   const [date, setDate] = useState("");
@@ -140,6 +153,7 @@ export function CashScreen({
       date: date.trim(),
       label: label.trim(),
       notes,
+      purpose: mode === "addition" ? additionPurpose : "withdrawal",
       type: mode,
     });
     resetForm();
@@ -171,15 +185,13 @@ export function CashScreen({
               value: formatCompactINR(monthlyMetrics.invested),
             },
             {
-              label: "Kept",
+              label: "Income",
               masked: maskWealthValues,
-              value: formatCompactINR(
-                Math.max(0, monthlyMetrics.added - monthlyMetrics.invested),
-              ),
+              value: formatCompactINR(monthlyMetrics.income),
             },
             {
-              label: "Savings",
-              value: formatSavingsRate(monthlyMetrics.savingsRate),
+              label: "Invested / income",
+              value: formatInvestmentRate(monthlyMetrics.investmentRate),
             },
           ]}
         />
@@ -249,6 +261,47 @@ export function CashScreen({
               </AppText>
             </View>
           </View>
+          {mode === "addition" ? (
+            <View style={styles.purposeGroup}>
+              <AppText color="secondary" variant="caption" weight="bold">
+                Deposit purpose
+              </AppText>
+              <View style={styles.segmentedControl}>
+                {additionPurposes.map((purpose) => (
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityState={{
+                      selected: additionPurpose === purpose.value,
+                    }}
+                    key={purpose.value}
+                    onPress={() => setAdditionPurpose(purpose.value)}
+                    style={({ pressed }) => [
+                      styles.segment,
+                      additionPurpose === purpose.value && styles.segmentActive,
+                      pressed && styles.pressed,
+                    ]}
+                    testID={`cash-purpose-${purpose.value}`}
+                  >
+                    <AppText
+                      color={
+                        additionPurpose === purpose.value
+                          ? "primary"
+                          : "secondary"
+                      }
+                      style={
+                        additionPurpose === purpose.value
+                          ? styles.segmentActiveText
+                          : undefined
+                      }
+                      weight="bold"
+                    >
+                      {purpose.label}
+                    </AppText>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+          ) : null}
           <View style={styles.formRow}>
             <View style={styles.formRowField}>
               <FormTextField
@@ -369,6 +422,9 @@ const styles = StyleSheet.create({
   },
   pressed: {
     opacity: interaction.pressedOpacity,
+  },
+  purposeGroup: {
+    gap: spacing.xs,
   },
   segment: {
     alignItems: "center",

--- a/src/features/cash/__tests__/CashScreen.test.tsx
+++ b/src/features/cash/__tests__/CashScreen.test.tsx
@@ -33,7 +33,7 @@ describe("CashScreen", () => {
     await waitFor(() => {
       expect(getAllByText("₹1,000.00").length).toBeGreaterThan(0);
       expect(getByText("Broker cash")).toBeTruthy();
-      expect(getByText("Increased deployable cash")).toBeTruthy();
+      expect(getByText("Capital added to deployable cash")).toBeTruthy();
       expect(getByText("+₹1,000.00")).toBeTruthy();
     });
 
@@ -46,7 +46,7 @@ describe("CashScreen", () => {
     await waitFor(() => {
       expect(getAllByText("₹750.00").length).toBeGreaterThan(0);
       expect(getByText("Emergency withdrawal")).toBeTruthy();
-      expect(getByText("Reduced deployable cash")).toBeTruthy();
+      expect(getByText("Withdrawn from deployable cash")).toBeTruthy();
       expect(getByText("-₹250.00")).toBeTruthy();
     });
   });
@@ -73,6 +73,28 @@ describe("CashScreen", () => {
     expect(queryByText("Deposit cash")).toBeNull();
   });
 
+  it("records deposit purpose explicitly", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const { getByLabelText, getByTestId } = render(<CashScreen store={store} />);
+
+    fireEvent.press(getByTestId("cash-purpose-income"));
+    fireEvent.changeText(getByLabelText("Amount"), "50000");
+    fireEvent.changeText(getByLabelText("Label"), "Salary");
+    fireEvent.changeText(getByLabelText("Date"), "2026-05-01");
+    fireEvent.press(getByTestId("save-cash-entry-button"));
+
+    await waitFor(() => {
+      expect(store.getState().cashEntries).toEqual([
+        expect.objectContaining({
+          amount: 50000,
+          label: "Salary",
+          purpose: "income",
+          type: "addition",
+        }),
+      ]);
+    });
+  });
+
   it("shows invested as derived evidence without exposing a manual Invest action", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     store.getState().addAsset({
@@ -88,9 +110,12 @@ describe("CashScreen", () => {
       date: "2026-05-01",
       id: "cash-salary",
       label: "Salary",
+      purpose: "income",
       type: "addition",
     });
-    store.getState().addTrade({
+    store.getState().recordFundedBuy({
+      cashLabel: "Reliance Industries purchase",
+      trade: {
       assetId: "asset-reliance",
       date: "2026-05-10",
       id: "trade-buy",
@@ -98,6 +123,7 @@ describe("CashScreen", () => {
       quantity: 200,
       totalValue: 20000,
       type: "buy",
+      },
     });
 
     const { getByText, queryByText } = render(
@@ -123,6 +149,7 @@ describe("CashScreen", () => {
       date: "2026-05-20",
       id: "cash-proceeds",
       label: "HDFC Bank redemption proceeds",
+      purpose: "saleProceeds",
       type: "addition",
     });
 
@@ -152,6 +179,7 @@ describe("CashScreen", () => {
       date: "2026-04-20",
       id: "cash-1",
       label: "Broker cash",
+      purpose: "capitalContribution",
       type: "addition",
     });
 

--- a/src/features/cash/__tests__/useCash.test.tsx
+++ b/src/features/cash/__tests__/useCash.test.tsx
@@ -12,6 +12,7 @@ describe("useCash", () => {
       date: "2026-04-20",
       id: "cash-add",
       label: "Broker cash",
+      purpose: "capitalContribution",
       type: "addition",
     });
     store.getState().addCashEntry({
@@ -19,6 +20,7 @@ describe("useCash", () => {
       date: "2026-04-22",
       id: "cash-withdraw",
       label: "Withdrawal",
+      purpose: "withdrawal",
       type: "withdrawal",
     });
 
@@ -40,12 +42,14 @@ describe("useCash", () => {
         amount: 1000,
         date: "2026-04-20",
         label: "Broker cash",
+        purpose: "capitalContribution",
         type: "addition",
       });
       result.current.addEntry({
         amount: 300,
         date: "2026-04-21",
         label: "Withdrawal",
+        purpose: "withdrawal",
         type: "withdrawal",
       });
     });
@@ -64,6 +68,7 @@ describe("useCash", () => {
         amount: 500,
         date: "2026-04-20",
         label: "Opening cash",
+        purpose: "capitalContribution",
         type: "addition",
       });
     });
@@ -93,6 +98,7 @@ describe("useCash", () => {
       date: "2026-05-01",
       id: "cash-salary",
       label: "Salary",
+      purpose: "income",
       type: "addition",
     });
     store.getState().addCashEntry({
@@ -100,6 +106,8 @@ describe("useCash", () => {
       date: "2026-05-10",
       id: "cash-transfer",
       label: "SIP transfer",
+      linkedTradeId: "trade-buy",
+      purpose: "purchaseFunding",
       type: "withdrawal",
     });
     store.getState().addTrade({
@@ -119,8 +127,10 @@ describe("useCash", () => {
     expect(result.current.monthlyMetrics).toEqual({
       added: 100000,
       available: 80000,
+      contributions: 0,
+      income: 100000,
+      investmentRate: 20,
       invested: 20000,
-      savingsRate: 20,
     });
   });
 
@@ -139,16 +149,20 @@ describe("useCash", () => {
       date: "2026-05-03",
       id: "cash-salary",
       label: "Salary added",
+      purpose: "income",
       type: "addition",
     });
-    store.getState().addTrade({
-      assetId: "asset-hdfc",
-      date: "2026-05-05",
-      id: "trade-buy",
-      pricePerUnit: 1500,
-      quantity: 10,
-      totalValue: 15000,
-      type: "buy",
+    store.getState().recordFundedBuy({
+      cashLabel: "HDFC Bank purchase",
+      trade: {
+        assetId: "asset-hdfc",
+        date: "2026-05-05",
+        id: "trade-buy",
+        pricePerUnit: 1500,
+        quantity: 10,
+        totalValue: 15000,
+        type: "buy",
+      },
     });
 
     const { result } = renderHook(() =>
@@ -158,7 +172,8 @@ describe("useCash", () => {
     expect(result.current.manualEntryModes).toEqual(["addition", "withdrawal"]);
     expect(result.current.monthlyMetrics).toMatchObject({
       added: 70000,
-      available: 70000,
+      available: 55000,
+      income: 70000,
       invested: 15000,
     });
     expect(result.current.monthlyMovementSummary).toBe(
@@ -166,7 +181,7 @@ describe("useCash", () => {
     );
   });
 
-  it("marks savings rate unavailable when current-month added cash is missing", () => {
+  it("marks the investment rate unavailable when typed income is missing", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     store.getState().addAsset({
       assetClass: "stock",
@@ -176,14 +191,25 @@ describe("useCash", () => {
       symbol: "RELIANCE",
       ticker: "RELIANCE.NS",
     });
-    store.getState().addTrade({
-      assetId: "asset-reliance",
-      date: "2026-05-10",
-      id: "trade-buy",
-      pricePerUnit: 100,
-      quantity: 200,
-      totalValue: 20000,
-      type: "buy",
+    store.getState().addCashEntry({
+      amount: 20000,
+      date: "2026-05-01",
+      id: "cash-contribution",
+      label: "Capital contribution",
+      purpose: "capitalContribution",
+      type: "addition",
+    });
+    store.getState().recordFundedBuy({
+      cashLabel: "Reliance Industries purchase",
+      trade: {
+        assetId: "asset-reliance",
+        date: "2026-05-10",
+        id: "trade-buy",
+        pricePerUnit: 100,
+        quantity: 200,
+        totalValue: 20000,
+        type: "buy",
+      },
     });
 
     const { result } = renderHook(() =>
@@ -191,9 +217,12 @@ describe("useCash", () => {
     );
 
     expect(result.current.monthlyMetrics).toMatchObject({
-      added: 0,
+      added: 20000,
+      available: 0,
+      contributions: 20000,
+      income: 0,
+      investmentRate: null,
       invested: 20000,
-      savingsRate: null,
     });
   });
 });

--- a/src/features/cash/useCash.ts
+++ b/src/features/cash/useCash.ts
@@ -8,7 +8,11 @@ import {
 } from "@/src/domain/calculations";
 import { formatCompactINR } from "@/src/domain/formatters";
 import { getPortfolioStore, type PortfolioStoreState } from "@/src/store";
-import type { CashEntry, CashEntryType } from "@/src/types";
+import type {
+  CashEntry,
+  CashEntryPurpose,
+  CashEntryType,
+} from "@/src/types";
 import { createId } from "@/src/utils";
 
 type UseCashInput = {
@@ -21,6 +25,7 @@ type AddCashEntryInput = {
   date: string;
   label: string;
   notes?: string;
+  purpose: CashEntryPurpose;
   type: CashEntryType;
 };
 

--- a/src/features/dashboard/__tests__/DashboardScreen.test.tsx
+++ b/src/features/dashboard/__tests__/DashboardScreen.test.tsx
@@ -147,6 +147,7 @@ describe("DashboardScreen", () => {
       date: "2026-04-22",
       id: "cash-1",
       label: "Broker cash",
+      purpose: "capitalContribution",
       type: "addition",
     });
     store.getState().addCashEntry({
@@ -154,6 +155,7 @@ describe("DashboardScreen", () => {
       date: "2026-05-05",
       id: "cash-2",
       label: "Withdrawal",
+      purpose: "withdrawal",
       type: "withdrawal",
     });
     store.getState().upsertQuote({
@@ -232,6 +234,7 @@ describe("DashboardScreen", () => {
       date: "2026-04-22",
       id: "cash-1",
       label: "Broker cash",
+      purpose: "capitalContribution",
       type: "addition",
     });
     store.getState().upsertQuote({

--- a/src/features/dashboard/__tests__/useDashboard.test.tsx
+++ b/src/features/dashboard/__tests__/useDashboard.test.tsx
@@ -58,6 +58,7 @@ describe("useDashboard", () => {
       date: "2026-04-22",
       id: "cash-1",
       label: "Broker cash",
+      purpose: "capitalContribution",
       type: "addition",
     });
     store.getState().upsertQuote({
@@ -193,6 +194,7 @@ describe("useDashboard", () => {
       date: "2026-04-22",
       id: "cash-1",
       label: "Broker cash",
+      purpose: "capitalContribution",
       type: "addition",
     });
 
@@ -234,6 +236,7 @@ describe("useDashboard", () => {
       date: "2026-05-01",
       id: "cash-addition",
       label: "Salary",
+      purpose: "income",
       type: "addition",
     });
     store.getState().addCashEntry({
@@ -241,6 +244,7 @@ describe("useDashboard", () => {
       date: "2026-05-10",
       id: "cash-withdrawal",
       label: "Transfer",
+      purpose: "withdrawal",
       type: "withdrawal",
     });
     store.getState().addOpeningPosition({

--- a/src/features/openingPositions/AddOpeningPositionForm.tsx
+++ b/src/features/openingPositions/AddOpeningPositionForm.tsx
@@ -616,6 +616,13 @@ export function AddOpeningPositionForm({
               </AppText>
             </View>
           </View>
+          <View style={styles.cashImpact}>
+            <AppText weight="bold">Cash impact</AppText>
+            <AppText color="secondary" variant="caption">
+              No cash movement. Opening positions are existing holdings funded
+              outside CogVest.
+            </AppText>
+          </View>
           </View>
         </PremiumCard>
       ) : null}
@@ -728,6 +735,12 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     flexWrap: "wrap",
     gap: spacing.sm,
+  },
+  cashImpact: {
+    backgroundColor: colors.surface.card,
+    borderRadius: radii.button,
+    gap: spacing.xs,
+    padding: spacing.sm,
   },
   convictionChip: {
     alignItems: "center",

--- a/src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
+++ b/src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
@@ -151,6 +151,12 @@ describe("AddOpeningPositionForm", () => {
     expect(getByText("₹36,250.00")).toBeTruthy();
     expect(getByText("₹41,956.25")).toBeTruthy();
     expect(getByText("+₹5,706.25")).toBeTruthy();
+    expect(getByText("Cash impact")).toBeTruthy();
+    expect(
+      getByText(
+        "No cash movement. Opening positions are existing holdings funded outside CogVest.",
+      ),
+    ).toBeTruthy();
     expect(getByTestId("save-holding-button")).toBeTruthy();
 
     fireEvent.press(getByText("Save Holding"));

--- a/src/features/progress/__tests__/ProgressScreen.test.tsx
+++ b/src/features/progress/__tests__/ProgressScreen.test.tsx
@@ -77,6 +77,7 @@ function seedHoldingAndCash(store: ReturnType<typeof createPortfolioStore>) {
     date: "2026-07-01T00:00:00.000Z",
     id: "cash-salary",
     label: "Salary added",
+    purpose: "income",
     type: "addition",
   };
 

--- a/src/features/progress/__tests__/useProgress.test.tsx
+++ b/src/features/progress/__tests__/useProgress.test.tsx
@@ -30,6 +30,7 @@ function seedHoldingAndCash(store: ReturnType<typeof createPortfolioStore>) {
     date: "2026-07-01T00:00:00.000Z",
     id: "cash-salary",
     label: "Salary added",
+    purpose: "income",
     type: "addition",
   };
 

--- a/src/features/sellRedeem/SellRedeemScreen.tsx
+++ b/src/features/sellRedeem/SellRedeemScreen.tsx
@@ -1,4 +1,4 @@
-import { Pressable, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import type { StoreApi } from "zustand/vanilla";
 
 import {
@@ -13,7 +13,6 @@ import {
   ScreenHeader,
   SectionHeader,
   assetClassLabel,
-  getPressedStateStyle,
 } from "@/src/components/common";
 import { FormTextField } from "@/src/components/forms";
 import { formatCompactINR, formatINR } from "@/src/domain/formatters";
@@ -194,64 +193,23 @@ export function SellRedeemScreen({
         </PremiumCard>
 
         <PremiumCard>
-          <Pressable
-            accessibilityRole="checkbox"
-            accessibilityState={{ checked: flow.linkCashEntry }}
-            onPress={() => flow.setLinkCashEntry(!flow.linkCashEntry)}
-            style={({ pressed }) => [
-              styles.cashToggle,
-              getPressedStateStyle({ pressed }),
-            ]}
-            testID="sell-redeem-link-cash-toggle"
-          >
-            <View
-              style={[
-                styles.checkbox,
-                flow.linkCashEntry && styles.checkboxActive,
-              ]}
-            >
-              {flow.linkCashEntry ? <View style={styles.checkboxDot} /> : null}
-            </View>
-            <View style={styles.assetCopy}>
-              <AppText weight="bold">Add proceeds to Cash Ledger</AppText>
-              <AppText color="secondary" variant="caption">
-                Keeps deployable cash aligned with this asset exit.
-              </AppText>
-            </View>
-          </Pressable>
-
-          {flow.linkCashEntry ? (
-            flow.preview ? (
-              <View style={styles.formRow}>
-                <View style={styles.formField}>
-                  <FormTextField
-                    error={flow.errors.cashAmount}
-                    keyboardType="decimal-pad"
-                    label="Cash amount"
-                    onChangeText={flow.setCashAmount}
-                    placeholder="8400"
-                    testID="sell-redeem-cash-amount-input"
-                    value={flow.cashAmount}
-                  />
-                </View>
-                <View style={styles.formField}>
-                  <FormTextField
-                    error={flow.errors.cashLabel}
-                    label="Cash label"
-                    onChangeText={flow.setCashLabel}
-                    placeholder="Redemption proceeds"
-                    testID="sell-redeem-cash-label-input"
-                    value={flow.cashLabel}
-                  />
-                </View>
-              </View>
-            ) : (
-              <AppText color="secondary" variant="caption">
-                Cash entry appears after the exit proceeds are valid.
-              </AppText>
-            )
+          <SectionHeader title="Cash proceeds" />
+          <AppText color="secondary" variant="caption">
+            Net proceeds are added to deployable cash automatically. Record a
+            withdrawal separately if the money leaves the portfolio.
+          </AppText>
+          {flow.preview ? (
+            <AppText testID="sell-redeem-cash-link-summary" weight="bold">
+              {formatINR(flow.preview.netProceeds)} will be added to Cash Ledger
+            </AppText>
           ) : null}
         </PremiumCard>
+
+        {flow.errors.save ? (
+          <AppText style={styles.errorText} variant="caption">
+            {flow.errors.save}
+          </AppText>
+        ) : null}
 
         {flow.successMessage ? (
           <AppText style={styles.successText} weight="bold">
@@ -307,32 +265,13 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     width: 48,
   },
-  cashToggle: {
-    alignItems: "center",
-    flexDirection: "row",
-    gap: spacing.md,
-  },
-  checkbox: {
-    alignItems: "center",
-    backgroundColor: colors.surface.elevated,
-    borderRadius: radii.pill,
-    height: 28,
-    justifyContent: "center",
-    width: 28,
-  },
-  checkboxActive: {
-    backgroundColor: colors.primary,
-  },
-  checkboxDot: {
-    backgroundColor: colors.text.inverse,
-    borderRadius: radii.pill,
-    height: 8,
-    width: 8,
-  },
   content: {
     gap: spacing.cardGap,
     paddingBottom: spacing.lg,
     paddingTop: spacing.md,
+  },
+  errorText: {
+    color: colors.loss,
   },
   formField: {
     flex: 1,

--- a/src/features/sellRedeem/__tests__/SellRedeemScreen.test.tsx
+++ b/src/features/sellRedeem/__tests__/SellRedeemScreen.test.tsx
@@ -54,8 +54,12 @@ describe("SellRedeemScreen", () => {
     expect(getByText("Available units")).toBeTruthy();
     expect(getByText("25")).toBeTruthy();
     expect(getByPlaceholderText("Max 25")).toBeTruthy();
-    expect(getByText("Add proceeds to Cash Ledger")).toBeTruthy();
-    expect(getByText("Cash entry appears after the exit proceeds are valid.")).toBeTruthy();
+    expect(getByText("Cash proceeds")).toBeTruthy();
+    expect(
+      getByText(
+        "Net proceeds are added to deployable cash automatically. Record a withdrawal separately if the money leaves the portfolio.",
+      ),
+    ).toBeTruthy();
     expect(queryByTestId("sell-redeem-cash-amount-input")).toBeNull();
   });
 
@@ -85,29 +89,28 @@ describe("SellRedeemScreen", () => {
     });
     expect(store.getState().cashEntries[0]).toMatchObject({
       amount: 8400,
-      label: "HDFC Bank redemption proceeds",
+      label: "HDFC Bank sale proceeds",
+      purpose: "saleProceeds",
       type: "addition",
     });
     expect(onSaved).toHaveBeenCalledTimes(1);
   });
 
-  it("lets the user disable linked cash proceeds", () => {
+  it("shows derived linked proceeds without editable cash fields", () => {
     const store = seedStore();
     const { getByLabelText, getByTestId, queryByTestId } = render(
       <SellRedeemScreen assetId={asset.id} store={store} />,
     );
 
-    fireEvent.press(getByTestId("sell-redeem-link-cash-toggle"));
-
-    expect(queryByTestId("sell-redeem-cash-amount-input")).toBeNull();
-
     fireEvent.changeText(getByLabelText("Quantity"), "1");
     fireEvent.changeText(getByLabelText("Sell price"), "1700");
     fireEvent.changeText(getByLabelText("Date"), "2026-05-20");
-    fireEvent.press(getByTestId("sell-redeem-save-button"));
 
-    expect(store.getState().trades).toHaveLength(1);
-    expect(store.getState().cashEntries).toEqual([]);
+    expect(getByTestId("sell-redeem-cash-link-summary")).toHaveTextContent(
+      "₹1,700.00 will be added to Cash Ledger",
+    );
+    expect(queryByTestId("sell-redeem-cash-amount-input")).toBeNull();
+    expect(queryByTestId("sell-redeem-link-cash-toggle")).toBeNull();
   });
 
   it("blocks overselling before save and keeps cash fields hidden", () => {

--- a/src/features/sellRedeem/__tests__/useSellRedeemHolding.test.tsx
+++ b/src/features/sellRedeem/__tests__/useSellRedeemHolding.test.tsx
@@ -58,9 +58,6 @@ describe("useSellRedeemHolding", () => {
       netProceeds: 8400,
       remainingUnits: 20,
     });
-    expect(result.current.linkCashEntry).toBe(true);
-    expect(result.current.cashAmount).toBe("8400");
-
     act(() => {
       result.current.save();
     });
@@ -79,29 +76,13 @@ describe("useSellRedeemHolding", () => {
       expect.objectContaining({
         amount: 8400,
         date: "2026-05-20",
-        label: "HDFC Bank redemption proceeds",
+        label: "HDFC Bank sale proceeds",
+        linkedTradeId: expect.any(String),
+        purpose: "saleProceeds",
         type: "addition",
       }),
     ]);
     expect(result.current.successMessage).toBe("Sell / redeem recorded.");
-  });
-
-  it("can save without linked cash proceeds", () => {
-    const store = seedStore();
-    const { result } = renderHook(() =>
-      useSellRedeemHolding({ assetId: hdfc.id, store }),
-    );
-
-    act(() => result.current.setQuantity("2"));
-    act(() => result.current.setSellPrice("1600"));
-    act(() => result.current.setDate("2026-05-21"));
-    act(() => result.current.setLinkCashEntry(false));
-    act(() => {
-      result.current.save();
-    });
-
-    expect(store.getState().trades).toHaveLength(1);
-    expect(store.getState().cashEntries).toEqual([]);
   });
 
   it("rejects selling more than available units", () => {

--- a/src/features/sellRedeem/useSellRedeemHolding.ts
+++ b/src/features/sellRedeem/useSellRedeemHolding.ts
@@ -18,7 +18,7 @@ type UseSellRedeemHoldingInput = {
 };
 
 type FieldErrors = Partial<
-  Record<"cashAmount" | "cashLabel" | "date" | "fees" | "quantity" | "sellPrice", string>
+  Record<"date" | "fees" | "quantity" | "save" | "sellPrice", string>
 >;
 
 type SaveResult =
@@ -28,23 +28,17 @@ type SaveResult =
 export type UseSellRedeemHoldingResult = {
   availableUnits: number;
   canSave: boolean;
-  cashAmount: string;
-  cashLabel: string;
   date: string;
   errors: FieldErrors;
   fees: string;
   holding: Holding | null;
-  linkCashEntry: boolean;
   notes: string;
   preview: SellRedeemPreview | null;
   quantity: string;
   save: () => SaveResult;
   sellPrice: string;
-  setCashAmount: (value: string) => void;
-  setCashLabel: (value: string) => void;
   setDate: (value: string) => void;
   setFees: (value: string) => void;
-  setLinkCashEntry: (value: boolean) => void;
   setNotes: (value: string) => void;
   setQuantity: (value: string) => void;
   setSellPrice: (value: string) => void;
@@ -72,10 +66,6 @@ function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
   return useSyncExternalStore(store.subscribe, store.getState, store.getState);
 }
 
-function defaultCashLabel(holding: Holding | null) {
-  return holding ? `${holding.asset.name} redemption proceeds` : "";
-}
-
 export function useSellRedeemHolding({
   assetId,
   store = getPortfolioStore(),
@@ -86,10 +76,6 @@ export function useSellRedeemHolding({
   const [fees, setFees] = useState("");
   const [date, setDate] = useState(todayInputValue());
   const [notes, setNotes] = useState("");
-  const [linkCashEntry, setLinkCashEntry] = useState(true);
-  const [cashAmount, setCashAmount] = useState("");
-  const [cashAmountWasEdited, setCashAmountWasEdited] = useState(false);
-  const [cashLabel, setCashLabel] = useState("");
   const [errors, setErrors] = useState<FieldErrors>({});
   const [successMessage, setSuccessMessage] = useState("");
 
@@ -151,29 +137,6 @@ export function useSellRedeemHolding({
     }
   }, [holding, sellPrice]);
 
-  useEffect(() => {
-    if (holding && cashLabel.trim().length === 0) {
-      setCashLabel(defaultCashLabel(holding));
-    }
-  }, [cashLabel, holding]);
-
-  useEffect(() => {
-    if (preview && !cashAmountWasEdited) {
-      setCashAmount(String(preview.netProceeds));
-    }
-  }, [cashAmountWasEdited, preview]);
-
-  useEffect(() => {
-    if (!preview && !cashAmountWasEdited) {
-      setCashAmount("");
-    }
-  }, [cashAmountWasEdited, preview]);
-
-  function updateCashAmount(value: string) {
-    setCashAmountWasEdited(true);
-    setCashAmount(value);
-  }
-
   function validate() {
     const nextErrors: FieldErrors = {};
 
@@ -219,20 +182,6 @@ export function useSellRedeemHolding({
       }
     }
 
-    if (linkCashEntry) {
-      const cashAmountValue = parseNumber(cashAmount);
-
-      if (!Number.isFinite(cashAmountValue)) {
-        nextErrors.cashAmount = "Cash amount must be a valid number.";
-      } else if (cashAmountValue < 0) {
-        nextErrors.cashAmount = "Cash amount must be zero or greater.";
-      }
-
-      if (cashLabel.trim().length === 0) {
-        nextErrors.cashLabel = "Cash label is required.";
-      }
-    }
-
     return nextErrors;
   }
 
@@ -267,27 +216,26 @@ export function useSellRedeemHolding({
       totalValue: preview.netProceeds,
       type: "sell",
     };
-    let cashEntry: CashEntry | undefined;
+    const result = store.getState().recordSaleWithProceeds({
+      cashLabel: `${holding.asset.name} sale proceeds`,
+      cashNotes:
+        trimmedNotes || `Linked to ${holding.asset.name} sell / redeem`,
+      trade,
+    });
 
-    store.getState().addTrade(trade);
-
-    if (linkCashEntry) {
-      cashEntry = {
-        amount: parseNumber(cashAmount),
-        date: date.trim(),
-        id: createId("cash"),
-        label: cashLabel.trim(),
-        notes: trimmedNotes || `Linked to ${holding.asset.name} sell / redeem`,
-        type: "addition",
+    if (!result.isValid) {
+      const saveErrors = {
+        save: "This sale could not be saved safely. Review it and try again.",
       };
-      store.getState().addCashEntry(cashEntry);
+      setErrors(saveErrors);
+      return { errors: saveErrors, isValid: false };
     }
 
     setErrors({});
     setSuccessMessage("Sell / redeem recorded.");
 
     return {
-      cashEntry,
+      cashEntry: result.cashEntry,
       isValid: true,
       trade,
     };
@@ -296,23 +244,17 @@ export function useSellRedeemHolding({
   return {
     availableUnits,
     canSave,
-    cashAmount,
-    cashLabel,
     date,
     errors: displayErrors,
     fees,
     holding,
-    linkCashEntry,
     notes,
     preview,
     quantity,
     save,
     sellPrice,
-    setCashAmount: updateCashAmount,
-    setCashLabel,
     setDate,
     setFees,
-    setLinkCashEntry,
     setNotes,
     setQuantity,
     setSellPrice,

--- a/src/features/trades/__tests__/AddTradeForm.test.tsx
+++ b/src/features/trades/__tests__/AddTradeForm.test.tsx
@@ -43,6 +43,14 @@ describe("AddTradeForm", () => {
 
   it("creates a manual asset and persists a reviewed buy trade", async () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addCashEntry({
+      amount: 1000,
+      date: "2026-04-20",
+      id: "cash-contribution",
+      label: "Broker contribution",
+      purpose: "capitalContribution",
+      type: "addition",
+    });
     const { getByLabelText, getByTestId, getByText } = render(
       <AddTradeForm store={store} />,
     );
@@ -105,6 +113,12 @@ describe("AddTradeForm", () => {
       quantity: 2,
       totalValue: 205,
       type: "buy",
+    });
+    expect(store.getState().cashEntries[1]).toMatchObject({
+      amount: 205,
+      linkedTradeId: store.getState().trades[0].id,
+      purpose: "purchaseFunding",
+      type: "withdrawal",
     });
     expect(store.getState().quoteCache[store.getState().assets[0].id]).toMatchObject({
       price: 100,

--- a/src/features/trades/__tests__/useAddTrade.test.tsx
+++ b/src/features/trades/__tests__/useAddTrade.test.tsx
@@ -8,6 +8,14 @@ import { useAddTrade } from "../useAddTrade";
 describe("useAddTrade", () => {
   it("reviews and confirms a manual buy trade through the feature controller", async () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addCashEntry({
+      amount: 1000,
+      date: "2026-04-20",
+      id: "cash-contribution",
+      label: "Broker contribution",
+      purpose: "capitalContribution",
+      type: "addition",
+    });
     const { result } = renderHook(() => useAddTrade({ store }));
 
     act(() => {
@@ -35,6 +43,14 @@ describe("useAddTrade", () => {
 
     expect(store.getState().assets).toHaveLength(1);
     expect(store.getState().trades).toHaveLength(1);
+    expect(store.getState().cashEntries).toEqual([
+      expect.objectContaining({ amount: 1000 }),
+      expect.objectContaining({
+        amount: 200,
+        purpose: "purchaseFunding",
+        type: "withdrawal",
+      }),
+    ]);
     expect(store.getState().quoteCache[store.getState().assets[0].id]).toMatchObject({
       price: 100,
       source: "manual",

--- a/src/features/trades/add-trade-form.tsx
+++ b/src/features/trades/add-trade-form.tsx
@@ -290,6 +290,12 @@ export function AddTradeForm({ store = getPortfolioStore() }: AddTradeFormProps)
         </AppText>
       ) : null}
 
+      {trade.errors.cash ? (
+        <AppText selectable style={styles.errorText} variant="caption">
+          {trade.errors.cash}
+        </AppText>
+      ) : null}
+
       <View style={styles.actions}>
         <AppButton
           title="Review Holding"

--- a/src/features/trades/useAddTrade.ts
+++ b/src/features/trades/useAddTrade.ts
@@ -204,11 +204,34 @@ export function useAddTrade({
       return;
     }
 
-    if (!selectedAsset) {
-      store.getState().addAsset(reviewAsset);
+    const commandResult =
+      reviewTrade.type === "buy"
+        ? store.getState().recordFundedBuy({
+            asset: selectedAsset ? undefined : reviewAsset,
+            cashLabel: `${reviewAsset.name} purchase`,
+            cashNotes: reviewTrade.notes,
+            trade: reviewTrade,
+          })
+        : store.getState().recordSaleWithProceeds({
+            cashLabel: `${reviewAsset.name} sale proceeds`,
+            cashNotes: reviewTrade.notes,
+            trade: reviewTrade,
+          });
+
+    if (!commandResult.isValid) {
+      setErrors({
+        cash:
+          commandResult.reason === "insufficientCash"
+            ? `Not enough deployable cash. Available ₹${(
+                commandResult.availableCash ?? 0
+              ).toFixed(2)}; required ₹${(
+                commandResult.requiredCash ?? reviewTrade.totalValue
+              ).toFixed(2)}.`
+            : "This trade could not be saved safely. Review it and try again.",
+      });
+      return;
     }
 
-    store.getState().addTrade(reviewTrade);
     store.getState().upsertQuote({
       asOf: new Date().toISOString(),
       assetId: reviewAsset.id,
@@ -217,6 +240,7 @@ export function useAddTrade({
       source: "manual",
     });
     await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    setErrors({});
     setSuccessMessage("Holding saved.");
     setReviewTrade(undefined);
   }

--- a/src/store/__tests__/portfolioStore.test.ts
+++ b/src/store/__tests__/portfolioStore.test.ts
@@ -38,6 +38,7 @@ const cashEntry: CashEntry = {
   date: "2026-04-26T00:00:00.000Z",
   id: "cash-1",
   label: "Broker cash",
+  purpose: "capitalContribution",
   type: "addition",
 };
 
@@ -129,6 +130,160 @@ describe("portfolio store", () => {
     expect(store.getState().monthlySnapshots).toEqual([]);
   });
 
+  it("records a funded buy and linked cash movement in one transition", () => {
+    const storage = createMemoryJsonStorage();
+    const store = createPortfolioStore({ storage });
+    store.getState().addAsset(asset);
+    store.getState().addCashEntry({ ...cashEntry, amount: 100000 });
+    const fundedBuy = {
+      ...trade,
+      pricePerUnit: 100,
+      quantity: 800,
+      totalValue: 80000,
+    };
+
+    const result = store.getState().recordFundedBuy({
+      cashLabel: "Reliance Industries purchase",
+      trade: fundedBuy,
+    });
+
+    expect(result).toMatchObject({ isValid: true, trade: fundedBuy });
+    expect(store.getState().trades).toEqual([fundedBuy]);
+    expect(store.getState().cashEntries).toEqual([
+      expect.objectContaining({ amount: 100000 }),
+      expect.objectContaining({
+        amount: 80000,
+        linkedTradeId: fundedBuy.id,
+        purpose: "purchaseFunding",
+        type: "withdrawal",
+      }),
+    ]);
+    expect(storage.getItem(portfolioStorageKey)).toMatchObject({
+      cashEntries: store.getState().cashEntries,
+      trades: [fundedBuy],
+    });
+  });
+
+  it("rejects a funded buy above available cash before mutation", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset(asset);
+    store.getState().addCashEntry({ ...cashEntry, amount: 5000 });
+
+    const result = store.getState().recordFundedBuy({
+      cashLabel: "Reliance Industries purchase",
+      trade: { ...trade, totalValue: 5800 },
+    });
+
+    expect(result).toEqual({
+      availableCash: 5000,
+      isValid: false,
+      reason: "insufficientCash",
+      requiredCash: 5800,
+    });
+    expect(store.getState().trades).toEqual([]);
+    expect(store.getState().cashEntries).toEqual([
+      expect.objectContaining({ amount: 5000 }),
+    ]);
+  });
+
+  it("records sale proceeds as a linked cash addition", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const sale = {
+      ...trade,
+      id: "trade-sale",
+      pricePerUnit: 3100,
+      totalValue: 6200,
+      type: "sell" as const,
+    };
+    store.getState().addAsset(asset);
+    store.getState().addOpeningPosition(openingPosition);
+
+    const result = store.getState().recordSaleWithProceeds({
+      cashLabel: "Reliance Industries sale proceeds",
+      trade: sale,
+    });
+
+    expect(result).toMatchObject({ isValid: true, trade: sale });
+    expect(store.getState().cashEntries).toEqual([
+      expect.objectContaining({
+        amount: 6200,
+        linkedTradeId: sale.id,
+        purpose: "saleProceeds",
+        type: "addition",
+      }),
+    ]);
+  });
+
+  it("rejects a sale above available units before mutation", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset(asset);
+    store.getState().addOpeningPosition(openingPosition);
+
+    const result = store.getState().recordSaleWithProceeds({
+      cashLabel: "Reliance Industries sale proceeds",
+      trade: {
+        ...trade,
+        id: "trade-sale",
+        pricePerUnit: 100,
+        quantity: 30,
+        totalValue: 3000,
+        type: "sell",
+      },
+    });
+
+    expect(result).toEqual({
+      availableUnits: 25,
+      isValid: false,
+      reason: "insufficientUnits",
+      requiredUnits: 30,
+    });
+    expect(store.getState().trades).toEqual([]);
+    expect(store.getState().cashEntries).toEqual([]);
+  });
+
+  it("rejects a linked trade whose total does not match its units and fees", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset(asset);
+    store.getState().addCashEntry({ ...cashEntry, amount: 10000 });
+
+    const result = store.getState().recordFundedBuy({
+      cashLabel: "Reliance Industries purchase",
+      trade: { ...trade, totalValue: 5000 },
+    });
+
+    expect(result).toEqual({ isValid: false, reason: "invalidTrade" });
+    expect(store.getState().trades).toEqual([]);
+    expect(store.getState().cashEntries).toEqual([
+      expect.objectContaining({ amount: 10000 }),
+    ]);
+  });
+
+  it("keeps memory unchanged when an atomic accounting write fails", () => {
+    const storage = createMemoryJsonStorage();
+    const store = createPortfolioStore({ storage });
+    store.getState().addAsset(asset);
+    store.getState().addCashEntry({ ...cashEntry, amount: 10000 });
+    const originalSetItem = storage.setItem;
+    storage.setItem = (key, value) => {
+      if (key === portfolioStorageKey) {
+        throw new Error("simulated persistence failure");
+      }
+
+      originalSetItem(key, value);
+    };
+
+    expect(() =>
+      store.getState().recordFundedBuy({
+        cashLabel: "Reliance Industries purchase",
+        trade,
+      }),
+    ).toThrow("simulated persistence failure");
+    expect(store.getState().trades).toEqual([]);
+    expect(store.getState().cashEntries).toEqual([
+      expect.objectContaining({ amount: 10000 }),
+    ]);
+  });
+
   it("persists only raw portfolio data under the portfolio key", () => {
     const storage = createMemoryJsonStorage();
     const store = createPortfolioStore({ storage });
@@ -147,7 +302,7 @@ describe("portfolio store", () => {
       monthlySnapshots: [monthlySnapshot],
       openingPositions: [openingPosition],
       preferences: createDefaultPreferences(),
-      schemaVersion: 4,
+      schemaVersion: 5,
       trades: [trade],
     });
     expect(persisted).not.toHaveProperty("holdings");
@@ -177,7 +332,7 @@ describe("portfolio store", () => {
       monthlySnapshots: [monthlySnapshot],
       openingPositions: [openingPosition],
       preferences: { ...createDefaultPreferences(), maskWealthValues: true },
-      schemaVersion: 4,
+      schemaVersion: 5,
       trades: [trade],
     });
     storage.setItem(quoteCacheStorageKey, {
@@ -203,7 +358,7 @@ describe("portfolio store", () => {
       monthlySnapshots: [monthlySnapshot],
       openingPositions: [openingPosition],
       preferences: createDefaultPreferences(),
-      schemaVersion: 4,
+      schemaVersion: 5,
       trades: [trade],
     });
 
@@ -290,7 +445,7 @@ describe("portfolio store", () => {
     expect(store.getState().openingPositions).toEqual([]);
     expect(store.getState().monthlySnapshots).toEqual([]);
     expect(store.getState().trades).toEqual([trade]);
-    expect(store.getState().schemaVersion).toBe(4);
+    expect(store.getState().schemaVersion).toBe(5);
     expect(store.getState().assets[0]).toMatchObject({
       instrumentType: "stock",
       quoteSourceId: "RELIANCE.NS",
@@ -325,7 +480,7 @@ describe("portfolio store", () => {
       quoteSourceId: "NIFTYBEES.NS",
       sectorType: "diversified",
     });
-    expect(store.getState().schemaVersion).toBe(4);
+    expect(store.getState().schemaVersion).toBe(5);
   });
 
   it("migrates V3 snapshots by defaulting monthly snapshots", () => {
@@ -342,6 +497,37 @@ describe("portfolio store", () => {
     const store = createPortfolioStore({ storage });
 
     expect(store.getState().monthlySnapshots).toEqual([]);
-    expect(store.getState().schemaVersion).toBe(4);
+    expect(store.getState().schemaVersion).toBe(5);
+  });
+
+  it("migrates V4 additions without inventing income semantics", () => {
+    const storage = createMemoryJsonStorage();
+    storage.setItem(portfolioStorageKey, {
+      assets: [],
+      cashEntries: [
+        {
+          amount: 5000,
+          date: "2026-05-01",
+          id: "legacy-addition",
+          label: "Old deposit",
+          type: "addition",
+        },
+      ],
+      monthlySnapshots: [],
+      openingPositions: [],
+      preferences: createDefaultPreferences(),
+      schemaVersion: 4,
+      trades: [],
+    });
+
+    const store = createPortfolioStore({ storage });
+
+    expect(store.getState().cashEntries).toEqual([
+      expect.objectContaining({
+        id: "legacy-addition",
+        purpose: "legacyUncategorized",
+      }),
+    ]);
+    expect(store.getState().schemaVersion).toBe(5);
   });
 });

--- a/src/store/__tests__/selectors.test.ts
+++ b/src/store/__tests__/selectors.test.ts
@@ -71,6 +71,7 @@ const cashEntries: CashEntry[] = [
     date: "2026-04-26T00:00:00.000Z",
     id: "cash-1",
     label: "Deposit",
+    purpose: "capitalContribution",
     type: "addition",
   },
   {
@@ -78,6 +79,7 @@ const cashEntries: CashEntry[] = [
     date: "2026-04-26T00:00:00.000Z",
     id: "cash-2",
     label: "Withdrawal",
+    purpose: "withdrawal",
     type: "withdrawal",
   },
 ];

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -6,6 +6,7 @@ import { createMmkvJsonStorage } from "@/src/services/storage";
 import type {
   Asset,
   CashEntry,
+  CashEntryPurpose,
   HistoricalQuote,
   HistoricalQuoteCache,
   MonthlySnapshot,
@@ -29,7 +30,7 @@ export const portfolioStorageKey = "cogvest:v1:portfolio";
 export const quoteCacheStorageKey = "cogvest:v1:quote-cache";
 export const historicalQuoteCacheStorageKey =
   "cogvest:v1:historical-quote-cache";
-export const portfolioSchemaVersion = 4;
+export const portfolioSchemaVersion = 5;
 
 export { historicalQuoteCacheKey };
 
@@ -57,6 +58,12 @@ export type PortfolioStoreState = RawPortfolioSnapshot & {
   removeMonthlySnapshot: (monthlySnapshotId: string) => void;
   removeOpeningPosition: (openingPositionId: string) => void;
   removeTrade: (tradeId: string) => void;
+  recordFundedBuy: (
+    input: LinkedTradeCommandInput,
+  ) => LinkedTradeCommandResult;
+  recordSaleWithProceeds: (
+    input: LinkedTradeCommandInput,
+  ) => LinkedTradeCommandResult;
   updateAsset: (asset: Asset) => void;
   updateCashEntry: (cashEntry: CashEntry) => void;
   updateMonthlySnapshot: (monthlySnapshot: MonthlySnapshot) => void;
@@ -66,6 +73,29 @@ export type PortfolioStoreState = RawPortfolioSnapshot & {
   upsertHistoricalQuote: (historicalQuote: HistoricalQuote) => void;
   upsertQuote: (quote: Quote) => void;
 };
+
+export type LinkedTradeCommandInput = {
+  asset?: Asset;
+  cashLabel: string;
+  cashNotes?: string;
+  trade: Trade;
+};
+
+export type LinkedTradeCommandResult =
+  | { cashEntry: CashEntry; isValid: true; trade: Trade }
+  | {
+      availableCash?: number;
+      availableUnits?: number;
+      isValid: false;
+      reason:
+        | "duplicateTrade"
+        | "insufficientCash"
+        | "insufficientUnits"
+        | "invalidTrade"
+        | "invalidTradeType";
+      requiredCash?: number;
+      requiredUnits?: number;
+    };
 
 type CreatePortfolioStoreOptions = {
   storage?: JsonStorage;
@@ -91,11 +121,25 @@ export function createEmptyPortfolioSnapshot(): RawPortfolioSnapshot {
   };
 }
 
+type StoredCashEntry = Omit<CashEntry, "purpose"> & {
+  purpose?: CashEntryPurpose;
+};
+
 type StoredPortfolioSnapshot = Partial<
-  Omit<RawPortfolioSnapshot, "schemaVersion">
+  Omit<RawPortfolioSnapshot, "cashEntries" | "schemaVersion">
 > & {
+  cashEntries?: StoredCashEntry[];
   schemaVersion?: number;
 };
+
+function normalizeCashEntry(entry: StoredCashEntry): CashEntry {
+  return {
+    ...entry,
+    purpose:
+      entry.purpose ??
+      (entry.type === "withdrawal" ? "withdrawal" : "legacyUncategorized"),
+  };
+}
 
 function readPortfolioSnapshot(storage: JsonStorage): RawPortfolioSnapshot {
   const stored = storage.getItem<StoredPortfolioSnapshot & JsonValue>(
@@ -104,14 +148,14 @@ function readPortfolioSnapshot(storage: JsonStorage): RawPortfolioSnapshot {
 
   if (
     !stored ||
-    ![1, 2, 3, portfolioSchemaVersion].includes(stored.schemaVersion ?? 0)
+    ![1, 2, 3, 4, portfolioSchemaVersion].includes(stored.schemaVersion ?? 0)
   ) {
     return createEmptyPortfolioSnapshot();
   }
 
   return {
     assets: (stored.assets ?? []).map(normalizeAssetMetadata),
-    cashEntries: stored.cashEntries ?? [],
+    cashEntries: (stored.cashEntries ?? []).map(normalizeCashEntry),
     monthlySnapshots: stored.monthlySnapshots ?? [],
     openingPositions: stored.openingPositions ?? [],
     preferences: {
@@ -154,6 +198,85 @@ function persistPortfolio(
   state: PortfolioStoreState,
 ) {
   storage.setItem(portfolioStorageKey, selectRawSnapshot(state) as JsonValue);
+}
+
+function persistPortfolioTransition(
+  storage: JsonStorage,
+  state: PortfolioStoreState,
+  transition: Partial<RawPortfolioSnapshot>,
+) {
+  storage.setItem(portfolioStorageKey, {
+    ...selectRawSnapshot(state),
+    ...transition,
+    schemaVersion: portfolioSchemaVersion,
+  } as JsonValue);
+}
+
+function cashBalance(cashEntries: CashEntry[]) {
+  return cashEntries.reduce(
+    (balance, entry) =>
+      entry.type === "withdrawal"
+        ? balance - entry.amount
+        : balance + entry.amount,
+    0,
+  );
+}
+
+function linkedCashEntry(
+  input: LinkedTradeCommandInput,
+  purpose: "purchaseFunding" | "saleProceeds",
+): CashEntry {
+  return {
+    amount: input.trade.totalValue,
+    date: input.trade.date,
+    id: `cash-${input.trade.id}`,
+    label: input.cashLabel,
+    linkedTradeId: input.trade.id,
+    notes: input.cashNotes,
+    purpose,
+    type: purpose === "purchaseFunding" ? "withdrawal" : "addition",
+  };
+}
+
+function validateLinkedTrade(
+  state: PortfolioStoreState,
+  input: LinkedTradeCommandInput,
+  trade: Trade,
+  expectedType: Trade["type"],
+): LinkedTradeCommandResult | null {
+  if (trade.type !== expectedType) {
+    return { isValid: false, reason: "invalidTradeType" };
+  }
+
+  const fees = trade.fees ?? 0;
+  const grossValue = trade.quantity * trade.pricePerUnit;
+  const expectedTotal =
+    trade.type === "buy" ? grossValue + fees : grossValue - fees;
+  const hasMatchingAsset =
+    state.assets.some((asset) => asset.id === trade.assetId) ||
+    input.asset?.id === trade.assetId;
+
+  if (
+    !hasMatchingAsset ||
+    input.cashLabel.trim().length === 0 ||
+    !Number.isFinite(trade.quantity) ||
+    trade.quantity <= 0 ||
+    !Number.isFinite(trade.pricePerUnit) ||
+    trade.pricePerUnit <= 0 ||
+    !Number.isFinite(fees) ||
+    fees < 0 ||
+    !Number.isFinite(trade.totalValue) ||
+    trade.totalValue <= 0 ||
+    Math.abs(trade.totalValue - expectedTotal) > 0.01
+  ) {
+    return { isValid: false, reason: "invalidTrade" };
+  }
+
+  if (state.trades.some((currentTrade) => currentTrade.id === trade.id)) {
+    return { isValid: false, reason: "duplicateTrade" };
+  }
+
+  return null;
 }
 
 function persistQuoteCache(storage: JsonStorage, quoteCache: QuoteCache) {
@@ -246,6 +369,87 @@ export function createPortfolioStore({
         trades: state.trades.filter((trade) => trade.id !== tradeId),
       }));
       persistPortfolio(storage, get());
+    },
+    recordFundedBuy: (input) => {
+      const state = get();
+      const invalidResult = validateLinkedTrade(
+        state,
+        input,
+        input.trade,
+        "buy",
+      );
+
+      if (invalidResult) {
+        return invalidResult;
+      }
+
+      const availableCash = cashBalance(state.cashEntries);
+
+      if (input.trade.totalValue > availableCash) {
+        return {
+          availableCash,
+          isValid: false,
+          reason: "insufficientCash",
+          requiredCash: input.trade.totalValue,
+        };
+      }
+
+      const cashEntry = linkedCashEntry(input, "purchaseFunding");
+      const assets =
+        input.asset &&
+        !state.assets.some((currentAsset) => currentAsset.id === input.asset?.id)
+          ? [...state.assets, normalizeAssetMetadata(input.asset)]
+          : state.assets;
+      const cashEntries = [...state.cashEntries, cashEntry];
+      const trades = [...state.trades, input.trade];
+
+      persistPortfolioTransition(storage, state, { assets, cashEntries, trades });
+      set({ assets, cashEntries, trades });
+
+      return { cashEntry, isValid: true, trade: input.trade };
+    },
+    recordSaleWithProceeds: (input) => {
+      const state = get();
+      const invalidResult = validateLinkedTrade(
+        state,
+        input,
+        input.trade,
+        "sell",
+      );
+
+      if (invalidResult) {
+        return invalidResult;
+      }
+
+      const availableUnits =
+        state.openingPositions
+          .filter((position) => position.assetId === input.trade.assetId)
+          .reduce((total, position) => total + position.quantity, 0) +
+        state.trades
+          .filter((trade) => trade.assetId === input.trade.assetId)
+          .reduce(
+            (total, trade) =>
+              total + (trade.type === "buy" ? trade.quantity : -trade.quantity),
+            0,
+          );
+
+      if (input.trade.quantity > availableUnits) {
+        return {
+          availableUnits,
+          isValid: false,
+          reason: "insufficientUnits",
+          requiredUnits: input.trade.quantity,
+        };
+      }
+
+      const cashEntry = linkedCashEntry(input, "saleProceeds");
+      const cashEntries = [...state.cashEntries, cashEntry];
+      const trades = [...state.trades, input.trade];
+
+      persistPortfolioTransition(storage, state, { cashEntries, trades });
+      set({ cashEntries, trades });
+
+      return { cashEntry, isValid: true, trade: input.trade };
     },
     schemaVersion: portfolioSchemaVersion,
     updateAsset: (asset) => {

--- a/src/testing/__tests__/visualQaSeed.test.ts
+++ b/src/testing/__tests__/visualQaSeed.test.ts
@@ -53,6 +53,7 @@ describe("seedVisualQaPortfolio", () => {
       date: "2026-01-01T00:00:00.000Z",
       id: "old-cash",
       label: "Old cash",
+      purpose: "capitalContribution",
       type: "addition",
     });
 

--- a/src/testing/visualQaSeed.ts
+++ b/src/testing/visualQaSeed.ts
@@ -121,6 +121,7 @@ export const visualQaCashEntries: CashEntry[] = [
     date: "2026-05-03T00:00:00.000Z",
     id: "visual-qa-cash-salary",
     label: "Salary added",
+    purpose: "income",
     type: "addition",
   },
   {
@@ -128,6 +129,7 @@ export const visualQaCashEntries: CashEntry[] = [
     date: "2026-05-08T00:00:00.000Z",
     id: "visual-qa-cash-sip-index",
     label: "SIP transfer - Index Fund",
+    purpose: "purchaseFunding",
     type: "withdrawal",
   },
   {
@@ -135,6 +137,7 @@ export const visualQaCashEntries: CashEntry[] = [
     date: "2026-05-16T00:00:00.000Z",
     id: "visual-qa-cash-emergency",
     label: "Emergency fund top-up",
+    purpose: "capitalContribution",
     type: "addition",
   },
   {
@@ -142,6 +145,7 @@ export const visualQaCashEntries: CashEntry[] = [
     date: "2026-05-22T00:00:00.000Z",
     id: "visual-qa-cash-sip-large-cap",
     label: "SIP transfer - Large Cap",
+    purpose: "purchaseFunding",
     type: "withdrawal",
   },
 ];

--- a/src/types/cash.ts
+++ b/src/types/cash.ts
@@ -1,11 +1,21 @@
 export type CashEntryType = "addition" | "withdrawal";
 
+export type CashEntryPurpose =
+  | "capitalContribution"
+  | "income"
+  | "legacyUncategorized"
+  | "purchaseFunding"
+  | "saleProceeds"
+  | "withdrawal";
+
 export type CashEntry = {
   amount: number;
   date: string;
   id: string;
   institution?: string;
   label: string;
+  linkedTradeId?: string;
   notes?: string;
+  purpose: CashEntryPurpose;
   type: CashEntryType;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,7 @@ export type {
   InstrumentType,
   SectorType,
 } from "./asset";
-export type { CashEntry, CashEntryType } from "./cash";
+export type { CashEntry, CashEntryPurpose, CashEntryType } from "./cash";
 export type { Holding } from "./holding";
 export type {
   MonthlySnapshot,


### PR DESCRIPTION
## Summary

- add typed cash-entry purposes with schema v5 migration for legacy entries
- make funded buys and sale proceeds atomic, linked store commands with cash, unit, and total validation
- update Cash, Add Holding, and Sell/Redeem flows to expose the accounting contract clearly
- calculate investment rate from typed income only
- add accounting invariants and a funded-buy Android E2E flow

## Verification

- `npm run test:verify` (262 tests; Expo Doctor 17/17)
- local `assembleRelease` APK build
- fresh install on `emulator-5554` at 2026-07-18 02:21:33
- `npm run android:smoke -- --strict`
- `npm run maestro:test -- e2e/funded-buy-cash.yaml`
- full Maestro suite passed smoke, navigation, Add Holding, lookup, and most of Holdings, then stopped on the pre-existing stale `Qty 2` assertion tracked in #162

No EAS build was triggered.

Closes #161