### PR TITLE
fix: backfill missing monthly snapshots

### DIFF
--- a/docs/reviews/2026-07-11-adversarial-codebase-review.md
+++ b/docs/reviews/2026-07-11-adversarial-codebase-review.md
@@ -227,17 +227,35 @@ legacy addition keeps both income and the rate unavailable until classified.
 
 ### H3. Automation only covers the immediately previous month
 
-The generator computes one target month using `getPreviousCompletedMonth`. If the
-app remains unopened for several months, older gaps are not backfilled.
+**Status (2026-07-22): Remediated by #178.** Snapshot automation now determines
+every missing completed month from the earliest opening position, trade, or cash
+entry through the last completed month. It processes gaps oldest-first, excludes
+the current month, and preserves existing snapshots.
 
-**Evidence:**
+**Remediation evidence:**
 
-- `src/domain/calculations/monthEndSnapshots.ts:210-226`.
-- `src/features/progress/useMonthEndSnapshotAutomation.ts:20-31` runs the process
-  once per mount.
-
-**Required direction:** Determine every missing completed month from the earliest
-portfolio record through the last completed month, then process them in order.
+- `getMissingCompletedSnapshotMonths` owns deterministic cross-year month
+  enumeration and existing-snapshot exclusion.
+- `buildGeneratedMonthEndSnapshot` accepts an explicit target month while
+  preserving its previous-month default for existing callers.
+- Progress automation requests historical prices for each target month, persists
+  successful snapshots in order, continues after a non-derivable month, and
+  reports a run-level status from the final store state.
+- Completed-month selection follows the device-local calendar, explicit target
+  months are rejected unless already completed, and fully closed positions do
+  not trigger unnecessary historical-price requests.
+- Concurrent app, Progress, and review touchpoints share one in-flight run per
+  portfolio store, preventing duplicate provider work and competing results;
+  callers crossing local month-end wait for that run and then process the newly
+  completed month.
+- Domain and hook tests cover cross-year enumeration, partial gaps, current-month
+  exclusion, no-record behavior, per-month historical lookup, ordered
+  persistence, idempotent reruns, preserved existing snapshots, and continuation
+  after underivable months, plus local month boundaries, invalid targets, closed
+  positions, and concurrent calls.
+- `npm run test:verify` passed 47 suites and 310 tests; Expo Doctor passed 17/17.
+- Historical fallback confidence and retry semantics remain open under H4 and
+  #150; this remediation does not mark estimated prices as final-quality data.
 
 ### H4. Historical fallback can permanently store current prices as past values
 

--- a/src/domain/calculations/__tests__/monthEndSnapshots.test.ts
+++ b/src/domain/calculations/__tests__/monthEndSnapshots.test.ts
@@ -1,5 +1,6 @@
 import {
   buildGeneratedMonthEndSnapshot,
+  getMissingCompletedSnapshotMonths,
   getPreviousCompletedMonth,
 } from "@/src/domain/calculations";
 import { historicalQuoteCacheKey } from "@/src/types";
@@ -95,6 +96,24 @@ function cashEntry(overrides: Partial<CashEntry>): CashEntry {
   };
 }
 
