### PR TITLE
fix: enforce INR-only V1 valuation

### DIFF
--- a/app/add-holding.tsx
+++ b/app/add-holding.tsx
@@ -1,4 +1,4 @@
-import { useLocalSearchParams } from "expo-router";
+import { router, useLocalSearchParams } from "expo-router";
 
 import { AddOpeningPositionForm } from "@/src/features/openingPositions";
 import {
@@ -20,6 +20,7 @@ export default function AddHoldingScreen() {
       initialVisualQaState={
         visualQaState === "review" ? "review" : undefined
       }
+      onComplete={() => router.replace("/(tabs)/holdings")}
       resolveQuote={
         visualQaState === "lookup"
           ? async ({ asset }) => {

--- a/docs/cogvest-master-spec.md
+++ b/docs/cogvest-master-spec.md
@@ -109,6 +109,25 @@ All domain calculations must be pure functions under `src/domain/`.
 - Persisted pre-contract additions migrate to legacy uncategorized entries so
   historical cash remains visible without inventing income semantics.
 
+### V1 Currency And Quote Contract
+
+- INR is the only reporting, transaction-entry, cash, quote, and snapshot
+  currency supported in V1.
+- Yahoo-assisted capture accepts supported NSE and BSE securities only. Foreign
+  securities must be rejected before persistence instead of being aggregated
+  as INR.
+- CoinGecko current and historical crypto prices are requested in INR. The
+  value is CoinGecko's globally aggregated market estimate expressed in INR,
+  not a direct INR trading pair or an exchange-specific execution price.
+- Selected lookup identity, ticker, exchange, currency, quote source ID, and
+  provider quote provenance must survive review and save.
+- Asset and quote currency compatibility must be proven before a record enters
+  INR totals, allocation, P&L, or monthly snapshots.
+- Unsupported persisted records remain local and visible as excluded data; they
+  must never be silently converted, deleted, or included in INR calculations.
+- General foreign-asset portfolios, FX conversion, and user-selectable reporting
+  currency remain outside V1.
+
 ## Screen Contract
 
 Primary tabs:

--- a/e2e/add-holding-lookup.yaml
+++ b/e2e/add-holding-lookup.yaml
@@ -12,11 +12,14 @@ appId: com.abdulshaikh.cogvest
 - tapOn:
     id: "asset-lookup-input"
 - eraseText: 50
-- inputText: "btc-usd"
+- inputText: "bitcoin"
 - hideKeyboard
-- assertVisible: "Bitcoin USD"
-- tapOn: "Select"
-- assertVisible: "BTC-USD"
+- assertVisible:
+    id: "asset-lookup-result-coingecko:bitcoin"
+- tapOn:
+    id: "asset-lookup-result-coingecko:bitcoin"
+- assertVisible: "BTC"
+- assertVisible: "Live price autofilled from CoinGecko."
 - scrollUntilVisible:
     element:
       id: "continue-class-button"
@@ -37,9 +40,6 @@ appId: com.abdulshaikh.cogvest
 - tapOn:
     id: "average-cost-input"
 - inputText: "100"
-- tapOn:
-    id: "price-input"
-- inputText: "110"
 - hideKeyboard
 - tapOn:
     id: "review-holding-button"
@@ -53,4 +53,7 @@ appId: com.abdulshaikh.cogvest
     direction: DOWN
 - tapOn:
     id: "save-holding-button"
-- assertVisible: "Opening position saved."
+- assertVisible:
+    id: "holdings-screen"
+- assertVisible: "Bitcoin"
+- assertVisible: "Invested ₹100"

--- a/e2e/add-trade.yaml
+++ b/e2e/add-trade.yaml
@@ -52,4 +52,6 @@ appId: com.abdulshaikh.cogvest
     direction: DOWN
 - tapOn:
     id: "save-holding-button"
-- assertVisible: "Opening position saved."
+- assertVisible:
+    id: "holdings-screen"
+- assertVisible: "Reliance Industries"

--- a/e2e/holdings.yaml
+++ b/e2e/holdings.yaml
@@ -50,8 +50,6 @@ appId: com.abdulshaikh.cogvest
     direction: DOWN
 - tapOn:
     id: "save-holding-button"
-- assertVisible: "Opening position saved."
-- openLink: "cogvest:///holdings"
 - assertVisible:
     id: "holdings-screen"
 - assertVisible: "Reliance Industries"

--- a/e2e/value-masking.yaml
+++ b/e2e/value-masking.yaml
@@ -40,7 +40,8 @@ appId: com.abdulshaikh.cogvest
     direction: DOWN
 - tapOn:
     id: "save-holding-button"
-- assertVisible: "Opening position saved."
+- assertVisible:
+    id: "holdings-screen"
 - openLink: "cogvest:///settings"
 - assertVisible:
     id: "settings-screen"

--- a/src/__tests__/addHoldingRoute.test.tsx
+++ b/src/__tests__/addHoldingRoute.test.tsx
@@ -1,0 +1,27 @@
+const mockReplace = jest.fn();
+
+jest.mock("expo-router", () => ({
+  router: {
+    replace: mockReplace,
+  },
+  useLocalSearchParams: () => ({}),
+}));
+
+const AddHoldingRoute =
+  require("../../app/add-holding").default as typeof import("../../app/add-holding").default;
+
+describe("Add Holding route", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+  });
+
+  it("replaces the completed wizard with Holdings", () => {
+    const routeElement = AddHoldingRoute() as {
+      props: { onComplete: () => void };
+    };
+
+    routeElement.props.onComplete();
+
+    expect(mockReplace).toHaveBeenCalledWith("/(tabs)/holdings");
+  });
+});

--- a/src/domain/calculations/__tests__/holdings.test.ts
+++ b/src/domain/calculations/__tests__/holdings.test.ts
@@ -30,13 +30,25 @@ const reliance: Asset = {
 
 const bitcoin: Asset = {
   assetClass: "crypto",
-  currency: "USD",
+  currency: "INR",
+  exchange: "CRYPTO",
   id: "asset-btc",
   instrumentType: "crypto",
   name: "Bitcoin",
   sectorType: "digitalAsset",
   symbol: "BTC",
   ticker: "bitcoin",
+};
+
+const unsupportedForeignAsset: Asset = {
+  assetClass: "stock",
+  currency: "USD",
+  id: "asset-aapl",
+  instrumentType: "stock",
+  name: "Apple",
+  sectorType: "technology",
+  symbol: "AAPL",
+  ticker: "AAPL",
 };
 
 const ppf: Asset = {
@@ -285,6 +297,53 @@ describe("holding calculations", () => {
       totalInvested: 250000,
       unrealisedPnL: 40000,
     });
+  });
+
+  it("excludes unsupported foreign assets from INR holdings", () => {
+    const holdings = calculateHoldings({
+      assets: [reliance, unsupportedForeignAsset],
+      quoteCache: {
+        [reliance.id]: {
+          assetId: reliance.id,
+          asOf: "2026-05-10T00:00:00.000Z",
+          currency: "INR",
+          price: 125,
+          source: "yahoo",
+        },
+        [unsupportedForeignAsset.id]: {
+          assetId: unsupportedForeignAsset.id,
+          asOf: "2026-05-10T00:00:00.000Z",
+          currency: "USD",
+          price: 200,
+          source: "yahoo",
+        },
+      },
+      trades: [
+        trade({ assetId: reliance.id }),
+        trade({ assetId: unsupportedForeignAsset.id }),
+      ],
+    });
+
+    expect(holdings).toHaveLength(1);
+    expect(holdings[0]?.asset.id).toBe(reliance.id);
+  });
+
+  it("excludes INR assets whose stored quote is not INR", () => {
+    const holdings = calculateHoldings({
+      assets: [reliance],
+      quoteCache: {
+        [reliance.id]: {
+          assetId: reliance.id,
+          asOf: "2026-05-10T00:00:00.000Z",
+          currency: "USD",
+          price: 125,
+          source: "yahoo",
+        },
+      },
+      trades: [trade({ assetId: reliance.id })],
+    });
+
+    expect(holdings).toEqual([]);
   });
 });
 

