### PR TITLE
Fix typed-income investment metrics in Progress

### DIFF
--- a/docs/reviews/2026-07-11-adversarial-codebase-review.md
+++ b/docs/reviews/2026-07-11-adversarial-codebase-review.md
@@ -203,25 +203,27 @@ instead of presenting a misleading gain.
 
 ### H2. Cash savings metrics mix income, deposits, and sale proceeds
 
-**Status (2026-07-21): Partially remediated by #161.** Cash additions are typed,
-legacy entries remain uncategorized, and Cash Ledger metrics use typed income.
-Progress still derives its no-snapshot savings figure from all additions and
-is tracked for focused remediation in #175.
+**Status (2026-07-21): Remediated by #161 and #175.** Cash and Progress now use
+the same pure monthly metric. Only typed `income` entries form the investment-rate
+denominator; capital contributions, sale proceeds, transfers, withdrawals, and
+legacy uncategorized additions do not. Missing typed income produces an
+unavailable rate instead of zero or a guessed percentage, and any unclassified
+legacy addition keeps both income and the rate unavailable until classified.
 
-Every cash addition is used as the savings-rate denominator. Deposits, broker
-transfers, emergency-fund movements, and linked redemption proceeds therefore
-behave like salary/income. Sell proceeds can inflate both cash added and savings
-rate.
+**Remediation evidence:**
 
-**Evidence:**
-
-- `src/domain/calculations/holdings.ts:230-261`.
-- `src/features/sellRedeem/useSellRedeemHolding.ts:274-283` records linked sale
-  proceeds as a generic addition.
-
-**Required direction:** Add cash-entry purpose/category or model income,
-contributions, transfers, withdrawals, and sale proceeds as distinct movement
-types.
+- `calculateCashMonthlyMetrics` owns typed income, monthly investment, and the
+  nullable investment rate for both Cash and Progress.
+- Linked buy trades and `purchaseFunding` cash movements are matched against all
+  buy IDs and counted once in the canonical trade month. Unlinked legacy purchase
+  funding remains countable without duplicating a known trade.
+- Stored record dates use their calendar month while the active period follows
+  the device-local month, avoiding UTC rollover errors around local midnight.
+- Cash and Progress use the user-facing label `Investment rate` and render
+  `Not enough data` for income and rate when classification is insufficient.
+- Domain, hook, and component tests cover income, contribution, sale-proceeds,
+  legacy-entry, linked-funded-buy, shared Cash/Progress, and unavailable paths.
+- `npm run test:verify` passed 47 suites and 296 tests; Expo Doctor passed 17/17.
 
 ### H3. Automation only covers the immediately previous month
 

--- a/src/domain/calculations/__tests__/holdings.test.ts
+++ b/src/domain/calculations/__tests__/holdings.test.ts
@@ -490,16 +490,119 @@ describe("portfolio calculations", () => {
         cashEntries: monthlyEntries,
         now: new Date("2026-05-20T00:00:00.000Z"),
         openingPositions: [],
-        trades: [],
+        trades: [
+          trade({
+            date: "2026-05-03T00:00:00.000Z",
+            id: "trade-buy",
+            pricePerUnit: 1000,
+            quantity: 10,
+            totalValue: 10000,
+          }),
+        ],
       }),
     ).toEqual({
       added: 75000,
       available: 77000,
       contributions: 25000,
       income: 50000,
+      incomeStatus: "available",
       investmentRate: 20,
       invested: 10000,
     });
