### PR TITLE
test: verify persisted value masking semantics

### DIFF
--- a/e2e/value-masking.yaml
+++ b/e2e/value-masking.yaml
@@ -4,11 +4,70 @@ appId: com.abdulshaikh.cogvest
     clearState: true
 - assertVisible:
     id: "dashboard-screen"
-- stopApp
+- openLink: "cogvest:///add-holding"
+- assertVisible:
+    id: "add-holding-phase-asset"
+- tapOn:
+    id: "asset-input"
+- inputText: "Masking Test Asset"
+- hideKeyboard
+- tapOn:
+    id: "symbol-input"
+- inputText: "MASK"
+- tapOn:
+    id: "ticker-input"
+- inputText: "MASK.NS"
+- hideKeyboard
+- tapOn:
+    id: "continue-class-button"
+- tapOn:
+    id: "continue-position-button"
+- tapOn:
+    id: "quantity-input"
+- inputText: "2"
+- tapOn:
+    id: "average-cost-input"
+- inputText: "90"
+- tapOn:
+    id: "price-input"
+- inputText: "100"
+- hideKeyboard
+- tapOn:
+    id: "review-holding-button"
+- scrollUntilVisible:
+    element:
+      id: "save-holding-button"
+    direction: DOWN
+- tapOn:
+    id: "save-holding-button"
+- assertVisible: "Opening position saved."
 - openLink: "cogvest:///settings"
 - assertVisible:
     id: "settings-screen"
-- assertVisible: "Value masking"
 - tapOn:
     id: "value-mask-toggle"
-- assertVisible: "Values masked"
+- assertVisible:
+    id: "value-mask-toggle"
+    checked: true
+- openLink: "cogvest:///holdings"
+- assertVisible: "Masking Test Asset"
+- assertVisible: "₹\\*\\*\\*\\* \\*\\*,\\*\\*\\*\\.\\*\\*"
+- assertVisible: "+11.11%"
+- tapOn:
+    id: "holding-row-.*"
+- assertVisible:
+    id: "holding-quantity-.*"
+- assertVisible: "Quantity"
+- assertVisible: "2"
+- stopApp
+- launchApp
+- assertVisible:
+    id: "dashboard-screen"
+- openLink: "cogvest:///settings"
+- assertVisible:
+    id: "value-mask-toggle"
+    checked: true
+- openLink: "cogvest:///holdings"
+- assertVisible: "Masking Test Asset"
+- assertVisible: "₹\\*\\*\\*\\* \\*\\*,\\*\\*\\*\\.\\*\\*"
+- assertVisible: "+11.11%"


### PR DESCRIPTION
## Summary

- replace stale `Values masked` copy verification with the Android switch's semantic checked state
- create a known holding and verify wealth values are actually masked
- prove percentages and quantities remain visible
- verify the masking preference survives an app restart

## Verification

- `npm run maestro:test -- e2e/value-masking.yaml`
- complete `npm run maestro:test` (all nine default flows passed)
- `npm run test:v1:pc`
- 44 Jest suites / 262 tests passed
- Expo Doctor 17/17 checks passed
- verified on `emulator-5554` with the freshly installed local release APK; production app source did not change in this PR

Closes #164