--- a/src/domain/calculations/__tests__/monthEndSnapshots.test.ts
+++ b/src/domain/calculations/__tests__/monthEndSnapshots.test.ts
@@ -49,6 +49,7 @@ const debtAsset: Asset = {
 const cryptoAsset: Asset = {
   assetClass: "crypto",
   currency: "INR",
+  exchange: "CRYPTO",
   id: "asset-crypto",
   instrumentType: "crypto",
   name: "Bitcoin",
@@ -247,6 +248,40 @@ describe("buildGeneratedMonthEndSnapshot", () => {
         priceBasis: "historical-close",
         source: "auto",
         warnings: [],
+      },
+    });
+  });
+
+  it("does not relabel a foreign historical quote as INR", () => {
+    const result = buildGeneratedMonthEndSnapshot(
+      buildInput({
+        historicalQuotes: {
+          [historicalQuoteCacheKey(stockAsset.id, "2026-07")]: {
+            assetId: stockAsset.id,
+            asOfMonth: "2026-07",
+            basis: "historical-close",
+            currency: "USD",
+            fetchedAt: "2026-08-01T00:00:00.000Z",
+            price: 250,
+            source: "yahoo",
+          },
+        },
+        openingPositions: [
+          openingPosition({
+            assetId: stockAsset.id,
+            currentPrice: 175,
+            quantity: 10,
+          }),
+        ],
+      }),
+    );
+
+    expect(result.snapshot).toMatchObject({
+      equityValue: 1750,
+      portfolioValue: 1750,
+      generated: {
+        priceBasis: "manual-fallback",
+        warnings: ["1 holding used manual price fallback."],
       },
     });
   });

--- a/src/domain/calculations/holdings.ts
+++ b/src/domain/calculations/holdings.ts
@@ -8,6 +8,7 @@ import type {
   QuoteCache,
   Trade,
 } from "@/src/types";
