### PR TITLE
fix: preserve quote provenance on refresh failure

### DIFF
--- a/docs/reviews/2026-07-11-adversarial-codebase-review.md
+++ b/docs/reviews/2026-07-11-adversarial-codebase-review.md
@@ -106,6 +106,27 @@ and age.
 Fallback must preserve original source and timestamp and expose explicit stale
 status.
 
+**Remediation status (2026-07-19):** Implemented under GitHub issue #169,
+pending merge at the time of this update. Refresh now carries complete cached
+quote objects rather than numeric values labelled as manual input. A failed
+Yahoo or CoinGecko request returns the exact cached quote, preserving price,
+currency, source, timestamp, and day-change metadata. Genuine manual quotes
+also retain their original timestamp. Dashboard failure copy explicitly says
+that last-known prices are shown.
+
+**Remediation evidence:**
+
+- `src/services/quotes/quoteResolver.ts` preserves the cached quote on failure.
+- `src/features/dashboard/useDashboard.ts` and
+  `src/features/holdings/useHoldings.ts` pass the complete quote cache.
+- `src/services/quotes/__tests__/quotes.test.ts` covers Yahoo, CoinGecko,
+  genuine manual, debt, and mixed success/failure refresh paths.
+- Dashboard and Holdings hook/component tests cover the integration contract
+  and user-facing failure state.
+- `npm run test:verify` passed with 45 suites and 273 tests.
+- A fresh local x86_64 release APK was built, installed on `emulator-5554`, and
+  passed `e2e/smoke-launch.yaml`.
+
 ### C4. Release APK uses the public debug signing key
 
 **Impact:** Directly distributed APKs cannot be trusted as production artifacts.

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -441,7 +441,7 @@ function getQuoteStatus({
   }
 
   if (quoteFailures > 0) {
-    return "Some quotes could not refresh. Manual fallback ready.";
+    return "Some quotes could not refresh. Showing last known prices.";
   }
 
   if (!latestQuoteAsOf) {

--- a/src/features/dashboard/__tests__/DashboardScreen.test.tsx
+++ b/src/features/dashboard/__tests__/DashboardScreen.test.tsx
@@ -148,6 +148,39 @@ describe("DashboardScreen", () => {
     ).toBeTruthy();
   });
 
+  it("describes failed refreshes as last-known prices", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addAsset(asset);
+    store.getState().addTrade(buyTrade);
+    const cachedQuote = {
+      asOf: "2026-05-15T10:00:00.000Z",
+      assetId: asset.id,
+      currency: "INR" as const,
+      price: 165,
+      source: "yahoo" as const,
+    };
+    store.getState().upsertQuote(cachedQuote);
+    const refreshQuotes = jest.fn().mockResolvedValue({
+      failures: [{ assetId: asset.id, error: "Provider unavailable." }],
+      quoteCache: { [asset.id]: cachedQuote },
+    });
+
+    const { getByLabelText, getByText, queryByText } = render(
+      <DashboardScreen refreshQuotes={refreshQuotes} store={store} />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByLabelText("Refresh quotes"));
+    });
+
+    await waitFor(() => {
+      expect(
+        getByText("Some quotes could not refresh. Showing last known prices."),
+      ).toBeTruthy();
+    });
+    expect(queryByText(/Manual fallback ready/u)).toBeNull();
+  });
+
   it("wires Dashboard allocation and progress actions", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     const onOpenHoldings = jest.fn();

--- a/src/features/dashboard/__tests__/useDashboard.test.tsx
+++ b/src/features/dashboard/__tests__/useDashboard.test.tsx
@@ -284,6 +284,15 @@ describe("useDashboard", () => {
   it("refreshes quotes and persists refreshed quote cache", async () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     store.getState().addAsset(stockAsset);
+    const cachedQuote = {
+      asOf: "2026-05-15T10:00:00.000Z",
+      assetId: stockAsset.id,
+      currency: "INR" as const,
+      dayChangePct: 1.5,
+      price: 165,
+      source: "yahoo" as const,
+    };
+    store.getState().upsertQuote(cachedQuote);
     const refreshQuotes = jest.fn().mockResolvedValue({
       failures: [],
       quoteCache: {
@@ -306,7 +315,9 @@ describe("useDashboard", () => {
 
     expect(refreshQuotes).toHaveBeenCalledWith({
       assets: [expect.objectContaining(stockAsset)],
-      manualPrices: {},
+      cachedQuotes: {
+        [stockAsset.id]: cachedQuote,
+      },
     });
     expect(store.getState().quoteCache[stockAsset.id]).toMatchObject({
       price: 175,

--- a/src/features/dashboard/useDashboard.ts
+++ b/src/features/dashboard/useDashboard.ts
@@ -124,15 +124,6 @@ function isSameMonth(isoDate: string, now: Date) {
   );
 }
 
-function selectManualPrices(state: PortfolioStoreState) {
-  return Object.fromEntries(
-    Object.entries(state.quoteCache).map(([assetId, quote]) => [
-      assetId,
-      quote.price,
-    ]),
-  );
-}
-
 function calculateMonthlyMetrics(
   state: PortfolioStoreState,
   now: Date,
@@ -216,7 +207,7 @@ export function useDashboard({
       const currentState = store.getState();
       const result = await refreshQuotes({
         assets: currentState.assets,
-        manualPrices: selectManualPrices(currentState),
+        cachedQuotes: currentState.quoteCache,
       });
 
       for (const quote of Object.values(result.quoteCache)) {

--- a/src/features/holdings/__tests__/useHoldings.test.tsx
+++ b/src/features/holdings/__tests__/useHoldings.test.tsx
@@ -121,8 +121,14 @@ describe("useHoldings", () => {
     });
     expect(refreshQuotes).toHaveBeenCalledWith({
       assets: [asset],
-      manualPrices: {
-        [asset.id]: 100,
+      cachedQuotes: {
+        [asset.id]: {
+          asOf: "2026-04-20T10:00:00.000Z",
+          assetId: asset.id,
+          currency: "INR",
+          price: 100,
+          source: "manual",
+        },
       },
     });
     expect(result.current.holdings[0]).toMatchObject({

--- a/src/features/holdings/useHoldings.ts
+++ b/src/features/holdings/useHoldings.ts
@@ -63,15 +63,6 @@ function withQuoteMetadata(
   });
 }
 
-function selectManualPrices(state: PortfolioStoreState) {
-  return Object.fromEntries(
-    Object.entries(state.quoteCache).map(([assetId, quote]) => [
-      assetId,
-      quote.price,
-    ]),
-  );
-}
-
 function getLatestQuoteAsOf(holdings: HoldingWithQuoteMetadata[]) {
   return holdings
     .map((holding) => holding.lastUpdated)
@@ -109,7 +100,7 @@ export function useHoldings({
       const currentState = store.getState();
       const result = await refreshQuotes({
         assets: currentState.assets,
-        manualPrices: selectManualPrices(currentState),
+        cachedQuotes: currentState.quoteCache,
       });
 
       for (const quote of Object.values(result.quoteCache)) {

--- a/src/services/quotes/__tests__/quotes.test.ts
+++ b/src/services/quotes/__tests__/quotes.test.ts
@@ -4,7 +4,7 @@ import {
   refreshQuotes,
   resolveQuote,
 } from "@/src/services/quotes";
-import type { Asset } from "@/src/types";
+import type { Asset, Quote } from "@/src/types";
 
 const reliance: Asset = {
   assetClass: "stock",
@@ -253,65 +253,96 @@ describe("quote resolver", () => {
     expect(result.ok && result.quote.source).toBe("coingecko");
   });
 
-  it("uses manual fallback directly for debt assets", async () => {
+  it("uses the cached manual quote directly for debt assets", async () => {
     const fetcher = jest.fn();
+    const cachedQuote: Quote = {
+      assetId: ppf.id,
+      asOf: "2026-04-20T10:00:00.000Z",
+      currency: "INR",
+      price: 1,
+      source: "manual",
+    };
 
     const result = await resolveQuote({
       asset: ppf,
+      cachedQuote,
       fetcher,
-      manualPrice: 1,
       now: () => "2026-04-26T10:00:00.000Z",
     });
 
     expect(fetcher).not.toHaveBeenCalled();
     expect(result).toEqual({
       ok: true,
-      quote: {
-        assetId: ppf.id,
-        asOf: "2026-04-26T10:00:00.000Z",
-        currency: "INR",
-        price: 1,
-        source: "manual",
-      },
+      quote: cachedQuote,
     });
   });
 
-  it("keeps crypto manual fallback when CoinGecko fails", async () => {
+  it("preserves a cached CoinGecko quote when CoinGecko fails", async () => {
+    const cachedQuote: Quote = {
+      assetId: bitcoin.id,
+      asOf: "2026-04-20T10:00:00.000Z",
+      currency: "INR",
+      dayChangeAbs: -45000,
+      dayChangePct: -0.78,
+      price: 5700000,
+      source: "coingecko",
+    };
     const result = await resolveQuote({
       asset: bitcoin,
+      cachedQuote,
       fetcher: jest.fn().mockResolvedValue(response({}, false)),
-      manualPrice: 5700000,
       now: () => "2026-04-26T10:00:00.000Z",
     });
 
-    expect(result).toMatchObject({
-      fallbackQuote: {
-        assetId: bitcoin.id,
-        currency: "INR",
-        price: 5700000,
-        source: "manual",
-      },
+    expect(result).toEqual({
+      error: "CoinGecko quote request failed with status 500.",
+      fallbackQuote: cachedQuote,
       ok: false,
     });
   });
 
-  it("uses manual fallback when provider fetch fails", async () => {
+  it("preserves Yahoo provenance and timestamp when provider fetch fails", async () => {
+    const cachedQuote: Quote = {
+      assetId: reliance.id,
+      asOf: "2026-04-20T10:00:00.000Z",
+      currency: "INR",
+      dayChangeAbs: 25,
+      dayChangePct: 0.9,
+      price: 2800,
+      source: "yahoo",
+    };
     const result = await resolveQuote({
       asset: reliance,
+      cachedQuote,
       fetcher: jest.fn().mockResolvedValue(response({}, false)),
-      manualPrice: 2800,
       now: () => "2026-04-26T10:00:00.000Z",
     });
 
     expect(result).toEqual({
       error: "Yahoo quote request failed with status 500.",
-      fallbackQuote: {
-        assetId: reliance.id,
-        asOf: "2026-04-26T10:00:00.000Z",
-        currency: "INR",
-        price: 2800,
-        source: "manual",
-      },
+      fallbackQuote: cachedQuote,
+      ok: false,
+    });
+  });
+
+  it("preserves a genuine manual quote and its original timestamp", async () => {
+    const cachedQuote: Quote = {
+      assetId: reliance.id,
+      asOf: "2026-04-19T09:30:00.000Z",
+      currency: "INR",
+      price: 2750,
+      source: "manual",
+    };
+
+    const result = await resolveQuote({
+      asset: reliance,
+      cachedQuote,
+      fetcher: jest.fn().mockResolvedValue(response({}, false)),
+      now: () => "2026-04-26T10:00:00.000Z",
+    });
+
+    expect(result).toMatchObject({
+      fallbackQuote: cachedQuote,
       ok: false,
     });
   });
@@ -336,17 +367,38 @@ describe("quote resolver", () => {
       )
       .mockResolvedValueOnce(response({}, false));
 
+    const staleRelianceQuote: Quote = {
+      assetId: reliance.id,
+      asOf: "2026-04-17T10:00:00.000Z",
+      currency: "INR",
+      price: 95,
+      source: "yahoo",
+    };
+    const cachedQuote: Quote = {
+      assetId: niftyBees.id,
+      asOf: "2026-04-18T10:00:00.000Z",
+      currency: "INR",
+      dayChangeAbs: 2,
+      dayChangePct: 0.8,
+      price: 250,
+      source: "yahoo",
+    };
     const result = await refreshQuotes({
       assets: [reliance, niftyBees],
-      fetcher,
-      manualPrices: {
-        [niftyBees.id]: 250,
+      cachedQuotes: {
+        [reliance.id]: staleRelianceQuote,
+        [niftyBees.id]: cachedQuote,
       },
+      fetcher,
       now: () => "2026-04-26T10:00:00.000Z",
     });
 
-    expect(result.quoteCache[reliance.id]?.source).toBe("yahoo");
-    expect(result.quoteCache[niftyBees.id]?.source).toBe("manual");
+    expect(result.quoteCache[reliance.id]).toMatchObject({
+      asOf: "2026-04-26T10:00:00.000Z",
+      price: 101,
+      source: "yahoo",
+    });
+    expect(result.quoteCache[niftyBees.id]).toEqual(cachedQuote);
     expect(result.failures).toEqual([
       {
         assetId: niftyBees.id,

--- a/src/services/quotes/quoteResolver.ts
+++ b/src/services/quotes/quoteResolver.ts
@@ -9,12 +9,11 @@ import type {
 } from "./types";
 import { fetchCoinGeckoQuote } from "./coinGecko";
 import { fetchYahooQuote } from "./yahooFinance";
-import { createManualQuote } from "./utils";
 
 export async function resolveQuote({
   asset,
+  cachedQuote,
   fetcher,
-  manualPrice,
   now,
 }: ResolveQuoteInput): Promise<QuoteResult> {
   const currencyIssue = getV1AssetCurrencyIssue(asset);
@@ -27,10 +26,10 @@ export async function resolveQuote({
   }
 
   if (asset.assetClass === "debt") {
-    if (manualPrice !== undefined) {
+    if (cachedQuote) {
       return {
         ok: true,
-        quote: createManualQuote({ asset, now, price: manualPrice }),
+        quote: cachedQuote,
       };
     }
 
@@ -45,20 +44,20 @@ export async function resolveQuote({
       ? await fetchCoinGeckoQuote({ asset, fetcher, now })
       : await fetchYahooQuote({ asset, fetcher, now });
 
-  if (result.ok || manualPrice === undefined) {
+  if (result.ok || !cachedQuote) {
     return result;
   }
 
   return {
     ...result,
-    fallbackQuote: createManualQuote({ asset, now, price: manualPrice }),
+    fallbackQuote: cachedQuote,
   };
 }
 
 export async function refreshQuotes({
   assets,
+  cachedQuotes = {},
   fetcher,
-  manualPrices = {},
   now,
 }: RefreshQuotesInput) {
   const quoteCache: QuoteCache = {};
@@ -71,8 +70,8 @@ export async function refreshQuotes({
 
     const result = await resolveQuote({
       asset,
+      cachedQuote: cachedQuotes[asset.id],
       fetcher,
-      manualPrice: manualPrices[asset.id],
       now,
     });
 

--- a/src/services/quotes/types.ts
+++ b/src/services/quotes/types.ts
@@ -53,13 +53,13 @@ export type HistoricalPriceProviderInput = {
 };
 
 export type ResolveQuoteInput = QuoteProviderInput & {
-  manualPrice?: number;
+  cachedQuote?: Quote;
 };
 
 export type RefreshQuotesInput = {
   assets: Asset[];
+  cachedQuotes?: QuoteCache;
   fetcher?: QuoteFetcher;
-  manualPrices?: Record<string, number>;
   now?: QuoteNow;
 };
 


### PR DESCRIPTION
## Summary
- preserve complete cached quote provenance when Yahoo or CoinGecko refresh fails
- pass cached quote objects through Dashboard and Holdings instead of relabelling numeric values as manual
- clarify Dashboard failure copy and record C3 remediation evidence in the adversarial review

## Verification
- `npm run test:verify` (45 suites, 273 tests; Expo Doctor 17/17)
- `npm run test:v1:pc`
- local x86_64 release APK build and fresh install on `emulator-5554`
- `maestro test e2e/smoke-launch.yaml`

Closes #169