### PR TITLE
test: align Holdings E2E with expanded details

### DIFF
--- a/e2e/holdings.yaml
+++ b/e2e/holdings.yaml
@@ -55,4 +55,12 @@ appId: com.abdulshaikh.cogvest
 - assertVisible:
     id: "holdings-screen"
 - assertVisible: "Reliance Industries"
-- assertVisible: "Qty 2"
+- assertVisible: "Invested ₹180"
+- tapOn:
+    id: "holding-row-.*"
+- assertVisible:
+    id: "holding-expanded-.*"
+- assertVisible:
+    id: "holding-quantity-.*"
+- assertVisible: "Quantity"
+- assertVisible: "2"

--- a/src/features/holdings/HoldingsScreen.tsx
+++ b/src/features/holdings/HoldingsScreen.tsx
@@ -457,7 +457,11 @@ function HoldingRow({
           testID={`holding-expanded-${holding.asset.id}`}
         >
           <View style={styles.detailGrid}>
-            <Detail label="Quantity" value={formatQuantity(holding.totalUnits)} />
+            <Detail
+              label="Quantity"
+              testID={`holding-quantity-${holding.asset.id}`}
+              value={formatQuantity(holding.totalUnits)}
+            />
             <Detail
               label="Avg cost"
               masked={masked}
@@ -528,16 +532,18 @@ function HoldingRow({
 function Detail({
   label,
   masked,
+  testID,
   tone,
   value,
 }: {
   label: string;
   masked?: boolean;
+  testID?: string;
   tone?: "negative" | "positive";
   value: string;
 }) {
   return (
-    <View style={styles.detail}>
+    <View style={styles.detail} testID={testID}>
       <AppText color="secondary" variant="caption">
         {label}
       </AppText>

--- a/src/features/holdings/__tests__/HoldingsScreen.test.tsx
+++ b/src/features/holdings/__tests__/HoldingsScreen.test.tsx
@@ -160,6 +160,7 @@ describe("HoldingsScreen", () => {
     fireEvent.press(getByTestId(`holding-row-${asset.id}`));
 
     expect(getByTestId(`holding-expanded-${asset.id}`)).toBeTruthy();
+    expect(getByTestId(`holding-quantity-${asset.id}`)).toBeTruthy();
     expect(getByText("Quantity")).toBeTruthy();
     expect(getByText("Avg cost")).toBeTruthy();
     expect(getByText("Current price")).toBeTruthy();


### PR DESCRIPTION
## Summary

- expand the created Holdings card before checking quantity details
- assert invested value and quantity using the current compact/expanded contract
- expose a non-visual quantity detail test ID and protect it with a component test

## Verification

- `npm run test:verify`
- `npm run test:v1:pc`
- fresh local release APK built with `android/gradlew.bat -p android assembleRelease`
- clean-installed on `emulator-5554`
- `npm run maestro:test -- e2e/holdings.yaml`
- complete `npm run maestro:test` advanced past Holdings, Cash, and funded-buy flows; later stopped on the separate stale value-masking assertion tracked by #164

Closes #162