+import { isV1CompatibleQuote } from "@/src/domain/portfolioCurrency";
 
 type CalculateHoldingInput = {
   asset: Asset;
@@ -182,6 +183,12 @@ export function calculateHoldings({
 }: CalculateHoldingsInput) {
   return assets
     .map((asset) => {
+      const quote = quoteCache[asset.id];
+
+      if (!isV1CompatibleQuote(asset, quote)) {
+        return null;
+      }
+
       const assetTrades = trades.filter((trade) => trade.assetId === asset.id);
       const assetOpeningPositions = openingPositions.filter(
         (position) => position.assetId === asset.id,
@@ -197,7 +204,7 @@ export function calculateHoldings({
           (left, right) =>
             new Date(right.date).getTime() - new Date(left.date).getTime(),
         )[0]?.currentPrice;
-      const currentPrice = quoteCache[asset.id]?.price ?? latestManualPrice ?? 0;
+      const currentPrice = quote?.price ?? latestManualPrice ?? 0;
       const holding = calculateHolding({
         asset,
         currentPrice,

--- a/src/domain/calculations/monthEndSnapshots.ts
+++ b/src/domain/calculations/monthEndSnapshots.ts
@@ -9,6 +9,10 @@ import type {
   Trade,
 } from "@/src/types";
 import { historicalQuoteCacheKey } from "@/src/types";
+import {
+  isV1CompatibleQuote,
+  isV1SupportedAsset,
+} from "@/src/domain/portfolioCurrency";
 
 import {
   calculateCashBalance,
@@ -174,7 +178,7 @@ function selectAssetPrice({
   const historicalQuote =
     historicalQuotes[historicalQuoteCacheKey(asset.id, targetMonth)];
 
-  if (historicalQuote) {
+  if (historicalQuote && isV1CompatibleQuote(asset, historicalQuote)) {
     return {
       basis: historicalQuote.basis,
       price: historicalQuote.price,
@@ -183,7 +187,7 @@ function selectAssetPrice({
 
   const latestQuote = quoteCache[asset.id];
 
-  if (latestQuote) {
+  if (latestQuote && isV1CompatibleQuote(asset, latestQuote)) {
     return {
       basis: "latest-local-fallback",
       price: latestQuote.price,
@@ -249,10 +253,19 @@ export function buildGeneratedMonthEndSnapshot({
   }
 
   const monthEnd = getMonthEndDate(targetMonth);
-  const monthOpeningPositions = openingPositions.filter((position) =>
-    isOnOrBefore(position.date, monthEnd),
+  const supportedAssetIds = new Set(
+    assets.filter(isV1SupportedAsset).map((asset) => asset.id),
   );
-  const monthTrades = trades.filter((trade) => isOnOrBefore(trade.date, monthEnd));
+  const monthOpeningPositions = openingPositions.filter(
+    (position) =>
+      supportedAssetIds.has(position.assetId) &&
+      isOnOrBefore(position.date, monthEnd),
+  );
+  const monthTrades = trades.filter(
+    (trade) =>
+      supportedAssetIds.has(trade.assetId) &&
+      isOnOrBefore(trade.date, monthEnd),
+  );
   const monthCashEntries = cashEntries.filter((entry) =>
     isOnOrBefore(entry.date, monthEnd),
   );
@@ -272,6 +285,10 @@ export function buildGeneratedMonthEndSnapshot({
   }
 
   const relevantAssets = assets.filter((asset) => {
+    if (!supportedAssetIds.has(asset.id)) {
+      return false;
+    }
+
     const hasOpeningPosition = monthOpeningPositions.some(
       (position) => position.assetId === asset.id,
     );
@@ -311,7 +328,7 @@ export function buildGeneratedMonthEndSnapshot({
     return cache;
   }, {});
   const holdings = calculateHoldings({
-    assets,
+    assets: relevantAssets,
     openingPositions: monthOpeningPositions,
     quoteCache: snapshotQuoteCache,
     trades: monthTrades,

--- a/src/domain/portfolioCurrency.ts
+++ b/src/domain/portfolioCurrency.ts
@@ -1,0 +1,77 @@
+import type { Asset, Quote, QuoteCache } from "@/src/types";
+
+export const V1_REPORTING_CURRENCY = "INR" as const;
+
+export type PortfolioCurrencyIssue = {
+  assetId: string;
+  assetName: string;
+  message: string;
+};
+
+function isSupportedIndianTicker(asset: Asset) {
+  return (
+    asset.exchange === "NSE" ||
+    asset.exchange === "BSE" ||
+    /\.(NS|BO)$/u.test(asset.ticker)
+  );
+}
+
+export function getV1AssetCurrencyIssue(asset: Asset): string | undefined {
+  if (asset.currency !== V1_REPORTING_CURRENCY) {
+    return `${asset.name} uses ${asset.currency}; CogVest V1 supports INR holdings only.`;
+  }
+
+  if (
+    (asset.assetClass === "stock" || asset.assetClass === "etf") &&
+    !isSupportedIndianTicker(asset)
+  ) {
+    return `${asset.name} is not linked to a supported NSE or BSE instrument.`;
+  }
+
+  if (asset.assetClass === "crypto" && asset.exchange !== "CRYPTO") {
+    return `${asset.name} is not linked to the supported crypto quote source.`;
+  }
+
+  return undefined;
+}
+
+export function getV1QuoteCurrencyIssue(
+  asset: Asset,
+  quote?: Pick<Quote, "currency">,
+): string | undefined {
+  const assetIssue = getV1AssetCurrencyIssue(asset);
+
+  if (assetIssue) {
+    return assetIssue;
+  }
+
+  if (quote && quote.currency !== V1_REPORTING_CURRENCY) {
+    return `${asset.name} has a ${quote.currency} quote; it was excluded from INR totals.`;
+  }
+
+  return undefined;
+}
+
+export function isV1SupportedAsset(asset: Asset) {
+  return getV1AssetCurrencyIssue(asset) === undefined;
+}
+
+export function isV1CompatibleQuote(
+  asset: Asset,
+  quote?: Pick<Quote, "currency">,
+) {
+  return getV1QuoteCurrencyIssue(asset, quote) === undefined;
+}
+
+export function getPortfolioCurrencyIssues(
+  assets: Asset[],
+  quoteCache: QuoteCache,
+): PortfolioCurrencyIssue[] {
+  return assets.flatMap((asset) => {
+    const message = getV1QuoteCurrencyIssue(asset, quoteCache[asset.id]);
+
+    return message
+      ? [{ assetId: asset.id, assetName: asset.name, message }]
+      : [];
+  });
+}

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -182,6 +182,25 @@ export function DashboardScreen({
           }
         />
 
+        {dashboard.currencyIssues.length > 0 ? (
+          <PremiumCard testID="dashboard-currency-warning">
+            <View style={styles.infoCardRow}>
+              <CategoryIcon assetClass="neutral" />
+              <View style={styles.infoCardCopy}>
+                <AppText weight="bold">Unsupported data excluded</AppText>
+                <AppText color="secondary" variant="caption">
+                  {dashboard.currencyIssues[0].message}
+                  {dashboard.currencyIssues.length > 1
+                    ? ` ${dashboard.currencyIssues.length - 1} more record${
+                        dashboard.currencyIssues.length === 2 ? "" : "s"
+                      } remain stored locally.`
+                    : " The record remains stored locally."}
+                </AppText>
+              </View>
+            </View>
+          </PremiumCard>
+        ) : null}
+
         <PremiumCard elevated style={styles.heroCard} testID="dashboard-portfolio-hero">
           <AppText color="secondary" variant="caption" weight="bold">
             Portfolio value

--- a/src/features/dashboard/__tests__/DashboardScreen.test.tsx
+++ b/src/features/dashboard/__tests__/DashboardScreen.test.tsx
@@ -26,6 +26,15 @@ const etfAsset: Asset = {
   ticker: "NIFTYBEES.NS",
 };
 
+const unsupportedForeignAsset: Asset = {
+  assetClass: "stock",
+  currency: "USD",
+  id: "asset-aapl",
+  name: "Apple",
+  symbol: "AAPL",
+  ticker: "AAPL",
+};
+
 const buyTrade: Trade = {
   assetId: asset.id,
   date: "2026-04-20",
@@ -66,6 +75,37 @@ describe("DashboardScreen", () => {
     fireEvent.press(getByText("Add Holding"));
 
     expect(onAddTrade).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns about retained foreign data and excludes it from INR totals", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.setState({
+      assets: [unsupportedForeignAsset],
+      quoteCache: {
+        [unsupportedForeignAsset.id]: {
+          asOf: "2026-05-16T10:00:00.000Z",
+          assetId: unsupportedForeignAsset.id,
+          currency: "USD",
+          price: 200,
+          source: "yahoo",
+        },
+      },
+      trades: [
+        {
+          ...buyTrade,
+          assetId: unsupportedForeignAsset.id,
+        },
+      ],
+    });
+
+    const { getAllByText, getByTestId, getByText } = render(
+      <DashboardScreen store={store} />,
+    );
+
+    expect(getByTestId("dashboard-currency-warning")).toBeTruthy();
+    expect(getByText("Unsupported data excluded")).toBeTruthy();
+    expect(getByText(/Apple uses USD/u)).toBeTruthy();
+    expect(getAllByText("₹0").length).toBeGreaterThan(0);
   });
 
   it("wires Dashboard header value masking and quote refresh actions", async () => {

--- a/src/features/dashboard/useDashboard.ts
+++ b/src/features/dashboard/useDashboard.ts
@@ -20,6 +20,11 @@ import {
   type PortfolioRollupTotals,
 } from "@/src/domain/calculations";
 import {
+  getPortfolioCurrencyIssues,
+  isV1CompatibleQuote,
+  type PortfolioCurrencyIssue,
+} from "@/src/domain/portfolioCurrency";
+import {
   refreshQuotes as defaultRefreshQuotes,
   type QuoteRefreshFailure,
   type QuoteRefreshResult,
@@ -53,6 +58,7 @@ export type DashboardState = {
   allocation: AllocationItem[];
   cashBalance: number;
   convictionReadiness: ConvictionReadiness;
+  currencyIssues: PortfolioCurrencyIssue[];
   dayChange: PortfolioDayChange;
   holdings: Holding[];
   instrumentAllocation: MetadataAllocationItem[];
@@ -130,12 +136,22 @@ function selectManualPrices(state: PortfolioStoreState) {
 function calculateMonthlyMetrics(
   state: PortfolioStoreState,
   now: Date,
+  supportedAssetIds: Set<string>,
 ): DashboardMonthlyMetrics {
   const tradeInvestment = state.trades
-    .filter((trade) => trade.type === "buy" && isSameMonth(trade.date, now))
+    .filter(
+      (trade) =>
+        supportedAssetIds.has(trade.assetId) &&
+        trade.type === "buy" &&
+        isSameMonth(trade.date, now),
+    )
     .reduce((total, trade) => total + trade.totalValue, 0);
   const openingInvestment = state.openingPositions
-    .filter((position) => isSameMonth(position.date, now))
+    .filter(
+      (position) =>
+        supportedAssetIds.has(position.assetId) &&
+        isSameMonth(position.date, now),
+    )
     .reduce(
       (total, position) =>
         total + position.quantity * position.averageCostPrice,
@@ -168,6 +184,17 @@ export function useDashboard({
   const snapshot = usePortfolioSnapshot(store);
   const [quoteFailures, setQuoteFailures] = useState<QuoteRefreshFailure[]>([]);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const currencyIssues = getPortfolioCurrencyIssues(
+    snapshot.assets,
+    snapshot.quoteCache,
+  );
+  const supportedAssetIds = new Set(
+    snapshot.assets
+      .filter((asset) =>
+        isV1CompatibleQuote(asset, snapshot.quoteCache[asset.id]),
+      )
+      .map((asset) => asset.id),
+  );
   const holdings = withQuoteMetadata(
     calculateHoldings({
       assets: snapshot.assets,
@@ -217,10 +244,13 @@ export function useDashboard({
     }),
     cashBalance,
     convictionReadiness: getConvictionReadiness(
-      snapshot.trades,
+      snapshot.trades.filter((trade) => supportedAssetIds.has(trade.assetId)),
       undefined,
-      snapshot.openingPositions,
+      snapshot.openingPositions.filter((position) =>
+        supportedAssetIds.has(position.assetId),
+      ),
     ),
+    currencyIssues,
     dayChange: calculatePortfolioDayChange(holdings),
     holdings,
     instrumentAllocation: calculateInstrumentAllocation(holdings),
@@ -228,7 +258,7 @@ export function useDashboard({
     latestQuoteAsOf: latestQuote?.asOf,
     latestQuoteSource: latestQuote?.source,
     maskWealthValues: snapshot.preferences.maskWealthValues,
-    monthlyMetrics: calculateMonthlyMetrics(snapshot, now),
+    monthlyMetrics: calculateMonthlyMetrics(snapshot, now, supportedAssetIds),
     quoteFailures,
     refresh,
     rollupRows,

--- a/src/features/openingPositions/AddOpeningPositionForm.tsx
+++ b/src/features/openingPositions/AddOpeningPositionForm.tsx
@@ -39,12 +39,14 @@ function formatSignedINR(value: number) {
 
 export function AddOpeningPositionForm({
   initialVisualQaState,
+  onComplete,
   resolveQuote,
   searchAssetLookupResults,
   store,
 }: AddOpeningPositionFormProps) {
   const holding = useAddOpeningPosition({
     initialVisualQaState,
+    onComplete,
     resolveQuote,
     searchAssetLookupResults,
     store,

--- a/src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
+++ b/src/features/openingPositions/__tests__/AddOpeningPositionForm.test.tsx
@@ -663,9 +663,16 @@ describe("AddOpeningPositionForm", () => {
     });
 
     expect(store.getState().assets[0]).toMatchObject({
+      currency: "INR",
+      exchange: "NSE",
       instrumentType: "stock",
       quoteSourceId: "HDFCBANK.NS",
       sectorType: "financialServices",
+    });
+    expect(store.getState().quoteCache[store.getState().assets[0].id]).toMatchObject({
+      currency: "INR",
+      price: 1678.25,
+      source: "yahoo",
     });
   });
 

--- a/src/features/openingPositions/__tests__/useAddOpeningPosition.test.tsx
+++ b/src/features/openingPositions/__tests__/useAddOpeningPosition.test.tsx
@@ -1,3 +1,4 @@
+import * as Haptics from "expo-haptics";
 import { act, renderHook } from "@testing-library/react-native";
 
 import { createMemoryJsonStorage } from "@/src/services/storage";
@@ -5,10 +6,24 @@ import { createPortfolioStore } from "@/src/store";
 
 import { useAddOpeningPosition } from "../useAddOpeningPosition";
 
+jest.mock("expo-haptics", () => ({
+  notificationAsync: jest.fn(),
+  NotificationFeedbackType: {
+    Success: "success",
+  },
+}));
+
 describe("useAddOpeningPosition", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("reviews and confirms a manual opening position through the feature controller", async () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
-    const { result } = renderHook(() => useAddOpeningPosition({ store }));
+    const onComplete = jest.fn();
+    const { result } = renderHook(() =>
+      useAddOpeningPosition({ onComplete, store }),
+    );
 
     act(() => {
       result.current.setAssetName("Reliance Industries");
@@ -40,5 +55,37 @@ describe("useAddOpeningPosition", () => {
       price: 120,
       source: "manual",
     });
+    expect(onComplete).toHaveBeenCalledWith(store.getState().assets[0].id);
+  });
+
+  it("completes after persistence when haptic feedback is unavailable", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const onComplete = jest.fn();
+    const { result } = renderHook(() =>
+      useAddOpeningPosition({ onComplete, store }),
+    );
+    (Haptics.notificationAsync as jest.Mock).mockRejectedValueOnce(
+      new Error("Haptics unavailable"),
+    );
+
+    act(() => {
+      result.current.setAssetName("Reliance Industries");
+      result.current.setSymbol("RELIANCE");
+      result.current.setTicker("RELIANCE.NS");
+      result.current.setQuantity("2");
+      result.current.setAverageCostPrice("100");
+      result.current.setCurrentPrice("120");
+    });
+
+    act(() => {
+      result.current.handleReview();
+    });
+
+    await act(async () => {
+      await result.current.handleConfirm();
+    });
+
+    expect(store.getState().openingPositions).toHaveLength(1);
+    expect(onComplete).toHaveBeenCalledWith(store.getState().assets[0].id);
   });
 });

--- a/src/features/openingPositions/useAddOpeningPosition.ts
+++ b/src/features/openingPositions/useAddOpeningPosition.ts
@@ -5,6 +5,10 @@ import type { StoreApi } from "zustand/vanilla";
 import { getDefaultAssetMetadata } from "@/src/domain/assets";
 import { calculateHolding } from "@/src/domain/calculations";
 import {
+  getV1AssetCurrencyIssue,
+  getV1QuoteCurrencyIssue,
+} from "@/src/domain/portfolioCurrency";
+import {
   searchAssetLookupResults as defaultSearchAssetLookupResults,
   type AssetLookupResult,
   type AssetLookupSearchResult,
@@ -21,6 +25,7 @@ import type {
   ConvictionScore,
   InstrumentType,
   OpeningPosition,
+  Quote,
   SectorType,
 } from "@/src/types";
 import { createId } from "@/src/utils";
@@ -32,6 +37,7 @@ export type FieldErrors = Partial<Record<string, string>>;
 
 export type AddOpeningPositionControllerInput = {
   initialVisualQaState?: "review";
+  onComplete?: (assetId: string) => void;
   resolveQuote?: (input: ResolveQuoteInput) => Promise<QuoteResult>;
   searchAssetLookupResults?: (input: {
     query: string;
@@ -58,6 +64,7 @@ function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
 
 export function useAddOpeningPosition({
   initialVisualQaState,
+  onComplete,
   resolveQuote = defaultResolveQuote,
   searchAssetLookupResults = defaultSearchAssetLookupResults,
   store = getPortfolioStore(),
@@ -98,6 +105,8 @@ export function useAddOpeningPosition({
   const [lookupResults, setLookupResults] = useState<AssetLookupResult[]>([]);
   const [selectedLookupResult, setSelectedLookupResult] =
     useState<AssetLookupResult | undefined>();
+  const [selectedLookupQuote, setSelectedLookupQuote] =
+    useState<Quote | undefined>();
   const [isLookupSearching, setIsLookupSearching] = useState(false);
   const [lookupStatus, setLookupStatus] = useState("");
   const [quoteStatus, setQuoteStatus] = useState("");
@@ -348,6 +357,7 @@ export function useAddOpeningPosition({
     if (selectedLookupResult) {
       setSelectedLookupResult(undefined);
     }
+    setSelectedLookupQuote(undefined);
     setMetadataReviewMessage(defaultMetadataReviewMessage);
     setInstrumentTypeConfidence("reviewRequired");
     setSectorTypeConfidence("reviewRequired");
@@ -365,6 +375,7 @@ export function useAddOpeningPosition({
   function changeSelectedAsset() {
     setSelectedAssetId("");
     setSelectedLookupResult(undefined);
+    setSelectedLookupQuote(undefined);
     setMetadataReviewMessage(defaultMetadataReviewMessage);
     setInstrumentTypeConfidence("reviewRequired");
     setSectorTypeConfidence("reviewRequired");
@@ -376,10 +387,19 @@ export function useAddOpeningPosition({
   }
 
   function selectAsset(asset: Asset) {
+    const currencyIssue = getV1AssetCurrencyIssue(asset);
+
+    if (currencyIssue) {
+      setErrors({ assetName: currencyIssue });
+      setLookupStatus(currencyIssue);
+      return;
+    }
+
     const quote = snapshot.quoteCache[asset.id];
 
     setSelectedAssetId(asset.id);
     setSelectedLookupResult(undefined);
+    setSelectedLookupQuote(undefined);
     setAssetClass(asset.assetClass);
     setAssetName(asset.name);
     setInstrumentType(asset.instrumentType ?? getDefaultAssetMetadata(asset.assetClass).instrumentType);
@@ -429,8 +449,17 @@ export function useAddOpeningPosition({
   }
 
   async function selectLookupResult(result: AssetLookupResult) {
+    const lookupAsset = buildLookupAsset(result);
+    const currencyIssue = getV1AssetCurrencyIssue(lookupAsset);
+
+    if (currencyIssue) {
+      setLookupStatus(currencyIssue);
+      return;
+    }
+
     setSelectedAssetId("");
     setSelectedLookupResult(result);
+    setSelectedLookupQuote(undefined);
     setAssetClass(result.assetClass);
     setAssetName(result.name);
     setInstrumentType(result.instrumentType);
@@ -447,15 +476,28 @@ export function useAddOpeningPosition({
     setQuoteStatus("Fetching live current price...");
     resetReview();
 
-    const quoteResult = await resolveQuote({ asset: buildLookupAsset(result) });
+    const quoteResult = await resolveQuote({ asset: lookupAsset });
 
     if (quoteResult.ok) {
+      const quoteCurrencyIssue = getV1QuoteCurrencyIssue(
+        lookupAsset,
+        quoteResult.quote,
+      );
+
+      if (quoteCurrencyIssue) {
+        setCurrentPrice("");
+        setQuoteStatus(quoteCurrencyIssue);
+        return;
+      }
+
+      setSelectedLookupQuote(quoteResult.quote);
       setCurrentPrice(quoteResult.quote.price.toString());
       setQuoteStatus(`Live price autofilled from ${result.sourceLabel}.`);
       return;
     }
 
     setCurrentPrice("");
+    setSelectedLookupQuote(undefined);
     setQuoteStatus("Live price unavailable. Enter current price manually.");
   }
 
@@ -493,7 +535,21 @@ export function useAddOpeningPosition({
     }
 
     const assetId = selectedAsset?.id ?? createId("asset");
-    const asset = selectedAsset ?? buildManualAsset(assetId);
+    const asset =
+      selectedAsset ??
+      (selectedLookupResult
+        ? {
+            ...buildLookupAsset(selectedLookupResult),
+            instrumentType,
+            sectorType,
+          }
+        : buildManualAsset(assetId));
+    const currencyIssue = getV1AssetCurrencyIssue(asset);
+
+    if (currencyIssue) {
+      setErrors({ assetName: currencyIssue });
+      return;
+    }
 
     setErrors({});
     setReviewAsset(asset);
@@ -520,16 +576,39 @@ export function useAddOpeningPosition({
     }
 
     store.getState().addOpeningPosition(reviewOpeningPosition);
-    store.getState().upsertQuote({
-      asOf: new Date().toISOString(),
-      assetId: reviewAsset.id,
-      currency: "INR",
-      price: reviewOpeningPosition.currentPrice ?? 0,
-      source: "manual",
-    });
-    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    const storedPrice = reviewOpeningPosition.currentPrice ?? 0;
+    const providerQuote = selectedAsset
+      ? snapshot.quoteCache[selectedAsset.id]
+      : selectedLookupQuote;
+    const shouldPreserveProviderQuote =
+      providerQuote !== undefined &&
+      providerQuote.currency === reviewAsset.currency &&
+      providerQuote.price === storedPrice;
+
+    store.getState().upsertQuote(
+      shouldPreserveProviderQuote
+        ? {
+            ...providerQuote,
+            assetId: reviewAsset.id,
+          }
+        : {
+            asOf: new Date().toISOString(),
+            assetId: reviewAsset.id,
+            currency: "INR",
+            price: storedPrice,
+            source: "manual",
+          },
+    );
+    try {
+      await Haptics.notificationAsync(
+        Haptics.NotificationFeedbackType.Success,
+      );
+    } catch {
+      // Saving and navigation must not depend on optional device feedback.
+    }
     setSuccessMessage("Opening position saved.");
     setReviewOpeningPosition(undefined);
+    onComplete?.(reviewAsset.id);
   }
 
   return {

--- a/src/services/assetLookup/__tests__/assetLookup.test.ts
+++ b/src/services/assetLookup/__tests__/assetLookup.test.ts
@@ -72,6 +72,17 @@ describe("asset lookup service", () => {
     });
   });
 
+  it("rejects foreign Yahoo results from the INR-only V1 lookup", () => {
+    expect(
+      mapYahooQuoteToLookupResult({
+        exchange: "NMS",
+        quoteType: "EQUITY",
+        shortname: "Apple Inc.",
+        symbol: "AAPL",
+      }),
+    ).toBeUndefined();
+  });
+
   it("maps CoinGecko coins to crypto metadata with coin ID as quote source", () => {
     expect(
       mapCoinGeckoCoinToLookupResult({

--- a/src/services/assetLookup/index.ts
+++ b/src/services/assetLookup/index.ts
@@ -89,10 +89,6 @@ function inferYahooExchange(symbol: string): AssetExchange | undefined {
   return undefined;
 }
 
-function inferYahooCurrency(symbol: string): Currency {
-  return symbol.endsWith(".NS") || symbol.endsWith(".BO") ? "INR" : "USD";
-}
-
 function normalizeYahooSymbol(symbol: string) {
   return symbol.replace(/\.(NS|BO)$/u, "").toUpperCase();
 }
@@ -110,6 +106,12 @@ export function mapYahooQuoteToLookupResult(
     return undefined;
   }
 
+  const exchange = inferYahooExchange(ticker);
+
+  if (!exchange) {
+    return undefined;
+  }
+
   const quoteType = quote.quoteType?.toUpperCase();
   const isEtf = quoteType === "ETF";
   const assetClass = inferYahooAssetClass(quoteType);
@@ -119,8 +121,8 @@ export function mapYahooQuoteToLookupResult(
 
   return {
     assetClass,
-    currency: inferYahooCurrency(ticker),
-    exchange: inferYahooExchange(ticker),
+    currency: "INR",
+    exchange,
     id: `yahoo:${ticker}`,
     instrumentType: defaults.instrumentType,
     instrumentTypeConfidence: "inferred",

--- a/src/services/quotes/__tests__/historicalPrices.test.ts
+++ b/src/services/quotes/__tests__/historicalPrices.test.ts
@@ -93,6 +93,7 @@ describe("historical Yahoo quote service", () => {
         chart: {
           result: [
             {
+              meta: { currency: "INR" },
               indicators: {
                 quote: [
                   {
@@ -134,6 +135,7 @@ describe("historical Yahoo quote service", () => {
         chart: {
           result: [
             {
+              meta: { currency: "INR" },
               indicators: {
                 quote: [
                   {
@@ -231,6 +233,7 @@ describe("historical Yahoo quote service", () => {
           chart: {
             result: [
               {
+                meta: { currency: "INR" },
                 indicators: {
                   quote: [
                     {
@@ -425,6 +428,7 @@ describe("historical quote resolver", () => {
           chart: {
             result: [
               {
+                meta: { currency: "INR" },
                 indicators: {
                   quote: [
                     {

--- a/src/services/quotes/__tests__/quotes.test.ts
+++ b/src/services/quotes/__tests__/quotes.test.ts
@@ -113,6 +113,7 @@ describe("Yahoo quote service", () => {
           result: [
             {
               meta: {
+                currency: "INR",
                 regularMarketPrice: 101,
               },
             },
@@ -129,6 +130,31 @@ describe("Yahoo quote service", () => {
     expect(fetcher).toHaveBeenCalledWith(
       "https://query1.finance.yahoo.com/v8/finance/chart/RELIANCE.BO?range=1d&interval=1d",
     );
+  });
+
+  it("rejects a Yahoo price whose provider currency is not INR", async () => {
+    const result = await fetchYahooQuote({
+      asset: reliance,
+      fetcher: jest.fn().mockResolvedValue(
+        response({
+          chart: {
+            result: [
+              {
+                meta: {
+                  currency: "USD",
+                  regularMarketPrice: 101,
+                },
+              },
+            ],
+          },
+        }),
+      ),
+    });
+
+    expect(result).toEqual({
+      error: "Yahoo quote currency was not INR; the price was not accepted.",
+      ok: false,
+    });
   });
 });
 

--- a/src/services/quotes/coinGecko.ts
+++ b/src/services/quotes/coinGecko.ts
@@ -1,4 +1,5 @@
 import type { QuoteProviderInput, QuoteResult } from "./types";
+import { getV1AssetCurrencyIssue } from "@/src/domain/portfolioCurrency";
 import {
   coinGeckoSimplePriceUrl,
   defaultNow,
@@ -30,6 +31,12 @@ export async function fetchCoinGeckoQuote({
   now = defaultNow,
 }: QuoteProviderInput): Promise<QuoteResult> {
   try {
+    const currencyIssue = getV1AssetCurrencyIssue(asset);
+
+    if (currencyIssue) {
+      return { error: currencyIssue, ok: false };
+    }
+
     const quoteSourceId = asset.quoteSourceId ?? asset.ticker;
     const response = await fetcher(buildCoinGeckoSimplePriceUrl(quoteSourceId));
 

--- a/src/services/quotes/historicalPrices.ts
+++ b/src/services/quotes/historicalPrices.ts
@@ -2,6 +2,7 @@ import type {
   HistoricalPriceProviderInput,
   HistoricalPriceResult,
 } from "./types";
+import { getV1AssetCurrencyIssue } from "@/src/domain/portfolioCurrency";
 import {
   coinGeckoMarketChartBaseUrl,
   defaultNow,
@@ -13,6 +14,9 @@ import {
 type YahooHistoricalChartResponse = {
   chart?: {
     result?: Array<{
+      meta?: {
+        currency?: string;
+      };
       indicators?: {
         quote?: Array<{
           close?: Array<number | null | undefined>;
@@ -108,6 +112,12 @@ export async function fetchYahooHistoricalPrice({
   targetMonth,
 }: HistoricalPriceProviderInput): Promise<HistoricalPriceResult> {
   try {
+    const currencyIssue = getV1AssetCurrencyIssue(asset);
+
+    if (currencyIssue) {
+      return { error: currencyIssue, ok: false };
+    }
+
     const providerId = asset.quoteSourceId ?? asset.ticker;
     const response = await fetcher(
       buildYahooHistoricalChartUrl(providerId, targetMonth),
@@ -124,6 +134,15 @@ export async function fetchYahooHistoricalPrice({
     const result = Array.isArray(payload.chart?.result)
       ? payload.chart.result[0]
       : undefined;
+
+    if (result?.meta?.currency?.toUpperCase() !== "INR") {
+      return {
+        error:
+          "Yahoo historical quote currency was not INR; the price was not accepted.",
+        ok: false,
+      };
+    }
+
     const timestamps = result?.timestamp ?? [];
     const closes = result?.indicators?.quote?.[0]?.close ?? [];
     const monthEndSeconds = Math.floor(
@@ -186,6 +205,12 @@ export async function fetchCoinGeckoHistoricalPrice({
   targetMonth,
 }: HistoricalPriceProviderInput): Promise<HistoricalPriceResult> {
   try {
+    const currencyIssue = getV1AssetCurrencyIssue(asset);
+
+    if (currencyIssue) {
+      return { error: currencyIssue, ok: false };
+    }
+
     const providerId = asset.quoteSourceId ?? asset.ticker;
     const response = await fetcher(
       buildCoinGeckoHistoricalRangeUrl(providerId, targetMonth),

--- a/src/services/quotes/quoteResolver.ts
+++ b/src/services/quotes/quoteResolver.ts
@@ -1,4 +1,5 @@
 import type { QuoteCache } from "@/src/types";
+import { getV1AssetCurrencyIssue } from "@/src/domain/portfolioCurrency";
 
 import type {
   QuoteRefreshFailure,
@@ -16,6 +17,15 @@ export async function resolveQuote({
   manualPrice,
   now,
 }: ResolveQuoteInput): Promise<QuoteResult> {
+  const currencyIssue = getV1AssetCurrencyIssue(asset);
+
+  if (currencyIssue) {
+    return {
+      error: currencyIssue,
+      ok: false,
+    };
+  }
+
   if (asset.assetClass === "debt") {
     if (manualPrice !== undefined) {
       return {

--- a/src/services/quotes/yahooFinance.ts
+++ b/src/services/quotes/yahooFinance.ts
@@ -45,6 +45,13 @@ export async function fetchYahooQuote({
     const meta = payload.chart?.result?.[0]?.meta;
     const price = meta?.regularMarketPrice;
 
+    if (meta?.currency?.toUpperCase() !== "INR") {
+      return {
+        error: "Yahoo quote currency was not INR; the price was not accepted.",
+        ok: false,
+      };
+    }
+
     if (typeof price !== "number") {
       return {
         error: "Yahoo quote response did not include a current price.",

--- a/src/store/__tests__/portfolioStore.test.ts
+++ b/src/store/__tests__/portfolioStore.test.ts
@@ -86,6 +86,32 @@ describe("portfolio store", () => {
     expect(store.getState().preferences).toEqual(createDefaultPreferences());
   });
 
+  it("rejects unsupported assets and quote currencies at write boundaries", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const foreignAsset: Asset = {
+      ...asset,
+      currency: "USD",
+      exchange: undefined,
+      id: "asset-aapl",
+      name: "Apple",
+      symbol: "AAPL",
+      ticker: "AAPL",
+    };
+
+    expect(() => store.getState().addAsset(foreignAsset)).toThrow(
+      "CogVest V1 supports INR holdings only",
+    );
+
+    store.getState().addAsset(asset);
+
+    expect(() =>
+      store.getState().upsertQuote({
+        ...quote,
+        currency: "USD",
+      }),
+    ).toThrow("has a USD quote");
+  });
+
   it("adds, updates, and removes raw portfolio records", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
 

--- a/src/store/__tests__/selectors.test.ts
+++ b/src/store/__tests__/selectors.test.ts
@@ -18,7 +18,8 @@ const stock: Asset = {
 
 const crypto: Asset = {
   assetClass: "crypto",
-  currency: "USD",
+  currency: "INR",
+  exchange: "CRYPTO",
   id: "asset-2",
   name: "Bitcoin",
   symbol: "BTC",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,10 @@
 import { createStore, type StoreApi } from "zustand/vanilla";
 
 import { normalizeAssetMetadata } from "@/src/domain/assets";
+import {
+  getV1AssetCurrencyIssue,
+  getV1QuoteCurrencyIssue,
+} from "@/src/domain/portfolioCurrency";
 import type { JsonStorage, JsonValue } from "@/src/services/storage";
 import { createMmkvJsonStorage } from "@/src/services/storage";
 import type {
@@ -255,9 +259,13 @@ function validateLinkedTrade(
   const hasMatchingAsset =
     state.assets.some((asset) => asset.id === trade.assetId) ||
     input.asset?.id === trade.assetId;
+  const tradeAsset =
+    state.assets.find((asset) => asset.id === trade.assetId) ?? input.asset;
 
   if (
     !hasMatchingAsset ||
+    !tradeAsset ||
+    getV1AssetCurrencyIssue(tradeAsset) !== undefined ||
     input.cashLabel.trim().length === 0 ||
     !Number.isFinite(trade.quantity) ||
     trade.quantity <= 0 ||
@@ -303,6 +311,12 @@ export function createPortfolioStore({
   return createStore<PortfolioStoreState>((set, get) => ({
     ...snapshot,
     addAsset: (asset) => {
+      const currencyIssue = getV1AssetCurrencyIssue(asset);
+
+      if (currencyIssue) {
+        throw new Error(currencyIssue);
+      }
+
       set((state) => ({
         assets: [...state.assets, normalizeAssetMetadata(asset)],
       }));
@@ -453,6 +467,12 @@ export function createPortfolioStore({
     },
     schemaVersion: portfolioSchemaVersion,
     updateAsset: (asset) => {
+      const currencyIssue = getV1AssetCurrencyIssue(asset);
+
+      if (currencyIssue) {
+        throw new Error(currencyIssue);
+      }
+
       const normalizedAsset = normalizeAssetMetadata(asset);
 
       set((state) => ({
@@ -508,6 +528,19 @@ export function createPortfolioStore({
       persistPortfolio(storage, get());
     },
     upsertHistoricalQuote: (historicalQuote) => {
+      const asset = get().assets.find(
+        (currentAsset) => currentAsset.id === historicalQuote.assetId,
+      );
+      const currencyIssue = asset
+        ? getV1QuoteCurrencyIssue(asset, historicalQuote)
+        : historicalQuote.currency === "INR"
+          ? undefined
+          : "Cannot save a non-INR historical quote without a supported asset.";
+
+      if (currencyIssue) {
+        throw new Error(currencyIssue);
+      }
+
       set((state) => ({
         historicalQuoteCache: {
           ...state.historicalQuoteCache,
@@ -520,6 +553,19 @@ export function createPortfolioStore({
       persistHistoricalQuoteCache(storage, get().historicalQuoteCache);
     },
     upsertQuote: (quote) => {
+      const asset = get().assets.find(
+        (currentAsset) => currentAsset.id === quote.assetId,
+      );
+      const currencyIssue = asset
+        ? getV1QuoteCurrencyIssue(asset, quote)
+        : quote.currency === "INR"
+          ? undefined
+          : "Cannot save a non-INR quote without a supported asset.";
+
+      if (currencyIssue) {
+        throw new Error(currencyIssue);
+      }
+
       set((state) => ({
         quoteCache: {
           ...state.quoteCache,


### PR DESCRIPTION
## Summary
- enforce CogVest V1's INR-only valuation boundary across lookup, quote providers, persistence, holdings, Dashboard, and month-end snapshots
- preserve CoinGecko/Yahoo quote identity and provenance while rejecting unsupported foreign securities or non-INR quotes
- retain incompatible persisted data locally, exclude it from financial totals, and surface a Dashboard warning
- complete Add Holding by replacing the saved wizard with Holdings, including haptics failure resilience
- align unit and Maestro coverage with explicit provider selection and the post-save destination

## Verification
- `npm run test:v1:pc` (45 suites, 271 tests, Expo Doctor 17/17, emulator and strict installed-package smoke)
- fresh local x86_64 release APK built and installed on `emulator-5554`
- `maestro test e2e/add-holding-lookup.yaml` passed with real CoinGecko lookup, selection, INR autofill, save, Holdings redirect, and persisted value
- affected manual Add Holding and Holdings Maestro flows passed during the full suite run
- full Maestro run later stopped in the unrelated `funded-buy-cash.yaml` flow at Android numeric-keyboard dismissal; no workaround from that investigation is included

Closes #167