+  });
+
+  it("marks income-based metrics unavailable when legacy additions are unclassified", () => {
+    const metrics = calculateCashMonthlyMetrics({
+      cashEntries: [
+        {
+          amount: 50000,
+          date: "2026-05-01T00:00:00.000Z",
+          id: "cash-income",
+          label: "Salary",
+          purpose: "income",
+          type: "addition",
+        },
+        {
+          amount: 4000,
+          date: "2026-05-02T00:00:00.000Z",
+          id: "cash-legacy",
+          label: "Legacy addition",
+          purpose: "legacyUncategorized",
+          type: "addition",
+        },
+      ],
+      now: new Date("2026-05-20T00:00:00.000Z"),
+      openingPositions: [],
+      trades: [],
+    });
+
+    expect(metrics).toMatchObject({
+      income: 50000,
+      incomeStatus: "unavailable",
+      investmentRate: null,
+    });
+  });
+
+  it("uses the trade date as the canonical month for linked purchase funding", () => {
+    const linkedFunding: CashEntry = {
+      amount: 10000,
+      date: "2026-07-01T00:00:00.000Z",
+      id: "cash-trade-buy",
+      label: "Funded purchase",
+      linkedTradeId: "trade-buy",
+      purpose: "purchaseFunding",
+      type: "withdrawal",
+    };
+    const juneBuy = trade({
+      date: "2026-06-30T00:00:00.000Z",
+      id: "trade-buy",
+      pricePerUnit: 1000,
+      quantity: 10,
+      totalValue: 10000,
+    });
+
+    expect(
+      calculateCashMonthlyMetrics({
+        cashEntries: [linkedFunding],
+        now: new Date("2026-07-20T00:00:00.000Z"),
+        openingPositions: [],
+        trades: [juneBuy],
+      }).invested,
+    ).toBe(0);
+    expect(
+      calculateCashMonthlyMetrics({
+        cashEntries: [linkedFunding],
+        now: new Date("2026-06-20T00:00:00.000Z"),
+        openingPositions: [],
+        trades: [juneBuy],
+      }).invested,
+    ).toBe(10000);
+  });
+
+  it("matches stored calendar dates against the device-local current month", () => {
+    const now = new Date("2026-06-30T19:00:00.000Z");
+    jest.spyOn(now, "getFullYear").mockReturnValue(2026);
+    jest.spyOn(now, "getMonth").mockReturnValue(6);
+    jest.spyOn(now, "getUTCFullYear").mockReturnValue(2026);
+    jest.spyOn(now, "getUTCMonth").mockReturnValue(5);
+    const metrics = calculateCashMonthlyMetrics({
+      cashEntries: [
+        {
+          amount: 50000,
+          date: "2026-07-01T00:00:00.000Z",
+          id: "cash-income",
+          label: "Salary",
+          purpose: "income",
+          type: "addition",
+        },
+      ],
+      now,
+      openingPositions: [],
+      trades: [],
+    });
+
+    expect(metrics.income).toBe(50000);
+    expect(metrics.incomeStatus).toBe("available");
   });
 
   it("calculates day change from holding values and quote change", () => {

--- a/src/domain/calculations/holdings.ts
+++ b/src/domain/calculations/holdings.ts
@@ -83,6 +83,7 @@ export type CashMonthlyMetrics = {
   available: number;
   contributions: number;
   income: number;
+  incomeStatus: "available" | "unavailable";
   investmentRate: number | null;
   invested: number;
 };
@@ -232,17 +233,18 @@ export function calculateCashBalance(cashEntries: CashEntry[]) {
 }
 
 function isSameMonth(isoDate: string, now: Date) {
-  const date = new Date(isoDate);
+  const recordMonth = isoDate.slice(0, 7);
+  const currentMonth = `${now.getFullYear()}-${String(
+    now.getMonth() + 1,
+  ).padStart(2, "0")}`;
 
-  return (
-    date.getUTCFullYear() === now.getUTCFullYear() &&
-    date.getUTCMonth() === now.getUTCMonth()
-  );
+  return recordMonth === currentMonth;
 }
 
 export function calculateCashMonthlyMetrics({
   cashEntries,
   now = new Date(),
+  trades,
 }: {
   cashEntries: CashEntry[];
   now?: Date;
@@ -269,19 +271,36 @@ export function calculateCashMonthlyMetrics({
         entry.type === "addition" && entry.purpose === "legacyUncategorized",
     )
     .reduce((total, entry) => total + entry.amount, 0);
-  const invested = monthlyEntries
+  const monthlyBuyTrades = trades.filter(
+    (trade) => trade.type === "buy" && isSameMonth(trade.date, now),
+  );
+  const allBuyTradeIds = new Set(
+    trades.filter((trade) => trade.type === "buy").map((trade) => trade.id),
+  );
+  const investedFromTrades = monthlyBuyTrades.reduce(
+    (total, trade) => total + trade.totalValue,
+    0,
+  );
+  const unmatchedPurchaseFunding = monthlyEntries
     .filter(
       (entry) =>
-        entry.type === "withdrawal" && entry.purpose === "purchaseFunding",
+        entry.type === "withdrawal" &&
+        entry.purpose === "purchaseFunding" &&
+        (!entry.linkedTradeId || !allBuyTradeIds.has(entry.linkedTradeId)),
     )
     .reduce((total, entry) => total + entry.amount, 0);
+  const invested = investedFromTrades + unmatchedPurchaseFunding;
+  const incomeStatus =
+    income > 0 && legacyAdded === 0 ? "available" : "unavailable";
 
   return {
     added: income + contributions + legacyAdded,
     available: calculateCashBalance(cashEntries),
     contributions,
     income,
-    investmentRate: income > 0 ? round((invested / income) * 100) : null,
+    incomeStatus,
+    investmentRate:
+      incomeStatus === "available" ? round((invested / income) * 100) : null,
     invested,
   };
 }

--- a/src/features/cash/CashScreen.tsx
+++ b/src/features/cash/CashScreen.tsx
@@ -187,10 +187,13 @@ export function CashScreen({
             {
               label: "Income",
               masked: maskWealthValues,
-              value: formatCompactINR(monthlyMetrics.income),
+              value:
+                monthlyMetrics.incomeStatus === "available"
+                  ? formatCompactINR(monthlyMetrics.income)
+                  : "Not enough data",
             },
             {
-              label: "Invested / income",
+              label: "Investment rate",
               value: formatInvestmentRate(monthlyMetrics.investmentRate),
             },
           ]}

--- a/src/features/cash/__tests__/CashScreen.test.tsx
+++ b/src/features/cash/__tests__/CashScreen.test.tsx
@@ -135,11 +135,13 @@ describe("CashScreen", () => {
 
     expect(getByText("Deployable cash")).toBeTruthy();
     expect(getByText("Invested")).toBeTruthy();
+    expect(getByText("Investment rate")).toBeTruthy();
     expect(getByText("₹20K moved into investments this month")).toBeTruthy();
     expect(getByText("Deposit")).toBeTruthy();
     expect(getByText("Withdraw")).toBeTruthy();
     expect(queryByText("Invest")).toBeNull();
     expect(queryByText("Investment Transfer")).toBeNull();
+    expect(queryByText("Invested / income")).toBeNull();
   });
 
   it("shows asset exit proceeds as linked cash movement", () => {
@@ -158,6 +160,36 @@ describe("CashScreen", () => {
     expect(getByText("HDFC Bank redemption proceeds")).toBeTruthy();
     expect(getByText("Added from asset exit")).toBeTruthy();
     expect(getByText("+₹8,400.00")).toBeTruthy();
+  });
+
+  it("shows income-based metrics as unavailable for unclassified legacy additions", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addCashEntry({
+      amount: 50000,
+      date: "2026-05-01",
+      id: "cash-income",
+      label: "Salary",
+      purpose: "income",
+      type: "addition",
+    });
+    store.getState().addCashEntry({
+      amount: 5000,
+      date: "2026-05-02",
+      id: "cash-legacy",
+      label: "Legacy addition",
+      purpose: "legacyUncategorized",
+      type: "addition",
+    });
+
+    const { getAllByText, getByText } = render(
+      <CashScreen
+        now={new Date("2026-05-16T00:00:00.000Z")}
+        store={store}
+      />,
+    );
+
+    expect(getByText("Investment rate")).toBeTruthy();
+    expect(getAllByText("Not enough data")).toHaveLength(2);
   });
 
   it("shows validation errors for invalid cash entries", () => {

--- a/src/features/cash/__tests__/useCash.test.tsx
+++ b/src/features/cash/__tests__/useCash.test.tsx
@@ -129,6 +129,7 @@ describe("useCash", () => {
       available: 80000,
       contributions: 0,
       income: 100000,
+      incomeStatus: "available",
       investmentRate: 20,
       invested: 20000,
     });
@@ -221,6 +222,7 @@ describe("useCash", () => {
       available: 0,
       contributions: 20000,
       income: 0,
+      incomeStatus: "unavailable",
       investmentRate: null,
       invested: 20000,
     });

--- a/src/features/progress/ProgressScreen.tsx
+++ b/src/features/progress/ProgressScreen.tsx
@@ -751,8 +751,11 @@ export function ProgressScreen({
                   value: formatCompactINR(progress.cashBalance),
                 },
                 {
-                  label: "Savings",
-                  value: progress.monthlyCashAdded === 0 ? "Not enough data" : formatPercentage(progress.savingsRate),
+                  label: "Investment rate",
+                  value:
+                    progress.investmentRate === null
+                      ? "Not enough data"
+                      : `${progress.investmentRate.toFixed(2)}%`,
                 },
               ]}
             />
@@ -763,7 +766,10 @@ export function ProgressScreen({
                 Monthly investment: {formatINR(progress.monthlyInvestment)}
               </AppText>
               <AppText color="secondary">
-                Cash added: {formatINR(progress.monthlyCashAdded)}
+                Typed income:{" "}
+                {progress.monthlyIncome === null
+                  ? "Not enough data"
+                  : formatINR(progress.monthlyIncome)}
               </AppText>
               <AppText color="secondary">
                 Expense rate needs explicit expense tracking and is not shown in V1.

--- a/src/features/progress/__tests__/ProgressScreen.test.tsx
+++ b/src/features/progress/__tests__/ProgressScreen.test.tsx
@@ -92,6 +92,53 @@ function seedHoldingAndCash(store: ReturnType<typeof createPortfolioStore>) {
   store.getState().addCashEntry(cashEntry);
 }
 
+function seedCurrentMonthMetrics(
+  store: ReturnType<typeof createPortfolioStore>,
+  { includeIncome = true }: { includeIncome?: boolean } = {},
+) {
+  store.getState().addAsset(stockAsset);
+  if (includeIncome) {
+    store.getState().addCashEntry({
+      amount: 50000,
+      date: "2026-07-01T00:00:00.000Z",
+      id: "cash-income",
+      label: "Salary",
+      purpose: "income",
+      type: "addition",
+    });
+  }
+  store.getState().addCashEntry({
+    amount: 25000,
+    date: "2026-07-02T00:00:00.000Z",
+    id: "cash-contribution",
+    label: "Capital contribution",
+    purpose: "capitalContribution",
+    type: "addition",
+  });
+  if (!includeIncome) {
+    store.getState().addCashEntry({
+      amount: 5000,
+      date: "2026-07-03T00:00:00.000Z",
+      id: "cash-legacy",
+      label: "Legacy addition",
+      purpose: "legacyUncategorized",
+      type: "addition",
+    });
+  }
+  store.getState().recordFundedBuy({
+    cashLabel: "HDFC Bank purchase",
+    trade: {
+      assetId: stockAsset.id,
+      date: "2026-07-05T00:00:00.000Z",
+      id: "trade-buy",
+      pricePerUnit: 1000,
+      quantity: 10,
+      totalValue: 10000,
+      type: "buy",
+    },
+  });
+}
+
 describe("ProgressScreen", () => {
   beforeEach(() => {
     jest.mocked(useReducedMotionPreference).mockReturnValue(false);
@@ -106,6 +153,39 @@ describe("ProgressScreen", () => {
     expect(
       getByText("Snapshots are created automatically once your portfolio has data. Review a snapshot only when a correction is needed."),
     ).toBeTruthy();
+  });
+
+  it("shows the typed-income investment rate before snapshots exist", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    seedCurrentMonthMetrics(store);
+
+    const { getByText, queryByText } = render(
+      <ProgressScreen
+        now={new Date("2026-07-20T00:00:00.000Z")}
+        store={store}
+      />,
+    );
+
+    expect(getByText("Investment rate")).toBeTruthy();
+    expect(getByText("20.00%")).toBeTruthy();
+    expect(getByText("Typed income: ₹50,000.00")).toBeTruthy();
+    expect(queryByText("Savings")).toBeNull();
+  });
+
+  it("shows an unavailable investment rate when typed income is missing", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    seedCurrentMonthMetrics(store, { includeIncome: false });
+
+    const { getByText } = render(
+      <ProgressScreen
+        now={new Date("2026-07-20T00:00:00.000Z")}
+        store={store}
+      />,
+    );
+
+    expect(getByText("Investment rate")).toBeTruthy();
+    expect(getByText("Not enough data")).toBeTruthy();
+    expect(getByText("Typed income: Not enough data")).toBeTruthy();
   });
 
   it("shows compact snapshot automation status instead of the manual form", async () => {

--- a/src/features/progress/__tests__/useProgress.test.tsx
+++ b/src/features/progress/__tests__/useProgress.test.tsx
@@ -4,6 +4,7 @@ import { createMemoryJsonStorage } from "@/src/services/storage";
 import { createPortfolioStore } from "@/src/store";
 import type { Asset, CashEntry, OpeningPosition } from "@/src/types";
 
+import { useCash } from "../../cash/useCash";
 import { useMonthEndSnapshotAutomation } from "../useMonthEndSnapshotAutomation";
 import { useProgress } from "../useProgress";
 
@@ -39,7 +40,102 @@ function seedHoldingAndCash(store: ReturnType<typeof createPortfolioStore>) {
   store.getState().addCashEntry(cashEntry);
 }
 
+function seedMonthlyInvestmentMetrics(
+  store: ReturnType<typeof createPortfolioStore>,
+  { includeIncome = true }: { includeIncome?: boolean } = {},
+) {
+  store.getState().addAsset(stockAsset);
+
+  const additions: CashEntry[] = [
+    ...(includeIncome
+      ? [
+          {
+            amount: 50000,
+            date: "2026-07-01T00:00:00.000Z",
+            id: "cash-income",
+            label: "Salary",
+            purpose: "income" as const,
+            type: "addition" as const,
+          },
+        ]
+      : []),
+    {
+      amount: 25000,
+      date: "2026-07-02T00:00:00.000Z",
+      id: "cash-contribution",
+      label: "Capital contribution",
+      purpose: "capitalContribution",
+      type: "addition",
+    },
+    ...(!includeIncome
+      ? [
+          {
+            amount: 5000,
+            date: "2026-07-03T00:00:00.000Z",
+            id: "cash-legacy",
+            label: "Legacy addition",
+            purpose: "legacyUncategorized" as const,
+            type: "addition" as const,
+          },
+        ]
+      : []),
+    {
+      amount: 12000,
+      date: "2026-07-04T00:00:00.000Z",
+      id: "cash-sale",
+      label: "Sale proceeds",
+      purpose: "saleProceeds",
+      type: "addition",
+    },
+  ];
+
+  additions.forEach((entry) => store.getState().addCashEntry(entry));
+  store.getState().recordFundedBuy({
+    cashLabel: "HDFC Bank purchase",
+    trade: {
+      assetId: stockAsset.id,
+      date: "2026-07-05T00:00:00.000Z",
+      id: "trade-buy",
+      pricePerUnit: 1000,
+      quantity: 10,
+      totalValue: 10000,
+      type: "buy",
+    },
+  });
+}
+
 describe("useProgress", () => {
+  it("shares typed-income investment metrics with Cash without double-counting a funded buy", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const now = new Date("2026-07-20T00:00:00.000Z");
+    seedMonthlyInvestmentMetrics(store);
+
+    const { result: cash } = renderHook(() => useCash({ now, store }));
+    const { result: progress } = renderHook(() => useProgress({ now, store }));
+
+    expect(progress.current.monthlyIncome).toBe(50000);
+    expect(progress.current.monthlyInvestment).toBe(10000);
+    expect(progress.current.investmentRate).toBe(20);
+    expect(progress.current.monthlyInvestment).toBe(
+      cash.current.monthlyMetrics.invested,
+    );
+    expect(progress.current.investmentRate).toBe(
+      cash.current.monthlyMetrics.investmentRate,
+    );
+  });
+
+  it("marks the investment rate unavailable without reliable typed income", () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    const now = new Date("2026-07-20T00:00:00.000Z");
+    seedMonthlyInvestmentMetrics(store, { includeIncome: false });
+
+    const { result } = renderHook(() => useProgress({ now, store }));
+
+    expect(result.current.monthlyIncome).toBeNull();
+    expect(result.current.monthlyInvestment).toBe(10000);
+    expect(result.current.investmentRate).toBeNull();
+  });
+
   it("saves and updates monthly snapshots through the feature controller", () => {
     const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
     const { result } = renderHook(() => useProgress({ store }));

--- a/src/features/progress/useProgress.ts
+++ b/src/features/progress/useProgress.ts
@@ -6,6 +6,7 @@ import {
   buildGeneratedMonthEndSnapshot,
   calculateAllocation,
   calculateCashBalance,
+  calculateCashMonthlyMetrics,
   calculateHoldings,
   calculateMonthlyProgressSummaries,
   calculatePortfolioTotal,
@@ -22,15 +23,6 @@ import { createId } from "@/src/utils";
 
 function usePortfolioSnapshot(store: StoreApi<PortfolioStoreState>) {
   return useSyncExternalStore(store.subscribe, store.getState, store.getState);
-}
-
-function isCurrentMonth(isoDate: string, now = new Date()) {
-  const date = new Date(isoDate);
-
-  return (
-    date.getFullYear() === now.getFullYear() &&
-    date.getMonth() === now.getMonth()
-  );
 }
 
 export function emptyProgressFormValues() {
@@ -234,22 +226,12 @@ export function useProgress({
     (total, holding) => total + holding.totalInvested,
     0,
   );
-  const monthlyTradeInvestment = snapshot.trades
-    .filter((trade) => trade.type === "buy" && isCurrentMonth(trade.date, now))
-    .reduce((total, trade) => total + trade.totalValue, 0);
-  const monthlyOpeningInvestment = snapshot.openingPositions
-    .filter((position) => isCurrentMonth(position.date, now))
-    .reduce(
-      (total, position) =>
-        total + position.quantity * position.averageCostPrice,
-      0,
-    );
-  const monthlyInvestment = monthlyTradeInvestment + monthlyOpeningInvestment;
-  const monthlyCashAdded = snapshot.cashEntries
-    .filter((entry) => entry.type === "addition" && isCurrentMonth(entry.date, now))
-    .reduce((total, entry) => total + entry.amount, 0);
-  const savingsRate =
-    monthlyCashAdded === 0 ? 0 : (monthlyInvestment / monthlyCashAdded) * 100;
+  const monthlyMetrics = calculateCashMonthlyMetrics({
+    cashEntries: snapshot.cashEntries,
+    now,
+    openingPositions: snapshot.openingPositions,
+    trades: snapshot.trades,
+  });
   const allocation = calculateAllocation({ cashBalance, holdings });
   const hasData = holdings.length > 0 || snapshot.cashEntries.length > 0;
   const monthlySummaries = calculateMonthlyProgressSummaries(
@@ -382,9 +364,13 @@ export function useProgress({
     errors,
     formValues,
     hasData,
+    investmentRate: monthlyMetrics.investmentRate,
     latestSummary,
-    monthlyCashAdded,
-    monthlyInvestment,
+    monthlyIncome:
+      monthlyMetrics.incomeStatus === "available"
+        ? monthlyMetrics.income
+        : null,
+    monthlyInvestment: monthlyMetrics.invested,
     monthlySummaries,
     portfolioChartData,
     portfolioChartRange,
@@ -392,7 +378,6 @@ export function useProgress({
     preferences: snapshot.preferences,
     saveSnapshot,
     saveSnapshotEdits: saveSnapshot,
-    savingsRate,
     setAssetChartRange,
     setField,
     setPortfolioChartRange,


### PR DESCRIPTION
## Summary
- share one typed-income monthly investment metric between Cash and Progress
- exclude contributions, sale proceeds, withdrawals, transfers, and unclassified legacy additions from reliable income
- count linked funded buys once in the canonical trade month and handle local month rollover
- show unavailable states honestly and align the Investment rate label
- record H2 remediation evidence in the adversarial review

## Verification
- focused Cash/Progress/domain tests passed
- npm run test:verify: 47 suites, 296 tests, Expo Doctor 17/17
- independent adversarial re-review found no remaining defects
- emulator visual verification not run; layout and Android integration are unchanged

Closes #175