+function monthlySnapshot(
+  overrides: Partial<MonthlySnapshot>,
+): MonthlySnapshot {
+  return {
+    cashValue: 0,
+    cryptoValue: 0,
+    debtValue: 0,
+    equityValue: 1000,
+    id: `snapshot-${Math.random()}`,
+    investedValue: 900,
+    month: "2026-01",
+    monthlyInvestment: 0,
+    portfolioValue: 1000,
+    salary: 0,
+    ...overrides,
+  };
+}
+
 function buildInput(overrides: {
   assets?: Asset[];
   cashEntries?: CashEntry[];
@@ -103,6 +122,7 @@ function buildInput(overrides: {
   now?: Date;
   openingPositions?: OpeningPosition[];
   quoteCache?: QuoteCache;
+  targetMonth?: string;
   trades?: Trade[];
 } = {}) {
   return {
@@ -113,6 +133,7 @@ function buildInput(overrides: {
     now: overrides.now ?? new Date("2026-08-15T10:00:00.000Z"),
     openingPositions: overrides.openingPositions ?? [],
     quoteCache: overrides.quoteCache ?? {},
+    targetMonth: overrides.targetMonth,
     trades: overrides.trades ?? [],
   };
 }
@@ -129,9 +150,93 @@ describe("getPreviousCompletedMonth", () => {
       getPreviousCompletedMonth(new Date("2026-01-01T10:00:00.000Z")),
     ).toBe("2025-12");
   });
+
+  it("uses the device-local month at the first hours of a new month", () => {
+    expect(getPreviousCompletedMonth(new Date(2026, 7, 1, 1, 30))).toBe(
+      "2026-07",
+    );
+  });
+});
+
+describe("getMissingCompletedSnapshotMonths", () => {
+  it("enumerates every completed month from the earliest record across years", () => {
+    expect(
+      getMissingCompletedSnapshotMonths({
+        cashEntries: [
+          cashEntry({ date: "2025-11-18T00:00:00.000Z" }),
+        ],
+        existingSnapshots: [],
+        now: new Date("2026-03-15T10:00:00.000Z"),
+        openingPositions: [],
+        trades: [],
+      }),
+    ).toEqual(["2025-11", "2025-12", "2026-01", "2026-02"]);
+  });
+
+  it("returns only gaps and never includes the current month", () => {
+    expect(
+      getMissingCompletedSnapshotMonths({
+        cashEntries: [cashEntry({ date: "2026-01-04T00:00:00.000Z" })],
+        existingSnapshots: [
+          monthlySnapshot({ month: "2026-02" }),
+          monthlySnapshot({ id: "snapshot-april", month: "2026-04" }),
+        ],
+        now: new Date("2026-05-20T10:00:00.000Z"),
+        openingPositions: [],
+        trades: [],
+      }),
+    ).toEqual(["2026-01", "2026-03"]);
+  });
+
+  it("returns no targets when there are no portfolio records", () => {
+    expect(
+      getMissingCompletedSnapshotMonths({
+        cashEntries: [],
+        existingSnapshots: [],
+        now: new Date("2026-05-20T10:00:00.000Z"),
+        openingPositions: [],
+        trades: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns no targets when the first record is in the current month", () => {
+    expect(
+      getMissingCompletedSnapshotMonths({
+        cashEntries: [],
+        existingSnapshots: [],
+        now: new Date("2026-05-20T10:00:00.000Z"),
+        openingPositions: [
+          openingPosition({ date: "2026-05-02T00:00:00.000Z" }),
+        ],
+        trades: [],
+      }),
+    ).toEqual([]);
+  });
 });
 
 describe("buildGeneratedMonthEndSnapshot", () => {
+  it.each(["not-a-month", "2026-08", "2026-09"])(
+    "rejects an explicit target that is not a completed month: %s",
+    (targetMonth) => {
+      const result = buildGeneratedMonthEndSnapshot(
+        buildInput({
+          cashEntries: [cashEntry({ date: "2026-07-05T00:00:00.000Z" })],
+          now: new Date(2026, 7, 15, 10, 0),
+          targetMonth,
+        }),
+      );
+
+      expect(result).toEqual({
+        snapshot: null,
+        status: "insufficient-data",
+        warnings: [
+          `Target month ${targetMonth} is invalid or has not completed yet.`,
+        ],
+      });
+    },
+  );
+
   it("returns already-exists when the target month snapshot is present", () => {
     const existingSnapshot: MonthlySnapshot = {
       cashValue: 1200,

--- a/src/domain/calculations/index.ts
+++ b/src/domain/calculations/index.ts
@@ -1,11 +1,13 @@
 export {
   buildGeneratedMonthEndSnapshot,
+  getMissingCompletedSnapshotMonths,
   getPreviousCompletedMonth,
 } from "./monthEndSnapshots";
 export type {
   BuildGeneratedMonthEndSnapshotInput,
   GeneratedMonthEndSnapshotResult,
   GeneratedSnapshotStatus,
+  MissingCompletedSnapshotMonthsInput,
 } from "./monthEndSnapshots";
 export {
   buildMonthlyProgressChartData,

--- a/src/domain/calculations/monthEndSnapshots.ts
+++ b/src/domain/calculations/monthEndSnapshots.ts
@@ -40,8 +40,14 @@ export type BuildGeneratedMonthEndSnapshotInput = {
   now: Date;
   openingPositions: OpeningPosition[];
   quoteCache: QuoteCache;
+  targetMonth?: string;
   trades: Trade[];
 };
+
+export type MissingCompletedSnapshotMonthsInput = Pick<
+  BuildGeneratedMonthEndSnapshotInput,
+  "cashEntries" | "existingSnapshots" | "now" | "openingPositions" | "trades"
+>;
 
 type PriceSelectionBasis = HistoricalPriceBasis;
 
@@ -213,7 +219,78 @@ function selectAssetPrice({
 }
 
 export function getPreviousCompletedMonth(now: Date) {
-  return formatMonth(new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 0)));
+  const previousMonth = new Date(now.getFullYear(), now.getMonth(), 0);
+
+  return `${previousMonth.getFullYear()}-${String(previousMonth.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function monthIndex(monthKey: string) {
+  const [yearValue, monthValue] = monthKey.split("-");
+  const year = Number(yearValue);
+  const month = Number(monthValue);
+
+  if (
+    !/^\d{4}-\d{2}$/.test(monthKey) ||
+    !Number.isInteger(year) ||
+    !Number.isInteger(month) ||
+    month < 1 ||
+    month > 12
+  ) {
+    return null;
+  }
+
+  return year * 12 + month - 1;
+}
+
+function formatMonthIndex(index: number) {
+  const year = Math.floor(index / 12);
+  const month = (index % 12) + 1;
+
+  return `${year}-${String(month).padStart(2, "0")}`;
+}
+
+export function getMissingCompletedSnapshotMonths({
+  cashEntries,
+  existingSnapshots,
+  now,
+  openingPositions,
+  trades,
+}: MissingCompletedSnapshotMonthsInput) {
+  const recordMonthIndexes = [
+    ...cashEntries.map((entry) => entry.date),
+    ...openingPositions.map((position) => position.date),
+    ...trades.map((trade) => trade.date),
+  ]
+    .map((date) => new Date(date))
+    .filter((date) => Number.isFinite(date.getTime()))
+    .map((date) => monthIndex(formatMonth(date)))
+    .filter((index): index is number => index !== null);
+
+  if (recordMonthIndexes.length === 0) {
+    return [];
+  }
+
+  const firstRecordMonth = Math.min(...recordMonthIndexes);
+  const lastCompletedMonth = monthIndex(getPreviousCompletedMonth(now));
+
+  if (lastCompletedMonth === null || firstRecordMonth > lastCompletedMonth) {
+    return [];
+  }
+
+  const existingMonths = new Set(
+    existingSnapshots.map((snapshot) => snapshot.month),
+  );
+  const missingMonths: string[] = [];
+
+  for (let index = firstRecordMonth; index <= lastCompletedMonth; index += 1) {
+    const month = formatMonthIndex(index);
+
+    if (!existingMonths.has(month)) {
+      missingMonths.push(month);
+    }
+  }
+
+  return missingMonths;
 }
 
 export function buildGeneratedMonthEndSnapshot({
@@ -224,9 +301,27 @@ export function buildGeneratedMonthEndSnapshot({
   now,
   openingPositions,
   quoteCache,
+  targetMonth: requestedTargetMonth,
   trades,
 }: BuildGeneratedMonthEndSnapshotInput): GeneratedMonthEndSnapshotResult {
-  const targetMonth = getPreviousCompletedMonth(now);
+  const targetMonth = requestedTargetMonth ?? getPreviousCompletedMonth(now);
+  const targetMonthIndex = monthIndex(targetMonth);
+  const lastCompletedMonthIndex = monthIndex(getPreviousCompletedMonth(now));
+
+  if (
+    targetMonthIndex === null ||
+    lastCompletedMonthIndex === null ||
+    targetMonthIndex > lastCompletedMonthIndex
+  ) {
+    return {
+      snapshot: null,
+      status: "insufficient-data",
+      warnings: [
+        `Target month ${targetMonth} is invalid or has not completed yet.`,
+      ],
+    };
+  }
+
   const existingSnapshot = existingSnapshots.find(
     (snapshot) => snapshot.month === targetMonth,
   );

--- a/src/features/progress/__tests__/useProgress.test.tsx
+++ b/src/features/progress/__tests__/useProgress.test.tsx
@@ -2,7 +2,12 @@ import { act, renderHook } from "@testing-library/react-native";
 
 import { createMemoryJsonStorage } from "@/src/services/storage";
 import { createPortfolioStore } from "@/src/store";
-import type { Asset, CashEntry, OpeningPosition } from "@/src/types";
+import type {
+  Asset,
+  CashEntry,
+  MonthlySnapshot,
+  OpeningPosition,
+} from "@/src/types";
 
 import { useCash } from "../../cash/useCash";
 import { useMonthEndSnapshotAutomation } from "../useMonthEndSnapshotAutomation";
@@ -38,6 +43,41 @@ function seedHoldingAndCash(store: ReturnType<typeof createPortfolioStore>) {
   store.getState().addAsset(stockAsset);
   store.getState().addOpeningPosition(openingPosition);
   store.getState().addCashEntry(cashEntry);
+}
+
+function seedBackfillRecords(store: ReturnType<typeof createPortfolioStore>) {
+  store.getState().addAsset(stockAsset);
+  store.getState().addOpeningPosition({
+    assetId: stockAsset.id,
+    averageCostPrice: 1450,
+    currentPrice: 1678.25,
+    date: "2026-01-15T00:00:00.000Z",
+    id: "opening-hdfc-january",
+    quantity: 10,
+  });
+  store.getState().addCashEntry({
+    amount: 70000,
+    date: "2026-01-01T00:00:00.000Z",
+    id: "cash-income-january",
+    label: "Salary added",
+    purpose: "income",
+    type: "addition",
+  });
+}
+
+function existingSnapshot(month: string): MonthlySnapshot {
+  return {
+    cashValue: 70000,
+    cryptoValue: 0,
+    debtValue: 0,
+    equityValue: 16000,
+    id: `snapshot-${month}`,
+    investedValue: 14500,
+    month,
+    monthlyInvestment: 0,
+    portfolioValue: 86000,
+    salary: 0,
+  };
 }
 
 function seedMonthlyInvestmentMetrics(
@@ -227,6 +267,293 @@ describe("useProgress", () => {
     expect(result.current.snapshotAutomationStatus).toMatchObject({
       status: "already-exists",
       targetMonth: "2026-07",
+    });
+  });
+
+  it("backfills every missing completed month oldest-first with month-specific prices", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    seedBackfillRecords(store);
+    const requestedMonths: string[] = [];
+    const historicalPriceFetcher = jest.fn().mockImplementation(
+      async ({ asset, targetMonth }: { asset: Asset; targetMonth: string }) => {
+        requestedMonths.push(targetMonth);
+        return {
+          ok: true as const,
+          quote: {
+            assetId: asset.id,
+            asOfMonth: targetMonth,
+            basis: "historical-close" as const,
+            currency: "INR" as const,
+            fetchedAt: "2026-05-10T10:00:00.000Z",
+            price: 1500,
+            source: "yahoo" as const,
+          },
+        };
+      },
+    );
+    const { result } = renderHook(() =>
+      useProgress({
+        historicalPriceFetcher,
+        now: new Date("2026-05-10T10:00:00.000Z"),
+        store,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.ensureMonthEndSnapshot();
+    });
+
+    expect(store.getState().monthlySnapshots.map(({ month }) => month)).toEqual([
+      "2026-01",
+      "2026-02",
+      "2026-03",
+      "2026-04",
+    ]);
+    expect(requestedMonths).toEqual([
+      "2026-01",
+      "2026-02",
+      "2026-03",
+      "2026-04",
+    ]);
+    expect(result.current.snapshotAutomationStatus).toMatchObject({
+      message: "4 missing month snapshots generated automatically.",
+      status: "created",
+      targetMonth: "2026-04",
+    });
+
+    await act(async () => {
+      await result.current.ensureMonthEndSnapshot();
+    });
+
+    expect(store.getState().monthlySnapshots).toHaveLength(4);
+    expect(historicalPriceFetcher).toHaveBeenCalledTimes(4);
+    expect(result.current.snapshotAutomationStatus).toMatchObject({
+      message: "All completed month snapshots are already recorded.",
+      status: "already-exists",
+    });
+  });
+
+  it("fills only partial gaps without replacing existing snapshots", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    seedBackfillRecords(store);
+    const february = existingSnapshot("2026-02");
+    const april = existingSnapshot("2026-04");
+    store.getState().addMonthlySnapshot(february);
+    store.getState().addMonthlySnapshot(april);
+    const historicalPriceFetcher = jest.fn().mockImplementation(
+      async ({ asset, targetMonth }: { asset: Asset; targetMonth: string }) => ({
+        ok: true as const,
+        quote: {
+          assetId: asset.id,
+          asOfMonth: targetMonth,
+          basis: "historical-close" as const,
+          currency: "INR" as const,
+          fetchedAt: "2026-05-10T10:00:00.000Z",
+          price: 1500,
+          source: "yahoo" as const,
+        },
+      }),
+    );
+    const { result } = renderHook(() =>
+      useProgress({
+        historicalPriceFetcher,
+        now: new Date("2026-05-10T10:00:00.000Z"),
+        store,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.ensureMonthEndSnapshot();
+    });
+
+    expect(store.getState().monthlySnapshots.map(({ month }) => month).sort()).toEqual([
+      "2026-01",
+      "2026-02",
+      "2026-03",
+      "2026-04",
+    ]);
+    expect(store.getState().monthlySnapshots).toContain(february);
+    expect(store.getState().monthlySnapshots).toContain(april);
+    expect(
+      historicalPriceFetcher.mock.calls.map(([{ targetMonth }]) => targetMonth),
+    ).toEqual(["2026-01", "2026-03"]);
+  });
+
+  it("skips underivable early months and continues with later portfolio data", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    store.getState().addOpeningPosition({
+      assetId: "missing-asset",
+      averageCostPrice: 100,
+      date: "2026-01-10T00:00:00.000Z",
+      id: "orphaned-opening-position",
+      quantity: 1,
+    });
+    store.getState().addCashEntry({
+      amount: 10000,
+      date: "2026-03-05T00:00:00.000Z",
+      id: "cash-march",
+      label: "Capital contribution",
+      purpose: "capitalContribution",
+      type: "addition",
+    });
+    const { result } = renderHook(() =>
+      useProgress({
+        now: new Date("2026-05-10T10:00:00.000Z"),
+        store,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.ensureMonthEndSnapshot();
+    });
+
+    expect(store.getState().monthlySnapshots.map(({ month }) => month)).toEqual([
+      "2026-03",
+      "2026-04",
+    ]);
+    expect(result.current.snapshotAutomationStatus).toMatchObject({
+      status: "created",
+      targetMonth: "2026-04",
+    });
+    expect(result.current.snapshotAutomationStatus.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("2026-01:"),
+        expect.stringContaining("2026-02:"),
+      ]),
+    );
+  });
+
+  it("does not request historical prices after a position is fully closed", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    seedBackfillRecords(store);
+    store.getState().addTrade({
+      assetId: stockAsset.id,
+      date: "2026-01-20T00:00:00.000Z",
+      id: "trade-close-hdfc",
+      pricePerUnit: 1500,
+      quantity: 10,
+      totalValue: 15000,
+      type: "sell",
+    });
+    const historicalPriceFetcher = jest.fn();
+    const { result } = renderHook(() =>
+      useProgress({
+        historicalPriceFetcher,
+        now: new Date("2026-05-10T10:00:00.000Z"),
+        store,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.ensureMonthEndSnapshot();
+    });
+
+    expect(historicalPriceFetcher).not.toHaveBeenCalled();
+    expect(store.getState().monthlySnapshots.map(({ month }) => month)).toEqual([
+      "2026-01",
+      "2026-02",
+      "2026-03",
+      "2026-04",
+    ]);
+  });
+
+  it("shares one in-flight backfill across concurrent automation calls", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    seedBackfillRecords(store);
+    const historicalPriceFetcher = jest.fn().mockImplementation(
+      async ({ asset, targetMonth }: { asset: Asset; targetMonth: string }) => {
+        await Promise.resolve();
+        return {
+          ok: true as const,
+          quote: {
+            assetId: asset.id,
+            asOfMonth: targetMonth,
+            basis: "historical-close" as const,
+            currency: "INR" as const,
+            fetchedAt: "2026-05-10T10:00:00.000Z",
+            price: 1500,
+            source: "yahoo" as const,
+          },
+        };
+      },
+    );
+    const { result } = renderHook(() =>
+      useProgress({
+        historicalPriceFetcher,
+        now: new Date("2026-05-10T10:00:00.000Z"),
+        store,
+      }),
+    );
+
+    await act(async () => {
+      await Promise.all([
+        result.current.ensureMonthEndSnapshot(),
+        result.current.ensureMonthEndSnapshot(),
+      ]);
+    });
+
+    expect(historicalPriceFetcher).toHaveBeenCalledTimes(4);
+    expect(store.getState().monthlySnapshots).toHaveLength(4);
+    expect(result.current.snapshotAutomationStatus).toMatchObject({
+      message: "4 missing month snapshots generated automatically.",
+      status: "created",
+    });
+  });
+
+  it("continues with a newly completed month after awaiting an older in-flight run", async () => {
+    const store = createPortfolioStore({ storage: createMemoryJsonStorage() });
+    seedBackfillRecords(store);
+    const historicalPriceFetcher = jest.fn().mockImplementation(
+      async ({ asset, targetMonth }: { asset: Asset; targetMonth: string }) => {
+        await Promise.resolve();
+        return {
+          ok: true as const,
+          quote: {
+            assetId: asset.id,
+            asOfMonth: targetMonth,
+            basis: "historical-close" as const,
+            currency: "INR" as const,
+            fetchedAt: "2026-07-01T00:01:00.000Z",
+            price: 1500,
+            source: "yahoo" as const,
+          },
+        };
+      },
+    );
+    const beforeMonthEnd = renderHook(() =>
+      useProgress({
+        historicalPriceFetcher,
+        now: new Date(2026, 5, 30, 23, 59),
+        store,
+      }),
+    );
+    const afterMonthEnd = renderHook(() =>
+      useProgress({
+        historicalPriceFetcher,
+        now: new Date(2026, 6, 1, 0, 1),
+        store,
+      }),
+    );
+
+    await act(async () => {
+      await Promise.all([
+        beforeMonthEnd.result.current.ensureMonthEndSnapshot(),
+        afterMonthEnd.result.current.ensureMonthEndSnapshot(),
+      ]);
+    });
+
+    expect(store.getState().monthlySnapshots.map(({ month }) => month)).toEqual([
+      "2026-01",
+      "2026-02",
+      "2026-03",
+      "2026-04",
+      "2026-05",
+      "2026-06",
+    ]);
+    expect(historicalPriceFetcher).toHaveBeenCalledTimes(6);
+    expect(afterMonthEnd.result.current.snapshotAutomationStatus).toMatchObject({
+      status: "created",
+      targetMonth: "2026-06",
     });
   });
 

--- a/src/features/progress/useProgress.ts
+++ b/src/features/progress/useProgress.ts
@@ -11,8 +11,8 @@ import {
   calculateMonthlyProgressSummaries,
   calculatePortfolioTotal,
   getDefaultMonthlyChartRange,
+  getMissingCompletedSnapshotMonths,
   getPreviousCompletedMonth,
-  type GeneratedMonthEndSnapshotResult,
   type GeneratedSnapshotStatus,
   type MonthlyChartRange,
 } from "@/src/domain/calculations";
@@ -53,6 +53,20 @@ export type ProgressSnapshotAutomationStatus = {
   targetMonth: string;
   warnings: string[];
 };
+
+type MonthEndSnapshotAutomationRunResult = {
+  createdCount: number;
+  lastCompletedMonth: string;
+  snapshot: MonthlySnapshot | null;
+  status: GeneratedSnapshotStatus;
+  targetMonths: string[];
+  warnings: string[];
+};
+
+const inFlightSnapshotAutomationRuns = new WeakMap<
+  StoreApi<PortfolioStoreState>,
+  Promise<MonthEndSnapshotAutomationRunResult>
+>();
 
 type UseProgressInput = {
   historicalPriceFetcher?: typeof resolveHistoricalPrice;
@@ -140,16 +154,24 @@ export function validateProgressSnapshotForm(values: ProgressFormValues) {
   };
 }
 
-function automationMessage(result: GeneratedMonthEndSnapshotResult) {
-  if (result.status === "created") {
-    return "Previous month snapshot generated automatically.";
+function automationMessage({
+  createdCount,
+  status,
+}: {
+  createdCount: number;
+  status: GeneratedSnapshotStatus;
+}) {
+  if (status === "created") {
+    return createdCount === 1
+      ? "1 missing month snapshot generated automatically."
+      : `${createdCount} missing month snapshots generated automatically.`;
   }
 
-  if (result.status === "already-exists") {
-    return "Previous month snapshot is already recorded.";
+  if (status === "already-exists") {
+    return "All completed month snapshots are already recorded.";
   }
 
-  return "Not enough portfolio data to generate the previous month snapshot yet.";
+  return "Not enough portfolio data to generate a completed month snapshot yet.";
 }
 
 function getMonthEndDate(targetMonth: string) {
@@ -180,15 +202,22 @@ function needsHistoricalPrice({
   }
 
   const monthEnd = getMonthEndDate(targetMonth);
-  const hasOpeningPosition = state.openingPositions.some(
-    (position) =>
-      position.assetId === assetId && isOnOrBefore(position.date, monthEnd),
+  const openingQuantity = state.openingPositions.reduce(
+    (quantity, position) =>
+      position.assetId === assetId && isOnOrBefore(position.date, monthEnd)
+        ? quantity + position.quantity
+        : quantity,
+    0,
   );
-  const hasTrade = state.trades.some(
-    (trade) => trade.assetId === assetId && isOnOrBefore(trade.date, monthEnd),
-  );
+  const tradedQuantity = state.trades.reduce((quantity, trade) => {
+    if (trade.assetId !== assetId || !isOnOrBefore(trade.date, monthEnd)) {
+      return quantity;
+    }
 
-  return hasOpeningPosition || hasTrade;
+    return quantity + (trade.type === "buy" ? trade.quantity : -trade.quantity);
+  }, 0);
+
+  return openingQuantity + tradedQuantity > 0;
 }
 
 export function useProgress({
@@ -293,15 +322,15 @@ export function useProgress({
     return true;
   }
 
-  async function ensureMonthEndSnapshot() {
-    const state = store.getState();
-    const targetMonth = getPreviousCompletedMonth(now);
-    const existingSnapshot = state.monthlySnapshots.some(
-      (monthlySnapshot) => monthlySnapshot.month === targetMonth,
-    );
-    const lookupWarnings: string[] = [];
+  async function runMonthEndSnapshotAutomation(
+    targetMonths: string[],
+  ): Promise<MonthEndSnapshotAutomationRunResult> {
+    const lastCompletedMonth = getPreviousCompletedMonth(now);
+    const warnings: string[] = [];
+    const createdSnapshots: MonthlySnapshot[] = [];
 
-    if (!existingSnapshot) {
+    for (const targetMonth of targetMonths) {
+      const state = store.getState();
       const quoteableAssets = state.assets.filter(
         (asset) => asset.assetClass !== "cash" && asset.assetClass !== "debt",
       );
@@ -319,40 +348,150 @@ export function useProgress({
         if (historicalPriceResult.ok) {
           store.getState().upsertHistoricalQuote(historicalPriceResult.quote);
         } else {
-          lookupWarnings.push(historicalPriceResult.error);
+          warnings.push(`${targetMonth}: ${historicalPriceResult.error}`);
         }
+      }
+
+      const refreshedState = store.getState();
+      const result = buildGeneratedMonthEndSnapshot({
+        assets: refreshedState.assets,
+        cashEntries: refreshedState.cashEntries,
+        existingSnapshots: refreshedState.monthlySnapshots,
+        historicalQuotes: refreshedState.historicalQuoteCache,
+        now,
+        openingPositions: refreshedState.openingPositions,
+        quoteCache: refreshedState.quoteCache,
+        targetMonth,
+        trades: refreshedState.trades,
+      });
+
+      warnings.push(
+        ...result.warnings.map((warning) => `${targetMonth}: ${warning}`),
+      );
+
+      if (result.status === "created" && result.snapshot) {
+        store.getState().addMonthlySnapshot(result.snapshot);
+        createdSnapshots.push(result.snapshot);
       }
     }
 
-    const refreshedState = store.getState();
-    const result = buildGeneratedMonthEndSnapshot({
-      assets: refreshedState.assets,
-      cashEntries: refreshedState.cashEntries,
-      existingSnapshots: refreshedState.monthlySnapshots,
-      historicalQuotes: refreshedState.historicalQuoteCache,
+    const completedState = store.getState();
+    const latestCompletedSnapshot = [...completedState.monthlySnapshots]
+      .filter((monthlySnapshot) => monthlySnapshot.month <= lastCompletedMonth)
+      .sort((left, right) => right.month.localeCompare(left.month))[0] ?? null;
+    const hasCompletedPortfolioRecord = [
+      ...completedState.cashEntries.map((entry) => entry.date),
+      ...completedState.openingPositions.map((position) => position.date),
+      ...completedState.trades.map((trade) => trade.date),
+    ].some((date) => isOnOrBefore(date, getMonthEndDate(lastCompletedMonth)));
+    const remainingMissingMonths = getMissingCompletedSnapshotMonths({
+      cashEntries: completedState.cashEntries,
+      existingSnapshots: completedState.monthlySnapshots,
       now,
-      openingPositions: refreshedState.openingPositions,
-      quoteCache: refreshedState.quoteCache,
-      trades: refreshedState.trades,
+      openingPositions: completedState.openingPositions,
+      trades: completedState.trades,
     });
-    const statusWarnings = [...result.warnings, ...lookupWarnings];
-
-    if (result.status === "created" && result.snapshot) {
-      store.getState().addMonthlySnapshot(result.snapshot);
-    }
-
-    setSnapshotAutomationStatus({
-      message: automationMessage(result),
-      snapshot: result.snapshot,
-      status: result.status,
-      targetMonth: getPreviousCompletedMonth(now),
-      warnings: statusWarnings,
-    });
+    const status: GeneratedSnapshotStatus =
+      createdSnapshots.length > 0
+        ? "created"
+        : remainingMissingMonths.length === 0 && hasCompletedPortfolioRecord
+          ? "already-exists"
+          : "insufficient-data";
+    const snapshot = createdSnapshots.at(-1) ?? latestCompletedSnapshot;
 
     return {
-      ...result,
-      warnings: statusWarnings,
+      createdCount: createdSnapshots.length,
+      lastCompletedMonth,
+      snapshot,
+      status,
+      targetMonths,
+      warnings,
     };
+  }
+
+  async function ensureMonthEndSnapshot() {
+    const requestedLastCompletedMonth = getPreviousCompletedMonth(now);
+
+    while (true) {
+      let run = inFlightSnapshotAutomationRuns.get(store);
+
+      if (!run) {
+        const state = store.getState();
+        const targetMonths = getMissingCompletedSnapshotMonths({
+          cashEntries: state.cashEntries,
+          existingSnapshots: state.monthlySnapshots,
+          now,
+          openingPositions: state.openingPositions,
+          trades: state.trades,
+        });
+
+        if (targetMonths.length === 0) {
+          const latestCompletedSnapshot = [...state.monthlySnapshots]
+            .filter(
+              (monthlySnapshot) =>
+                monthlySnapshot.month <= requestedLastCompletedMonth,
+            )
+            .sort((left, right) => right.month.localeCompare(left.month))[0] ?? null;
+          const hasCompletedPortfolioRecord = [
+            ...state.cashEntries.map((entry) => entry.date),
+            ...state.openingPositions.map((position) => position.date),
+            ...state.trades.map((trade) => trade.date),
+          ].some((date) =>
+            isOnOrBefore(date, getMonthEndDate(requestedLastCompletedMonth)),
+          );
+          const result: MonthEndSnapshotAutomationRunResult = {
+            createdCount: 0,
+            lastCompletedMonth: requestedLastCompletedMonth,
+            snapshot: latestCompletedSnapshot,
+            status: hasCompletedPortfolioRecord
+              ? "already-exists"
+              : "insufficient-data",
+            targetMonths,
+            warnings: [],
+          };
+
+          setSnapshotAutomationStatus({
+            message: automationMessage(result),
+            snapshot: result.snapshot,
+            status: result.status,
+            targetMonth: result.lastCompletedMonth,
+            warnings: result.warnings,
+          });
+
+          return result;
+        }
+
+        run = runMonthEndSnapshotAutomation(targetMonths);
+        inFlightSnapshotAutomationRuns.set(store, run);
+        const startedRun = run;
+        void startedRun
+          .finally(() => {
+            if (inFlightSnapshotAutomationRuns.get(store) === startedRun) {
+              inFlightSnapshotAutomationRuns.delete(store);
+            }
+          })
+          .catch(() => undefined);
+      }
+
+      const result = await run;
+
+      if (result.lastCompletedMonth !== requestedLastCompletedMonth) {
+        if (inFlightSnapshotAutomationRuns.get(store) === run) {
+          inFlightSnapshotAutomationRuns.delete(store);
+        }
+        continue;
+      }
+
+      setSnapshotAutomationStatus({
+        message: automationMessage(result),
+        snapshot: result.snapshot,
+        status: result.status,
+        targetMonth: result.lastCompletedMonth,
+        warnings: result.warnings,
+      });
+
+      return result;
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary
- enumerate and backfill every missing completed snapshot month oldest-first
- serialize concurrent automation touchpoints and handle local month-end boundaries
- skip closed-position quote lookups and reject invalid/incomplete target months
- update H3 remediation evidence

## Verification
- `npm run test:verify` (47 suites, 310 tests, Expo Doctor 17/17)
- independent Sol adversarial review: no findings

Android emulator testing was not run because this change is limited to domain and hook behavior with no installed-app or visual contract change.

Closes #178